### PR TITLE
track_namespace_lengthを取得するように修正

### DIFF
--- a/moqt-core/src/modules/messages/announce_ok_message.rs
+++ b/moqt-core/src/modules/messages/announce_ok_message.rs
@@ -2,13 +2,13 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::{
-    modules::variable_bytes::write_variable_bytes, variable_bytes::read_variable_bytes_from_buffer,
-    variable_integer::write_variable_integer,
+    modules::variable_bytes::write_variable_bytes, variable_bytes::{read_variable_bytes_with_length_from_buffer},
+    variable_integer::{read_variable_integer_from_buffer, write_variable_integer},
 };
 
 use super::moqt_payload::MOQTPayload;
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct AnnounceOk {
     track_namespace: String,
 }
@@ -21,8 +21,15 @@ impl AnnounceOk {
 
 impl MOQTPayload for AnnounceOk {
     fn depacketize(buf: &mut bytes::BytesMut) -> Result<Self> {
-        let track_namespace =
-            String::from_utf8(read_variable_bytes_from_buffer(buf)?).context("track namespace")?;
+        let track_namespace_length = u8::try_from(read_variable_integer_from_buffer(buf)?)
+            .context("number of supported versions")?;
+
+        let track_namespace = String::from_utf8(read_variable_bytes_with_length_from_buffer(
+            buf,
+            track_namespace_length as usize,
+        )?)
+        .context("track namespace")?;
+    
 
         Ok(AnnounceOk { track_namespace })
     }
@@ -35,5 +42,47 @@ impl MOQTPayload for AnnounceOk {
         buf.extend(write_variable_bytes(
             &self.track_namespace.as_bytes().to_vec(),
         ));
+    }
+}
+
+
+#[cfg(test)]
+mod success {
+    use bytes::BytesMut;
+    use crate::modules::messages::announce_ok_message::AnnounceOk;
+    use crate::messages::moqt_payload::MOQTPayload;
+
+    #[test]
+    fn packetize() {
+        let track_namespace = "test".to_string();
+        let announce_ok = AnnounceOk::new(track_namespace.clone());
+        let mut buf = BytesMut::new();
+        announce_ok.packetize(&mut buf);
+
+        // Track Namespace bytes Length
+        // .len()の時点ではusizeでu8としてto_be_bytesされないのでu8に事前に変換する
+        let mut combined_bytes = Vec::from((track_namespace.len() as u8).to_be_bytes()); 
+        // Track Namespace bytes
+        combined_bytes.extend(track_namespace.as_bytes().to_vec());
+
+
+        assert_eq!(buf.as_ref(), combined_bytes.as_slice());
+    }
+
+    #[test]
+    fn depacketize() {
+        let track_namespace = "test".to_string();
+        let mut buf = BytesMut::new();
+        // Track Namespace bytes Length
+        buf.extend((track_namespace.len() as u8).to_be_bytes());
+        // Track Namespace bytes
+        buf.extend(track_namespace.as_bytes().to_vec());
+        
+        let announce_ok = AnnounceOk::depacketize(&mut buf).unwrap();
+
+        let expected_announce_ok = AnnounceOk::new(track_namespace.clone());
+
+
+        assert_eq!(announce_ok, expected_announce_ok);
     }
 }


### PR DESCRIPTION
### エラー内容
- depacketize()の際に、track_namespace_lengthを取得していないため、文字列長がtrack_namespaceの中に含まれてしまう不具合があるため修正
  - \u{2} の2は文字列長。これは本来はtrack_namespaceに含まれてしまっている
```
moqt_client_sample.js:484 announce_ok_message: AnnounceOk {
    track_namespace: "\u{2}vc",
}
```