### PR TITLE
カバレッジレポートの詳細リンクの実装

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
             [Coverage report details](${artifact_link})
             "
 
-            cargo llvm-cov --html
+            cargo llvm-cov report --html
 
             github_comment_verion=6.0.4
             github_apps_token=$(cat githubapps_token)


### PR DESCRIPTION
カバレッジレポートの残課題への対応
https://github.com/nttcom-webcore/moqt/issues/24#issuecomment-2063004921

@yuki-uchida 
レポート下部の`Coverage report details`で詳細リンク開けますか？