### PR TITLE
unknown_parameterの処理を実装

### DIFF
--- a/moqt-core/src/modules/handlers/server_setup_handler.rs
+++ b/moqt-core/src/modules/handlers/server_setup_handler.rs
@@ -53,9 +53,9 @@ pub(crate) fn setup_handler(
         bail!("Role parameter is required in SETUP parameter from client.");
     }
 
-    // setupParametersでroleが2になるように作成して、付与する。
-    // 本来であれば、ここはserver側でroleを決めるところだが、一旦は、roleは2とする。
-    let role_parameter = SetupParameter::RoleParameter(RoleParameter::new(RoleCase::Delivery));
+    // setupParametersでroleが3になるように作成して、付与する。
+    // 本来であれば、ここはserver側でroleを決めるところだが、一旦は、roleは3とする。
+    let role_parameter = SetupParameter::RoleParameter(RoleParameter::new(RoleCase::Both));
     let server_setup_message =
         ServerSetupMessage::new(constants::MOQ_TRANSPORT_VERSION, vec![role_parameter]);
     // State: Connected -> Setup

--- a/moqt-core/src/modules/messages/version_specific_parameters.rs
+++ b/moqt-core/src/modules/messages/version_specific_parameters.rs
@@ -33,6 +33,9 @@ impl MOQTPayload for TrackRequestParameter {
             }
             _ => {
                 // unknown parameter
+                let _parameter_length = u8::try_from(read_variable_integer_from_buffer(buf)?)?;
+                let _parameter_value = String::from_utf8(read_variable_bytes_from_buffer(buf)?)?;
+
                 Ok(TrackRequestParameter::Unknown(parameter_key))
             }
         }


### PR DESCRIPTION
## 概要
meta clientでserver setup parameterを受け取った際にエラーが発生したため修正

- server側はpublisher かつ subscriberになるため、ROLEをbothに変更
- unknown_parameterの場合にその内容を無視するためにbufferからの読み取りを適切に行うように修正