### PR TITLE
Improved message error handling

### DIFF
--- a/moqt-core/src/modules/constants.rs
+++ b/moqt-core/src/modules/constants.rs
@@ -3,7 +3,7 @@ use num_enum::IntoPrimitive;
 // for draft-ietf-moq-transport-01
 pub const MOQ_TRANSPORT_VERSION: u32 = 0xff000001;
 
-#[derive(Debug, IntoPrimitive)]
+#[derive(Debug, IntoPrimitive, PartialEq)]
 #[repr(u8)]
 pub enum TerminationErrorCode {
     NoError = 0x0,

--- a/moqt-core/src/modules/constants.rs
+++ b/moqt-core/src/modules/constants.rs
@@ -3,7 +3,7 @@ use num_enum::IntoPrimitive;
 // for draft-ietf-moq-transport-01
 pub const MOQ_TRANSPORT_VERSION: u32 = 0xff000001;
 
-#[derive(Debug, IntoPrimitive, PartialEq)]
+#[derive(Debug, IntoPrimitive, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum TerminationErrorCode {
     NoError = 0x0,

--- a/moqt-core/src/modules/message_type.rs
+++ b/moqt-core/src/modules/message_type.rs
@@ -24,13 +24,13 @@ impl MessageType {
     pub fn is_setup_message(&self) -> bool {
         matches!(self, MessageType::ClientSetup | MessageType::ServerSetup)
     }
-    pub fn is_object(&self) -> bool {
+    pub fn is_object_message(&self) -> bool {
         matches!(
             self,
             MessageType::ObjectWithPayloadLength | MessageType::ObjectWithoutPayloadLength
         )
     }
     pub fn is_control_message(&self) -> bool {
-        !self.is_setup_message() && !self.is_object()
+        !self.is_setup_message() && !self.is_object_message()
     }
 }

--- a/moqt-core/src/modules/messages/announce.rs
+++ b/moqt-core/src/modules/messages/announce.rs
@@ -47,8 +47,12 @@ impl MOQTPayload for Announce {
             .context("number of parameters")?;
         let mut parameters = vec![];
         for _ in 0..number_of_parameters {
-            let param = VersionSpecificParameter::depacketize(buf)?;
-            parameters.push(param);
+            let version_specific_parameter = VersionSpecificParameter::depacketize(buf)?;
+            if let VersionSpecificParameter::Unknown(code) = version_specific_parameter {
+                tracing::warn!("unknown track request parameter {}", code);
+            } else {
+                parameters.push(version_specific_parameter);
+            }
         }
 
         let announce_message = Announce {

--- a/moqt-server/src/modules/handlers/announce_handler.rs
+++ b/moqt-server/src/modules/handlers/announce_handler.rs
@@ -6,6 +6,7 @@ use moqt_core::{
     MOQTClient,
 };
 
+#[derive(Debug, PartialEq)]
 pub(crate) enum AnnounceResponse {
     Success(AnnounceOk),
     Failure(AnnounceError),
@@ -35,6 +36,7 @@ pub(crate) async fn announce_handler(
                 track_namespace.to_string(),
             )))
         }
+        // TODO: Check if “already exist” should turn into closing connection
         Err(err) => {
             tracing::error!("announce_handler: err: {:?}", err.to_string());
 
@@ -44,5 +46,123 @@ pub(crate) async fn announce_handler(
                 String::from("already exist"),
             )))
         }
+    }
+}
+
+#[cfg(test)]
+mod success {
+    use crate::modules::handlers::announce_handler::{announce_handler, AnnounceResponse};
+    use crate::modules::track_namespace_manager::{
+        track_namespace_manager, TrackCommand, TrackNamespaceManager,
+    };
+    use moqt_core::{
+        messages::{
+            announce::Announce,
+            announce_ok::AnnounceOk,
+            moqt_payload::MOQTPayload,
+            version_specific_parameters::{AuthorizationInfo, VersionSpecificParameter},
+        },
+        moqt_client::MOQTClient,
+    };
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn normal_case() {
+        // Generate ANNOUNCE message
+        let track_namespace = "live.example.com".to_string();
+        let number_of_parameters = 1;
+
+        let parameter_value = "test".to_string();
+        let parameter = VersionSpecificParameter::AuthorizationInfo(AuthorizationInfo::new(
+            parameter_value.clone(),
+        ));
+        let parameters = vec![parameter];
+        let announce_message =
+            Announce::new(track_namespace.clone(), number_of_parameters, parameters);
+        let mut buf = bytes::BytesMut::new();
+        announce_message.packetize(&mut buf);
+
+        // Generate client
+        let stable_id = 0;
+        let mut client = MOQTClient::new(stable_id as usize);
+
+        // Generate TrackNamespaceManager
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        // Execute announce_handler and get result
+        let result = announce_handler(announce_message, &mut client, &mut track_namespace_manager)
+            .await
+            .unwrap();
+
+        let expected_result =
+            AnnounceResponse::Success(AnnounceOk::new(track_namespace.to_string()));
+
+        assert_eq!(result, expected_result);
+    }
+}
+
+#[cfg(test)]
+mod failure {
+    use crate::modules::handlers::announce_handler::{announce_handler, AnnounceResponse};
+    use crate::modules::track_namespace_manager::{
+        track_namespace_manager, TrackCommand, TrackNamespaceManager,
+    };
+    use moqt_core::{
+        messages::{
+            announce::Announce,
+            announce_error::AnnounceError,
+            moqt_payload::MOQTPayload,
+            version_specific_parameters::{AuthorizationInfo, VersionSpecificParameter},
+        },
+        moqt_client::MOQTClient,
+        TrackNamespaceManagerRepository,
+    };
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn publisher_already_exists() {
+        // Generate ANNOUNCE message
+        let track_namespace = "live.example.com".to_string();
+        let number_of_parameters = 1;
+
+        let parameter_value = "test".to_string();
+        let parameter = VersionSpecificParameter::AuthorizationInfo(AuthorizationInfo::new(
+            parameter_value.clone(),
+        ));
+        let parameters = vec![parameter];
+        let announce_message =
+            Announce::new(track_namespace.clone(), number_of_parameters, parameters);
+        let mut buf = bytes::BytesMut::new();
+        announce_message.packetize(&mut buf);
+
+        // Generate client
+        let stable_id = 0;
+        let mut client = MOQTClient::new(stable_id as usize);
+
+        // Generate TrackNamespaceManager
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        // Set the duplicated publisher in advance
+        let _ = track_namespace_manager
+            .set_publisher(announce_message.track_namespace(), client.id)
+            .await;
+
+        // Execute announce_handler and get result
+        let result = announce_handler(announce_message, &mut client, &mut track_namespace_manager)
+            .await
+            .unwrap();
+
+        let code = 1;
+        let message = "already exist".to_string();
+        let expected_result =
+            AnnounceResponse::Failure(AnnounceError::new(track_namespace, code, message));
+
+        assert_eq!(result, expected_result);
     }
 }

--- a/moqt-server/src/modules/handlers/object_handler.rs
+++ b/moqt-server/src/modules/handlers/object_handler.rs
@@ -123,7 +123,7 @@ mod success {
         object_with_payload_length_handler, object_without_payload_length_handler,
     };
     use crate::modules::send_stream_dispatcher::{
-        send_stream_dispatcher, SendStreamDispatcher, SendStreamDispatchCommand,
+        send_stream_dispatcher, SendStreamDispatchCommand, SendStreamDispatcher,
     };
     use crate::modules::track_namespace_manager::{
         track_namespace_manager, TrackCommand, TrackNamespaceManager,
@@ -279,7 +279,7 @@ mod failure {
         object_with_payload_length_handler, object_without_payload_length_handler,
     };
     use crate::modules::send_stream_dispatcher::{
-        send_stream_dispatcher, SendStreamDispatcher, SendStreamDispatchCommand,
+        send_stream_dispatcher, SendStreamDispatchCommand, SendStreamDispatcher,
     };
     use crate::modules::track_namespace_manager::{
         track_namespace_manager, TrackCommand, TrackNamespaceManager,

--- a/moqt-server/src/modules/handlers/object_handler.rs
+++ b/moqt-server/src/modules/handlers/object_handler.rs
@@ -116,3 +116,413 @@ pub(crate) async fn object_without_payload_length_handler(
         }
     }
 }
+
+#[cfg(test)]
+mod success {
+    use crate::modules::handlers::object_handler::{
+        object_with_payload_length_handler, object_without_payload_length_handler,
+    };
+    use crate::modules::send_stream_dispatcher::{
+        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+    };
+    use crate::modules::track_namespace_manager::{
+        track_namespace_manager, TrackCommand, TrackNamespaceManager,
+    };
+    use moqt_core::messages::{
+        moqt_payload::MOQTPayload,
+        object::{ObjectWithPayloadLength, ObjectWithoutPayloadLength},
+    };
+    use moqt_core::TrackNamespaceManagerRepository;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn with_payload_length_normal() {
+        // Generate OBJECT with payload length message
+        let track_id = 0;
+        let group_sequence = 1;
+        let object_sequence = 2;
+        let object_send_order = 3;
+        let object_payload = vec![0, 1, 2];
+
+        let object_with_payload_length = ObjectWithPayloadLength::new(
+            track_id,
+            group_sequence,
+            object_sequence,
+            object_send_order,
+            object_payload.clone(),
+        );
+
+        // Generate TrackNamespaceManager
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let track_namespace = "test_namespace";
+        let publisher_session_id = 1;
+        let subscriber_session_id = 2;
+        let track_name = "test_name";
+
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+        let _ = track_namespace_manager
+            .set_subscriber(track_namespace, subscriber_session_id, track_name)
+            .await;
+        let _ = track_namespace_manager
+            .set_track_id(track_namespace, track_name, track_id)
+            .await;
+        let _ = track_namespace_manager
+            .activate_subscriber(track_namespace, track_name, subscriber_session_id)
+            .await;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: subscriber_session_id,
+                stream_type: "unidirectional_stream".to_string(),
+                sender: uni_relay_tx,
+            })
+            .await;
+
+        // Execute object_with_payload_length_handler and get result
+        let result = object_with_payload_length_handler(
+            object_with_payload_length,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn without_payload_length_normal() {
+        // Generate OBJECT with payload length message
+        let track_id = 0;
+        let group_sequence = 1;
+        let object_sequence = 2;
+        let object_send_order = 3;
+        let object_payload = vec![0, 1, 2];
+
+        let object_without_payload_length = ObjectWithoutPayloadLength::new(
+            track_id,
+            group_sequence,
+            object_sequence,
+            object_send_order,
+            object_payload.clone(),
+        );
+
+        // Generate TrackNamespaceManager
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let track_namespace = "test_namespace";
+        let publisher_session_id = 1;
+        let subscriber_session_id = 2;
+        let track_name = "test_name";
+
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+        let _ = track_namespace_manager
+            .set_subscriber(track_namespace, subscriber_session_id, track_name)
+            .await;
+        let _ = track_namespace_manager
+            .set_track_id(track_namespace, track_name, track_id)
+            .await;
+        let _ = track_namespace_manager
+            .activate_subscriber(track_namespace, track_name, subscriber_session_id)
+            .await;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: subscriber_session_id,
+                stream_type: "unidirectional_stream".to_string(),
+                sender: uni_relay_tx,
+            })
+            .await;
+
+        // Execute object_withouot_payload_length_handler and get result
+        let result = object_without_payload_length_handler(
+            object_without_payload_length,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+}
+
+#[cfg(test)]
+mod failure {
+    use crate::modules::handlers::object_handler::{
+        object_with_payload_length_handler, object_without_payload_length_handler,
+    };
+    use crate::modules::send_stream_dispatcher::{
+        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+    };
+    use crate::modules::track_namespace_manager::{
+        track_namespace_manager, TrackCommand, TrackNamespaceManager,
+    };
+    use moqt_core::messages::{
+        moqt_payload::MOQTPayload,
+        object::{ObjectWithPayloadLength, ObjectWithoutPayloadLength},
+    };
+    use moqt_core::TrackNamespaceManagerRepository;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn with_payload_length_subscriber_not_found() {
+        // Generate OBJECT with payload length message
+        let track_id = 0;
+        let group_sequence = 1;
+        let object_sequence = 2;
+        let object_send_order = 3;
+        let object_payload = vec![0, 1, 2];
+
+        let object_with_payload_length = ObjectWithPayloadLength::new(
+            track_id,
+            group_sequence,
+            object_sequence,
+            object_send_order,
+            object_payload.clone(),
+        );
+
+        // Generate TrackNamespaceManager (without set subscriber)
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let track_namespace = "test_namespace";
+        let publisher_session_id = 1;
+        let subscriber_session_id = 2;
+
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: subscriber_session_id,
+                stream_type: "unidirectional_stream".to_string(),
+                sender: uni_relay_tx,
+            })
+            .await;
+
+        // Execute object_with_payload_length_handler and get result
+        let result = object_with_payload_length_handler(
+            object_with_payload_length,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn without_payload_length_subscriber_not_found() {
+        // Generate OBJECT with payload length message
+        let track_id = 0;
+        let group_sequence = 1;
+        let object_sequence = 2;
+        let object_send_order = 3;
+        let object_payload = vec![0, 1, 2];
+
+        let object_without_payload_length = ObjectWithoutPayloadLength::new(
+            track_id,
+            group_sequence,
+            object_sequence,
+            object_send_order,
+            object_payload.clone(),
+        );
+
+        // Generate TrackNamespaceManager (without set subscriber)
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let track_namespace = "test_namespace";
+        let publisher_session_id = 1;
+        let subscriber_session_id = 2;
+
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: subscriber_session_id,
+                stream_type: "unidirectional_stream".to_string(),
+                sender: uni_relay_tx,
+            })
+            .await;
+
+        // Execute object_without_payload_length_handler and get result
+        let result = object_without_payload_length_handler(
+            object_without_payload_length,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn with_payload_length_relay_fail() {
+        // Generate OBJECT with payload length message
+        let track_id = 0;
+        let group_sequence = 1;
+        let object_sequence = 2;
+        let object_send_order = 3;
+        let object_payload = vec![0, 1, 2];
+
+        let object_with_payload_length = ObjectWithPayloadLength::new(
+            track_id,
+            group_sequence,
+            object_sequence,
+            object_send_order,
+            object_payload.clone(),
+        );
+
+        // Generate TrackNamespaceManager
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let track_namespace = "test_namespace";
+        let publisher_session_id = 1;
+        let subscriber_session_id = 2;
+        let track_name = "test_name";
+
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+        let _ = track_namespace_manager
+            .set_subscriber(track_namespace, subscriber_session_id, track_name)
+            .await;
+        let _ = track_namespace_manager
+            .set_track_id(track_namespace, track_name, track_id)
+            .await;
+        let _ = track_namespace_manager
+            .activate_subscriber(track_namespace, track_name, subscriber_session_id)
+            .await;
+
+        // Generate SendStreamDispacher (without set sender)
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        // Execute object_with_payload_length_handler and get result
+        let result = object_with_payload_length_handler(
+            object_with_payload_length,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn without_payload_length_relay_fail() {
+        // Generate OBJECT with payload length message
+        let track_id = 0;
+        let group_sequence = 1;
+        let object_sequence = 2;
+        let object_send_order = 3;
+        let object_payload = vec![0, 1, 2];
+
+        let object_without_payload_length = ObjectWithoutPayloadLength::new(
+            track_id,
+            group_sequence,
+            object_sequence,
+            object_send_order,
+            object_payload.clone(),
+        );
+
+        // Generate TrackNamespaceManager
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let track_namespace = "test_namespace";
+        let publisher_session_id = 1;
+        let subscriber_session_id = 2;
+        let track_name = "test_name";
+
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+        let _ = track_namespace_manager
+            .set_subscriber(track_namespace, subscriber_session_id, track_name)
+            .await;
+        let _ = track_namespace_manager
+            .set_track_id(track_namespace, track_name, track_id)
+            .await;
+        let _ = track_namespace_manager
+            .activate_subscriber(track_namespace, track_name, subscriber_session_id)
+            .await;
+
+        // Generate SendStreamDispacher (without set sender)
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        // Execute object_without_payload_length_handler and get result
+        let result = object_without_payload_length_handler(
+            object_without_payload_length,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+}

--- a/moqt-server/src/modules/handlers/object_handler.rs
+++ b/moqt-server/src/modules/handlers/object_handler.rs
@@ -123,7 +123,7 @@ mod success {
         object_with_payload_length_handler, object_without_payload_length_handler,
     };
     use crate::modules::send_stream_dispatcher::{
-        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+        send_stream_dispatcher, SendStreamDispatcher, SendStreamDispatchCommand,
     };
     use crate::modules::track_namespace_manager::{
         track_namespace_manager, TrackCommand, TrackNamespaceManager,
@@ -181,8 +181,8 @@ mod success {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx
@@ -249,8 +249,8 @@ mod success {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx
@@ -279,7 +279,7 @@ mod failure {
         object_with_payload_length_handler, object_without_payload_length_handler,
     };
     use crate::modules::send_stream_dispatcher::{
-        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+        send_stream_dispatcher, SendStreamDispatcher, SendStreamDispatchCommand,
     };
     use crate::modules::track_namespace_manager::{
         track_namespace_manager, TrackCommand, TrackNamespaceManager,
@@ -327,8 +327,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx
@@ -385,8 +385,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx
@@ -453,8 +453,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         // Execute object_with_payload_length_handler and get result
         let result = object_with_payload_length_handler(
@@ -512,8 +512,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         // Execute object_without_payload_length_handler and get result
         let result = object_without_payload_length_handler(

--- a/moqt-server/src/modules/handlers/subscribe_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_handler.rs
@@ -77,7 +77,7 @@ pub(crate) async fn subscribe_handler(
 mod success {
     use crate::modules::handlers::subscribe_handler::subscribe_handler;
     use crate::modules::send_stream_dispatcher::{
-        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+        send_stream_dispatcher, SendStreamDispatchCommand, SendStreamDispatcher,
     };
     use crate::modules::track_namespace_manager::{
         track_namespace_manager, TrackCommand, TrackNamespaceManager,
@@ -134,8 +134,8 @@ mod success {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx
@@ -163,7 +163,7 @@ mod success {
 mod failure {
     use crate::modules::handlers::subscribe_handler::subscribe_handler;
     use crate::modules::send_stream_dispatcher::{
-        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+        send_stream_dispatcher, SendStreamDispatchCommand, SendStreamDispatcher,
     };
     use crate::modules::track_namespace_manager::{
         track_namespace_manager, TrackCommand, TrackNamespaceManager,
@@ -231,8 +231,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx
@@ -297,8 +297,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         // Execute subscribe_handler and get result
         let result = subscribe_handler(
@@ -351,8 +351,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx

--- a/moqt-server/src/modules/handlers/subscribe_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_handler.rs
@@ -58,11 +58,320 @@ pub(crate) async fn subscribe_handler(
                         subscribe_message.track_name()
                     );
                     tracing::trace!("subscribe_handler complete.");
-                    Ok(())
                 }
-                Err(e) => bail!("relay subscribe failed: {:?}", e),
+                Err(e) => {
+                    tracing::warn!("relay subscribe failed: {:?}", e);
+                    // Failure on SUBSCRIBE_OK relay doesn't turn into closing connection
+                }
             }
+
+            Ok(())
         }
+
+        // TODO: Check if “publisher not found” should turn into closing connection
         None => bail!("publisher session id not found"),
+    }
+}
+
+#[cfg(test)]
+mod success {
+    use crate::modules::handlers::subscribe_handler::subscribe_handler;
+    use crate::modules::send_stream_dispatcher::{
+        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+    };
+    use crate::modules::track_namespace_manager::{
+        track_namespace_manager, TrackCommand, TrackNamespaceManager,
+    };
+    use moqt_core::messages::{
+        moqt_payload::MOQTPayload,
+        subscribe::{Location, Subscribe},
+        version_specific_parameters::{GroupSequence, VersionSpecificParameter},
+    };
+    use moqt_core::MOQTClient;
+    use moqt_core::TrackNamespaceManagerRepository;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn normal_case() {
+        // Generate SUBSCRIBE message
+        let track_namespace = "track_namespace";
+        let track_name = "track_name".to_string();
+        let start_group = Location::None;
+        let start_object = Location::None;
+        let end_group = Location::None;
+        let end_object = Location::None;
+        let version_specific_parameter =
+            VersionSpecificParameter::GroupSequence(GroupSequence::new(0));
+        let track_request_parameters = vec![version_specific_parameter];
+
+        let subscribe = Subscribe::new(
+            track_namespace.to_string(),
+            track_name,
+            start_group,
+            start_object,
+            end_group,
+            end_object,
+            track_request_parameters,
+        );
+
+        // Generate client
+        let subscriber_sessin_id = 0;
+        let mut client = MOQTClient::new(subscriber_sessin_id);
+
+        // Generate TrackNamespaceManager
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let publisher_session_id = 1;
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: publisher_session_id,
+                stream_type: "bidirectional_stream".to_string(),
+                sender: uni_relay_tx,
+            })
+            .await;
+
+        // Execute subscribe_handler and get result
+        let result = subscribe_handler(
+            subscribe,
+            &mut client,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+}
+
+#[cfg(test)]
+mod failure {
+    use crate::modules::handlers::subscribe_handler::subscribe_handler;
+    use crate::modules::send_stream_dispatcher::{
+        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+    };
+    use crate::modules::track_namespace_manager::{
+        track_namespace_manager, TrackCommand, TrackNamespaceManager,
+    };
+    use moqt_core::messages::{
+        moqt_payload::MOQTPayload,
+        subscribe::{Location, Subscribe},
+        version_specific_parameters::{GroupSequence, VersionSpecificParameter},
+    };
+    use moqt_core::MOQTClient;
+    use moqt_core::TrackNamespaceManagerRepository;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn cannot_register() {
+        // Generate SUBSCRIBE message
+        let track_namespace = "track_namespace";
+        let track_name = "track_name";
+        let start_group = Location::None;
+        let start_object = Location::None;
+        let end_group = Location::None;
+        let end_object = Location::None;
+        let version_specific_parameter =
+            VersionSpecificParameter::GroupSequence(GroupSequence::new(0));
+        let track_request_parameters = vec![version_specific_parameter];
+
+        let subscribe = Subscribe::new(
+            track_namespace.to_string(),
+            track_name.to_string(),
+            start_group,
+            start_object,
+            end_group,
+            end_object,
+            track_request_parameters,
+        );
+
+        // Generate client
+        let subscriber_session_id = 0;
+        let mut client = MOQTClient::new(subscriber_session_id);
+
+        // Generate TrackNamespaceManager (register subscriber in advance)
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let publisher_session_id = 1;
+        let track_id = 0;
+
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+        let _ = track_namespace_manager
+            .set_subscriber(track_namespace, subscriber_session_id, track_name)
+            .await;
+        let _ = track_namespace_manager
+            .set_track_id(track_namespace, track_name, track_id)
+            .await;
+        let _ = track_namespace_manager
+            .activate_subscriber(track_namespace, track_name, subscriber_session_id)
+            .await;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: publisher_session_id,
+                stream_type: "bidirectional_stream".to_string(),
+                sender: uni_relay_tx,
+            })
+            .await;
+
+        // Execute subscribe_handler and get result
+        let result = subscribe_handler(
+            subscribe,
+            &mut client,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn relay_fail() {
+        // Generate SUBSCRIBE message
+        let track_namespace = "track_namespace";
+        let track_name = "track_name";
+        let start_group = Location::None;
+        let start_object = Location::None;
+        let end_group = Location::None;
+        let end_object = Location::None;
+        let version_specific_parameter =
+            VersionSpecificParameter::GroupSequence(GroupSequence::new(0));
+        let track_request_parameters = vec![version_specific_parameter];
+
+        let subscribe = Subscribe::new(
+            track_namespace.to_string(),
+            track_name.to_string(),
+            start_group,
+            start_object,
+            end_group,
+            end_object,
+            track_request_parameters,
+        );
+
+        // Generate client
+        let subscriber_session_id = 0;
+        let mut client = MOQTClient::new(subscriber_session_id);
+
+        // Generate TrackNamespaceManager
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let publisher_session_id = 1;
+        let _ = track_namespace_manager
+            .set_publisher(track_namespace, publisher_session_id)
+            .await;
+
+        // Generate SendStreamDispacher (without set sender)
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        // Execute subscribe_handler and get result
+        let result = subscribe_handler(
+            subscribe,
+            &mut client,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn publisher_not_found() {
+        // Generate SUBSCRIBE message
+        let track_namespace = "track_namespace";
+        let track_name = "track_name";
+        let start_group = Location::None;
+        let start_object = Location::None;
+        let end_group = Location::None;
+        let end_object = Location::None;
+        let version_specific_parameter =
+            VersionSpecificParameter::GroupSequence(GroupSequence::new(0));
+        let track_request_parameters = vec![version_specific_parameter];
+
+        let subscribe = Subscribe::new(
+            track_namespace.to_string(),
+            track_name.to_string(),
+            start_group,
+            start_object,
+            end_group,
+            end_object,
+            track_request_parameters,
+        );
+
+        // Generate client
+        let subscriber_session_id = 0;
+        let mut client = MOQTClient::new(subscriber_session_id);
+
+        // Generate TrackNamespaceManager (without set publisher)
+        let (track_namespace_tx, mut track_namespace_rx) = mpsc::channel::<TrackCommand>(1024);
+        tokio::spawn(async move { track_namespace_manager(&mut track_namespace_rx).await });
+        let mut track_namespace_manager: TrackNamespaceManager =
+            TrackNamespaceManager::new(track_namespace_tx);
+
+        let publisher_session_id = 1;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: RelayHandlerManager =
+            RelayHandlerManager::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: publisher_session_id,
+                stream_type: "bidirectional_stream".to_string(),
+                sender: uni_relay_tx,
+            })
+            .await;
+
+        // Execute subscribe_handler and get result
+        let result = subscribe_handler(
+            subscribe,
+            &mut client,
+            &mut track_namespace_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
+
+        assert!(result.is_err());
     }
 }

--- a/moqt-server/src/modules/handlers/subscribe_ok_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_ok_handler.rs
@@ -79,7 +79,7 @@ pub(crate) async fn subscribe_ok_handler(
 mod success {
     use crate::modules::handlers::subscribe_ok_handler::subscribe_ok_handler;
     use crate::modules::send_stream_dispatcher::{
-        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+        send_stream_dispatcher, SendStreamDispatchCommand, SendStreamDispatcher,
     };
     use crate::modules::track_namespace_manager::{
         track_namespace_manager, TrackCommand, TrackNamespaceManager,
@@ -125,8 +125,8 @@ mod success {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx
@@ -153,7 +153,7 @@ mod success {
 mod failure {
     use crate::modules::handlers::subscribe_ok_handler::subscribe_ok_handler;
     use crate::modules::send_stream_dispatcher::{
-        send_stream_dispatcher, RelayHandlerManager, SendStreamDispatchCommand,
+        send_stream_dispatcher, SendStreamDispatchCommand, SendStreamDispatcher,
     };
     use crate::modules::track_namespace_manager::{
         track_namespace_manager, TrackCommand, TrackNamespaceManager,
@@ -199,8 +199,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         // Execute subscribe_ok_handler and get result
         let result = subscribe_ok_handler(
@@ -246,8 +246,8 @@ mod failure {
         let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
 
         tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
-        let mut send_stream_dispatcher: RelayHandlerManager =
-            RelayHandlerManager::new(send_stream_tx.clone());
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
 
         let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
         let _ = send_stream_tx

--- a/moqt-server/src/modules/server_processes/announce_message.rs
+++ b/moqt-server/src/modules/server_processes/announce_message.rs
@@ -3,7 +3,6 @@ use anyhow::{bail, Result};
 use bytes::BytesMut;
 use moqt_core::{
     messages::{announce::Announce, moqt_payload::MOQTPayload},
-    moqt_client::MOQTClientStatus,
     MOQTClient, TrackNamespaceManagerRepository,
 };
 
@@ -13,12 +12,6 @@ pub(crate) async fn process_announce_message(
     write_buf: &mut BytesMut,
     track_namespace_manager_repository: &mut dyn TrackNamespaceManagerRepository,
 ) -> Result<AnnounceResponse> {
-    if client.status() != MOQTClientStatus::SetUp {
-        let message = String::from("Invalid timing");
-        tracing::error!(message);
-        bail!(message);
-    }
-
     let announce_message = match Announce::depacketize(payload_buf) {
         Ok(announce_message) => announce_message,
         Err(err) => {

--- a/moqt-server/src/modules/server_processes/client_setup_message.rs
+++ b/moqt-server/src/modules/server_processes/client_setup_message.rs
@@ -5,7 +5,6 @@ use anyhow::{bail, Result};
 use moqt_core::{
     constants::UnderlayType,
     messages::{client_setup::ClientSetup, moqt_payload::MOQTPayload},
-    moqt_client::MOQTClientStatus,
     MOQTClient,
 };
 
@@ -15,11 +14,6 @@ pub(crate) fn process_client_setup_message(
     underlay_type: UnderlayType,
     write_buf: &mut BytesMut,
 ) -> Result<()> {
-    if client.status() != MOQTClientStatus::Connected {
-        let message = String::from("Invalid timing");
-        tracing::error!(message);
-        bail!(message);
-    }
     let client_setup_message = match ClientSetup::depacketize(payload_buf) {
         Ok(client_setup_message) => client_setup_message,
         Err(err) => {

--- a/moqt-server/src/modules/server_processes/object_message.rs
+++ b/moqt-server/src/modules/server_processes/object_message.rs
@@ -8,22 +8,14 @@ use moqt_core::{
         moqt_payload::MOQTPayload,
         object::{ObjectWithPayloadLength, ObjectWithoutPayloadLength},
     },
-    moqt_client::MOQTClientStatus,
-    MOQTClient, SendStreamDispatcherRepository, TrackNamespaceManagerRepository,
+    SendStreamDispatcherRepository, TrackNamespaceManagerRepository,
 };
 
 pub(crate) async fn process_object_with_payload_length(
     payload_buf: &mut BytesMut,
-    client: &mut MOQTClient,
     track_namespace_manager_repository: &mut dyn TrackNamespaceManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
 ) -> Result<()> {
-    if client.status() != MOQTClientStatus::SetUp {
-        let message = String::from("Invalid timing");
-        tracing::error!(message);
-        bail!(message);
-    }
-
     let object_message = match ObjectWithPayloadLength::depacketize(payload_buf) {
         Ok(object_message) => object_message,
         Err(err) => {
@@ -42,16 +34,9 @@ pub(crate) async fn process_object_with_payload_length(
 
 pub(crate) async fn process_object_without_payload_length(
     payload_buf: &mut BytesMut,
-    client: &mut MOQTClient,
     track_namespace_manager_repository: &mut dyn TrackNamespaceManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
 ) -> Result<()> {
-    if client.status() != MOQTClientStatus::SetUp {
-        let message = String::from("Invalid timing");
-        tracing::error!(message);
-        bail!(message);
-    }
-
     let object_message = match ObjectWithoutPayloadLength::depacketize(payload_buf) {
         Ok(object_message) => object_message,
         Err(err) => {

--- a/moqt-server/src/modules/server_processes/subscribe_message.rs
+++ b/moqt-server/src/modules/server_processes/subscribe_message.rs
@@ -3,7 +3,6 @@ use anyhow::{bail, Result};
 use bytes::BytesMut;
 use moqt_core::{
     messages::{moqt_payload::MOQTPayload, subscribe::Subscribe},
-    moqt_client::MOQTClientStatus,
     MOQTClient, SendStreamDispatcherRepository, TrackNamespaceManagerRepository,
 };
 
@@ -13,12 +12,6 @@ pub(crate) async fn process_subscribe_message(
     track_namespace_manager_repository: &mut dyn TrackNamespaceManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
 ) -> Result<()> {
-    if client.status() != MOQTClientStatus::SetUp {
-        let message = String::from("Invalid timing");
-        tracing::error!(message);
-        bail!(message);
-    }
-
     let subscribe_request_message = match Subscribe::depacketize(payload_buf) {
         Ok(subscribe_request_message) => subscribe_request_message,
         Err(err) => {

--- a/moqt-server/src/modules/server_processes/subscribe_ok_message.rs
+++ b/moqt-server/src/modules/server_processes/subscribe_ok_message.rs
@@ -3,22 +3,14 @@ use anyhow::{bail, Result};
 use bytes::BytesMut;
 use moqt_core::{
     messages::{moqt_payload::MOQTPayload, subscribe_ok::SubscribeOk},
-    moqt_client::MOQTClientStatus,
-    MOQTClient, SendStreamDispatcherRepository, TrackNamespaceManagerRepository,
+    SendStreamDispatcherRepository, TrackNamespaceManagerRepository,
 };
 
 pub(crate) async fn process_subscribe_ok_message(
     payload_buf: &mut BytesMut,
-    client: &mut MOQTClient,
     track_namespace_manager_repository: &mut dyn TrackNamespaceManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
 ) -> Result<()> {
-    if client.status() != MOQTClientStatus::SetUp {
-        let message = String::from("Invalid timing");
-        tracing::error!(message);
-        bail!(message);
-    }
-
     let subscribe_ok_message = match SubscribeOk::depacketize(payload_buf) {
         Ok(subscribe_ok_message) => subscribe_ok_message,
         Err(err) => {


### PR DESCRIPTION
- Specify `Protocol Violation` for operations as specification violations
- When handling unidirectional streams, connections are terminated only by `Protocol Violation` errors
- Fixed to ignore unknown version specific parameter in announce messages
- Add tests to message_handler and handlers