### PR TITLE
Packetize Payload Type as x(b)

### DIFF
--- a/moqt-client-sample/src/lib.rs
+++ b/moqt-client-sample/src/lib.rs
@@ -123,7 +123,8 @@ impl MOQTClient {
             buf.extend(write_variable_integer(
                 u8::from(ControlMessageType::ClientSetup) as u64,
             ));
-            // Message Payload
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(client_setup_message_buf.len() as u64));
             buf.extend(client_setup_message_buf);
 
             // send
@@ -170,7 +171,8 @@ impl MOQTClient {
             buf.extend(write_variable_integer(
                 u8::from(ControlMessageType::Announce) as u64,
             ));
-            // Message Payload
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(announce_message_buf.len() as u64));
             buf.extend(announce_message_buf);
 
             // send
@@ -208,7 +210,8 @@ impl MOQTClient {
             buf.extend(write_variable_integer(
                 u8::from(ControlMessageType::UnAnnounce) as u64,
             ));
-            // Message Payload
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(unannounce_message_buf.len() as u64));
             buf.extend(unannounce_message_buf);
 
             // send
@@ -265,9 +268,12 @@ impl MOQTClient {
             subscribe_message.packetize(&mut subscribe_message_buf);
 
             let mut buf = Vec::new();
+            // Message Type
             buf.extend(write_variable_integer(
                 u8::from(ControlMessageType::Subscribe) as u64,
-            )); // subscribe
+            ));
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(subscribe_message_buf.len() as u64));
             buf.extend(subscribe_message_buf);
 
             let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
@@ -303,9 +309,12 @@ impl MOQTClient {
             subscribe_ok_message.packetize(&mut subscribe_ok_message_buf);
 
             let mut buf = Vec::new();
+            // Message Type
             buf.extend(write_variable_integer(
                 u8::from(ControlMessageType::SubscribeOk) as u64,
-            )); // subscribe ok
+            ));
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(subscribe_ok_message_buf.len() as u64));
             buf.extend(subscribe_ok_message_buf);
 
             let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
@@ -345,9 +354,14 @@ impl MOQTClient {
             subscribe_error_message.packetize(&mut subscribe_error_message_buf);
 
             let mut buf = Vec::new();
+            // Message Type
             buf.extend(write_variable_integer(
                 u8::from(ControlMessageType::SubscribeError) as u64,
-            )); // subscribe error
+            ));
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(
+                subscribe_error_message_buf.len() as u64
+            ));
             buf.extend(subscribe_error_message_buf);
 
             let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
@@ -380,9 +394,12 @@ impl MOQTClient {
             unsubscribe_message.packetize(&mut unsubscribe_message_buf);
 
             let mut buf = Vec::new();
+            // Message Type
             buf.extend(write_variable_integer(
                 u8::from(ControlMessageType::UnSubscribe) as u64,
-            )); // unsubscribe
+            ));
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(unsubscribe_message_buf.len() as u64));
             buf.extend(unsubscribe_message_buf);
 
             let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
@@ -501,7 +518,7 @@ async fn stream_read_thread(
         let ret_value = js_sys::Uint8Array::from(ret_value).to_vec();
 
         log(std::format!(
-            "recv value: {:#?} {} {:#x?}",
+            "recv value: {:#?} {} {:#?}",
             stream_direction,
             ret_value.len(),
             ret_value
@@ -531,6 +548,7 @@ async fn message_handler(
     mut buf: &mut BytesMut,
 ) -> Result<()> {
     let message_type_value = read_variable_integer_from_buffer(&mut buf);
+    let _payload_length = read_variable_integer_from_buffer(&mut buf);
 
     // TODO: Check stream type
     match message_type_value {

--- a/moqt-server/src/lib.rs
+++ b/moqt-server/src/lib.rs
@@ -416,7 +416,7 @@ async fn wait_and_relay_control_message(
             tracing::warn!("Unsupported message type for bi-directional stream");
             continue;
         }
-
+        message_buf.extend(write_variable_integer(write_buf.len() as u64));
         message_buf.extend(write_buf);
 
         let mut shread_send_stream = send_stream.lock().await;


### PR DESCRIPTION
### Summary
- Packetize Payload Type as x(b) along with draft-06.


### Notice
- `assert_protocol_violation()` function actually has a variety of roles, not just the assert. So that is not a good name and an excessive abstraction. I think it is better not to define this function, but to implement it separately in each test code.