### PR TITLE
Message format of SUBSCRIBE_NAMESPACE family 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Supported version: draft-ietf-moq-transport-06
   - [ ] SUBSCRIBE_UPDATE
   - [ ] UNSUBSCRIBE
   - [x] ANNOUNCE_OK
-  - [ ] ANNOUNCE_ERROR
+  - [x] ANNOUNCE_ERROR
   - [ ] ANNOUNCE_CANCEL
   - [ ] TRACK_STATUS_REQUEST
   - [ ] SUBSCRIBE_NAMESPACE

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Supported version: draft-ietf-moq-transport-06
   - [ ] SUBSCRIBE_NAMESPACE_ERROR
 - [ ] Data Streams
   - [ ] Object Datagram Message
-  - [x] Stream Header Track
+  - [x] Track Stream
   - [ ] Subgroup Stream
 - [ ] Features
   - [x] Manage Publisher / Subscriber

--- a/README.md
+++ b/README.md
@@ -4,16 +4,39 @@ Both server and browser client are written in Rust.
 
 ## Implementation
 
-- [x] Send/Recv SETUP message
-- [x] Send/Recv ANNOUNCE message
-- [x] Send/Recv SUBSCRIBE message
-- [x] Echo back OBJECT message
-- [ ] Send/Recv GOAWAY message
-- [ ] Send/Recv SUBSCRIBE_FIN/SUBSCRIBE_RST message
-- [x] Transfer SUBSCRIBE message
-  - [x] Manage stream of publishers
-- [x] Transfer OBJECT message
-  - [x] Manage subscriptions
+Supported version: draft-ietf-moq-transport-06
+
+- [ ] Control Messages
+  - [x] CLIENT_SETUP / SERVER_SETUP
+  - [ ] GOAWAY
+  - [x] ANNOUNCE
+  - [x] SUBSCRIBE
+  - [ ] SUBSCRIBE_UPDATE
+  - [ ] UNSUBSCRIBE
+  - [x] ANNOUNCE_OK
+  - [ ] ANNOUNCE_ERROR
+  - [ ] ANNOUNCE_CANCEL
+  - [ ] TRACK_STATUS_REQUEST
+  - [ ] SUBSCRIBE_NAMESPACE
+  - [ ] UNSUBSCRIBE_NAMESPACE
+  - [x] SUBSCRIBE_OK
+  - [ ] SUBSCRIBE_ERROR
+  - [ ] SUBSCRIBE_DONE
+  - [ ] MAX_SUBSCRIBE_ID
+  - [x] ANNOUNCE
+  - [ ] UNANNOUNCE
+  - [ ] TRACK_STATUS
+  - [ ] SUBSCRIBE_NAMESPACE_OK
+  - [ ] SUBSCRIBE_NAMESPACE_ERROR
+- [ ] Data Streams
+  - [ ] Object Datagram Message
+  - [x] Stream Header Track
+  - [ ] Subgroup Stream
+- [ ] Features
+  - [x] Manage Publisher / Subscriber
+  - [x] Forword Messages
+  - [ ] Priorities
+  - [ ] Object Cache
 
 ## Modules
 
@@ -31,10 +54,12 @@ Both server and browser client are written in Rust.
 ### moqt-server-sample
 
 - Sample server application
+  - Supported Roles: PubSub
 
 ### moqt-client-sample
 
 - Module for browser client and sample browser client application
+  - Supported Roles: Publisher, Subscriber, PubSub
 
 ## How to run
 

--- a/interoperability_test.md
+++ b/interoperability_test.md
@@ -2,7 +2,7 @@
 
 ## draft-ietf-moq-transport-06
 
-Comming Soon..
+coming soon
 
 ## draft-ietf-moq-transport-01
 

--- a/interoperability_test.md
+++ b/interoperability_test.md
@@ -1,4 +1,10 @@
-# 相互接続試験結果
+# Result
+
+## draft-ietf-moq-transport-06
+
+Comming Soon..
+
+## draft-ietf-moq-transport-01
 
 |                              | CLIENT_SETUP | SERVER_SETUP | OBJECT | SUBSCRIBE | SUBSCRIBE_OK | SUBSCRIBE_ERROR | UNSUBSCRIBE | SUBSCRIBE_FIN | SUBSCRIBE_RST | ANNOUNCE | ANNOUNCE_OK | ANNOUNCE_ERROR | UNANNOUNCE | GOAWAY |
 | ---------------------------- | ------------ | ------------ | ------ | --------- | ------------ | --------------- | ----------- | ------------- | ------------- | -------- | ----------- | -------------- | ---------- | ------ |

--- a/js/index.html
+++ b/js/index.html
@@ -35,7 +35,7 @@
           <label><input type="radio" name="message-type" id="" value="unsubscribe" />UNSUBSCRIBE</label>
           <div>
             <!-- <label>Supported versions: <input type="text" name="versions" id="" value="0xc0000000ff000001"></label> -->
-            <label>Supported versions: <input type="text" name="versions" id="" value="0xff000001" /></label>
+            <label>Supported versions: <input type="text" name="versions" id="" value="0xff000006" /></label>
             <br />
             <label>Track NameSpace: <input type="text" name="track-namespace" id="" value="vc/aa" /> </label>
             <br />

--- a/moqt-core/src/modules/constants.rs
+++ b/moqt-core/src/modules/constants.rs
@@ -1,7 +1,7 @@
 use num_enum::IntoPrimitive;
 
-// for draft-ietf-moq-transport-01
-pub const MOQ_TRANSPORT_VERSION: u32 = 0xff000001;
+// for draft-ietf-moq-transport-06
+pub const MOQ_TRANSPORT_VERSION: u32 = 0xff000006;
 
 #[derive(Debug, IntoPrimitive, PartialEq, Clone, Copy)]
 #[repr(u8)]

--- a/moqt-core/src/modules/messages/control_messages.rs
+++ b/moqt-core/src/modules/messages/control_messages.rs
@@ -7,6 +7,10 @@ pub mod server_setup;
 pub mod setup_parameters;
 pub mod subscribe;
 pub mod subscribe_error;
+pub mod subscribe_namespace;
+pub mod subscribe_namespace_error;
+pub mod subscribe_namespace_ok;
+
 pub mod subscribe_ok;
 pub mod unannounce;
 pub mod unsubscribe;

--- a/moqt-core/src/modules/messages/control_messages/announce.rs
+++ b/moqt-core/src/modules/messages/control_messages/announce.rs
@@ -73,14 +73,6 @@ impl MOQTPayload for Announce {
     }
 
     fn packetize(&self, buf: &mut bytes::BytesMut) {
-        /*
-            ANNOUNCE Message {
-                Track Namespace(b),
-                Number of Parameters (i),
-                Parameters (..) ...,
-            }
-        */
-
         // Track Namespace Number of elements
         let track_namespace_tuple_length = self.track_namespace.len();
         buf.extend(write_variable_integer(track_namespace_tuple_length as u64));

--- a/moqt-core/src/modules/messages/control_messages/announce_error.rs
+++ b/moqt-core/src/modules/messages/control_messages/announce_error.rs
@@ -51,13 +51,6 @@ impl MOQTPayload for AnnounceError {
     }
 
     fn packetize(&self, buf: &mut bytes::BytesMut) {
-        /*
-            ANNOUNCE_ERROR {
-                Track Namespace(b),
-                Error Code (i),
-                Reason Phrase (b),
-            }
-        */
         // Track Namespace Number of elements
         let track_namespace_tuple_length = self.track_namespace.len();
         buf.extend(write_variable_integer(track_namespace_tuple_length as u64));

--- a/moqt-core/src/modules/messages/control_messages/announce_error.rs
+++ b/moqt-core/src/modules/messages/control_messages/announce_error.rs
@@ -17,7 +17,6 @@ pub struct AnnounceError {
     reason_phrase: String,
 }
 
-// draft-03
 impl AnnounceError {
     pub fn new(track_namespace: Vec<String>, error_code: u64, reason_phrase: String) -> Self {
         AnnounceError {

--- a/moqt-core/src/modules/messages/control_messages/client_setup.rs
+++ b/moqt-core/src/modules/messages/control_messages/client_setup.rs
@@ -56,14 +56,6 @@ impl MOQTPayload for ClientSetup {
     }
 
     fn packetize(&self, buf: &mut bytes::BytesMut) {
-        /*
-            Client SETUP Message Payload {
-                Number of Supported Versions (i),
-                Supported Version (i) ...,
-                Number of Parameters (i) ...,
-                SETUP Parameters (..) ...,
-            }
-        */
         buf.extend(write_variable_integer(
             self.number_of_supported_versions as u64,
         ));

--- a/moqt-core/src/modules/messages/control_messages/client_setup.rs
+++ b/moqt-core/src/modules/messages/control_messages/client_setup.rs
@@ -107,7 +107,7 @@ mod success {
         let expected_bytes_array = [
             1,   // Number of Supported Versions (i)
             192, // Supported Version (i): Length(11 of 2MSB)
-            0, 0, 0, 255, 0, 0, 1, // Supported Version(i): Value(0xff000001) in 62bit
+            0, 0, 0, 255, 0, 0, 6, // Supported Version(i): Value(0xff000006) in 62bit
             1, // Number of Parameters (i)
             0, // SETUP Parameters (..): Type(Role)
             1, // SETUP Parameters (..): Length
@@ -122,7 +122,7 @@ mod success {
         let bytes_array = [
             1,   // Number of Supported Versions (i)
             192, // Supported Version (i): Length(11 of 2MSB)
-            0, 0, 0, 255, 0, 0, 1, // Supported Version(i): Value(0xff000001) in 62bit
+            0, 0, 0, 255, 0, 0, 6, // Supported Version(i): Value(0xff000006) in 62bit
             1, // Number of Parameters (i)
             0, // SETUP Parameters (..): Type(Role)
             1, // SETUP Parameters (..): Length

--- a/moqt-core/src/modules/messages/control_messages/server_setup.rs
+++ b/moqt-core/src/modules/messages/control_messages/server_setup.rs
@@ -90,7 +90,7 @@ mod success {
 
         let expected_bytes_array = [
             192, // Selected Version (i): Length(11 of 2MSB)
-            0, 0, 0, 255, 0, 0, 1, // Supported Version(i): Value(0xff000001) in 62bit
+            0, 0, 0, 255, 0, 0, 6, // Supported Version(i): Value(0xff000006) in 62bit
             1, // Number of Parameters (i)
             0, // SETUP Parameters (..): Type(Role)
             1, // SETUP Parameters (..): Length
@@ -104,7 +104,7 @@ mod success {
     fn depacketize_server_setup() {
         let bytes_array = [
             192, // Selected Version (i): Length(11 of 2MSB)
-            0, 0, 0, 255, 0, 0, 1, // Supported Version(i): Value(0xff000001) in 62bit
+            0, 0, 0, 255, 0, 0, 6, // Supported Version(i): Value(0xff000006) in 62bit
             1, // Number of Parameters (i)
             0, // SETUP Parameters (..): Type(Role)
             1, // SETUP Parameters (..): Length

--- a/moqt-core/src/modules/messages/control_messages/subscribe_namespace.rs
+++ b/moqt-core/src/modules/messages/control_messages/subscribe_namespace.rs
@@ -1,0 +1,152 @@
+use super::version_specific_parameters::VersionSpecificParameter;
+use crate::messages::moqt_payload::MOQTPayload;
+use crate::variable_integer::{read_variable_integer_from_buffer, write_variable_integer};
+use crate::{
+    modules::variable_bytes::write_variable_bytes, variable_bytes::read_variable_bytes_from_buffer,
+};
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::any::Any;
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct SubscribeNamespace {
+    track_namespace_prefix: Vec<String>,
+    number_of_parameters: u64,
+    parameters: Vec<VersionSpecificParameter>,
+}
+
+impl SubscribeNamespace {
+    pub fn new(
+        track_namespace_prefix: Vec<String>,
+        parameters: Vec<VersionSpecificParameter>,
+    ) -> Self {
+        let number_of_parameters = parameters.len() as u64;
+        SubscribeNamespace {
+            track_namespace_prefix,
+            number_of_parameters,
+            parameters,
+        }
+    }
+}
+
+impl MOQTPayload for SubscribeNamespace {
+    fn depacketize(buf: &mut bytes::BytesMut) -> Result<Self> {
+        let track_namespace_prefix_tuple_length =
+            u8::try_from(read_variable_integer_from_buffer(buf)?)
+                .context("track namespace prefix length")?;
+        let mut track_namespace_prefix_tuple: Vec<String> = Vec::new();
+        for _ in 0..track_namespace_prefix_tuple_length {
+            let track_namespace_prefix = String::from_utf8(read_variable_bytes_from_buffer(buf)?)
+                .context("track namespace prefix")?;
+            track_namespace_prefix_tuple.push(track_namespace_prefix);
+        }
+
+        let number_of_parameters =
+            read_variable_integer_from_buffer(buf).context("number of parameters")?;
+
+        let mut parameters = Vec::new();
+        for _ in 0..number_of_parameters {
+            let version_specific_parameter = VersionSpecificParameter::depacketize(buf)?;
+            if let VersionSpecificParameter::Unknown(code) = version_specific_parameter {
+                tracing::warn!("unknown track request parameter {}", code);
+            } else {
+                parameters.push(version_specific_parameter);
+            }
+        }
+
+        tracing::trace!("Depacketized subscribe namespace message.");
+
+        Ok(SubscribeNamespace {
+            track_namespace_prefix: track_namespace_prefix_tuple,
+            number_of_parameters,
+            parameters,
+        })
+    }
+
+    fn packetize(&self, buf: &mut bytes::BytesMut) {
+        // Track Namespace Prefix Number of elements
+        let track_namespace_prefix_tuple_length = self.track_namespace_prefix.len();
+        buf.extend(write_variable_integer(
+            track_namespace_prefix_tuple_length as u64,
+        ));
+        for track_namespace_prefix in &self.track_namespace_prefix {
+            // Track Namespace Prefix
+            buf.extend(write_variable_bytes(
+                &track_namespace_prefix.as_bytes().to_vec(),
+            ));
+        }
+
+        buf.extend(write_variable_integer(self.parameters.len() as u64));
+        for parameter in &self.parameters {
+            parameter.packetize(buf);
+        }
+
+        tracing::trace!("Packetized subscribe namespace message.");
+    }
+    /// Method to enable downcasting from MOQTPayload to SubscribeNamespace
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod success {
+    use crate::messages::control_messages::version_specific_parameters::{
+        AuthorizationInfo, VersionSpecificParameter,
+    };
+    use crate::messages::moqt_payload::MOQTPayload;
+    use crate::modules::messages::control_messages::subscribe_namespace::SubscribeNamespace;
+    use bytes::BytesMut;
+
+    #[test]
+    fn packetize() {
+        let track_namespace_prefix = Vec::from(["test".to_string(), "test".to_string()]);
+        let version_specific_parameter =
+            VersionSpecificParameter::AuthorizationInfo(AuthorizationInfo::new("test".to_string()));
+        let parameters = vec![version_specific_parameter];
+        let subscribe_namespace =
+            SubscribeNamespace::new(track_namespace_prefix.clone(), parameters);
+        let mut buf = BytesMut::new();
+        subscribe_namespace.packetize(&mut buf);
+
+        let expected_bytes_array = [
+            2, // Track Namespace Prefix(tuple): Number of elements
+            4, // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            4,   // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            1,   // Parameters (..): Number of Parameters
+            2,   // Parameter Type (i): AuthorizationInfo
+            4,   // Parameter Length
+            116, 101, 115, 116, // Parameter Value (..): test
+        ];
+        assert_eq!(buf.as_ref(), expected_bytes_array.as_slice());
+    }
+
+    #[test]
+    fn depacketize() {
+        let bytes_array = [
+            2, // Track Namespace Prefix(tuple): Number of elements
+            4, // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            4,   // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            1,   // Parameters (..): Number of Parameters
+            2,   // Parameter Type (i): AuthorizationInfo
+            4,   // Parameter Length
+            116, 101, 115, 116, // Parameter Value (..): test
+        ];
+        let mut buf = BytesMut::with_capacity(bytes_array.len());
+        buf.extend_from_slice(&bytes_array);
+        let subscribe_namespace = SubscribeNamespace::depacketize(&mut buf).unwrap();
+
+        let track_namespace_prefix = Vec::from(["test".to_string(), "test".to_string()]);
+        let version_specific_parameter =
+            VersionSpecificParameter::AuthorizationInfo(AuthorizationInfo::new("test".to_string()));
+        let parameters = vec![version_specific_parameter];
+        let expected_subscribe_namespace =
+            SubscribeNamespace::new(track_namespace_prefix, parameters);
+
+        assert_eq!(subscribe_namespace, expected_subscribe_namespace);
+    }
+}

--- a/moqt-core/src/modules/messages/control_messages/subscribe_namespace_error.rs
+++ b/moqt-core/src/modules/messages/control_messages/subscribe_namespace_error.rs
@@ -1,0 +1,148 @@
+use crate::messages::moqt_payload::MOQTPayload;
+use crate::variable_integer::{read_variable_integer_from_buffer, write_variable_integer};
+use crate::{
+    modules::variable_bytes::write_variable_bytes, variable_bytes::read_variable_bytes_from_buffer,
+};
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::any::Any;
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct SubscribeNamespaceError {
+    track_namespace_prefix: Vec<String>,
+    error_code: u64,
+    reason_phrase: String,
+}
+
+impl SubscribeNamespaceError {
+    pub fn new(
+        track_namespace_prefix: Vec<String>,
+        error_code: u64,
+        reason_phrase: String,
+    ) -> Self {
+        SubscribeNamespaceError {
+            track_namespace_prefix,
+            error_code,
+            reason_phrase,
+        }
+    }
+}
+
+impl MOQTPayload for SubscribeNamespaceError {
+    fn depacketize(buf: &mut bytes::BytesMut) -> Result<Self> {
+        let track_namespace_prefix_tuple_length =
+            u8::try_from(read_variable_integer_from_buffer(buf)?)
+                .context("track namespace prefix length")?;
+        let mut track_namespace_prefix_tuple: Vec<String> = Vec::new();
+        for _ in 0..track_namespace_prefix_tuple_length {
+            let track_namespace_prefix = String::from_utf8(read_variable_bytes_from_buffer(buf)?)
+                .context("track namespace prefix")?;
+            track_namespace_prefix_tuple.push(track_namespace_prefix);
+        }
+        let error_code = read_variable_integer_from_buffer(buf).context("error code")?;
+        let reason_phrase =
+            String::from_utf8(read_variable_bytes_from_buffer(buf)?).context("reason phrase")?;
+
+        tracing::trace!("Depacketized subscribe namespace error message.");
+
+        Ok(SubscribeNamespaceError {
+            track_namespace_prefix: track_namespace_prefix_tuple,
+            error_code,
+            reason_phrase,
+        })
+    }
+
+    fn packetize(&self, buf: &mut bytes::BytesMut) {
+        // Track Namespace Prefix Number of elements
+        let track_namespace_prefix_tuple_length = self.track_namespace_prefix.len();
+        buf.extend(write_variable_integer(
+            track_namespace_prefix_tuple_length as u64,
+        ));
+        for track_namespace_prefix in &self.track_namespace_prefix {
+            // Track Namespace Prefix
+            buf.extend(write_variable_bytes(
+                &track_namespace_prefix.as_bytes().to_vec(),
+            ));
+        }
+        // Error Code
+        buf.extend(write_variable_integer(self.error_code));
+        //　Reason Phrase
+        buf.extend(write_variable_bytes(
+            &self.reason_phrase.as_bytes().to_vec(),
+        ));
+
+        tracing::trace!("Packetized subscribe namespace error message.");
+    }
+    /// Method to enable downcasting from MOQTPayload to SubscribeNamespaceError
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod success {
+    use crate::messages::moqt_payload::MOQTPayload;
+    use crate::modules::messages::control_messages::subscribe_namespace_error::SubscribeNamespaceError;
+    use bytes::BytesMut;
+
+    #[test]
+    fn packetize() {
+        let track_namespace_prefix = Vec::from(["test".to_string(), "test".to_string()]);
+        let error_code: u64 = 1;
+        let reason_phrase = "subscribe namespace overlap".to_string();
+        let subscribe_namespace_error = SubscribeNamespaceError::new(
+            track_namespace_prefix.clone(),
+            error_code,
+            reason_phrase.clone(),
+        );
+        let mut buf = BytesMut::new();
+        subscribe_namespace_error.packetize(&mut buf);
+
+        let expected_bytes_array = [
+            2, // Track Namespace Prefix(tuple): Number of elements
+            4, // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            4,   // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            1,   // Error Code (i)
+            27,  // Reason Phrase (b): length
+            115, 117, 98, 115, 99, 114, 105, 98, 101, 32, 110, 97, 109, 101, 115, 112, 97, 99, 101,
+            32, 111, 118, 101, 114, 108, 97,
+            112, // Reason Phrase (b): Value("subscribe namespace overlap")
+        ];
+        assert_eq!(buf.as_ref(), expected_bytes_array.as_slice());
+    }
+
+    #[test]
+    fn depacketize() {
+        let bytes_array = [
+            2, // Track Namespace Prefix(tuple): Number of elements
+            4, // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            4,   // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            1,   // Error Code (i)
+            27,  // Reason Phrase (b): length
+            115, 117, 98, 115, 99, 114, 105, 98, 101, 32, 110, 97, 109, 101, 115, 112, 97, 99, 101,
+            32, 111, 118, 101, 114, 108, 97,
+            112, // Reason Phrase (b): Value("subscribe namespace overlap")
+        ];
+        let mut buf = BytesMut::with_capacity(bytes_array.len());
+        buf.extend_from_slice(&bytes_array);
+        let subscribe_namespace_error = SubscribeNamespaceError::depacketize(&mut buf).unwrap();
+
+        let track_namespace_prefix = Vec::from(["test".to_string(), "test".to_string()]);
+        let error_code: u64 = 1;
+        let reason_phrase = "subscribe namespace overlap".to_string();
+        let expected_subscribe_namespace_error = SubscribeNamespaceError::new(
+            track_namespace_prefix.clone(),
+            error_code,
+            reason_phrase.clone(),
+        );
+
+        assert_eq!(
+            subscribe_namespace_error,
+            expected_subscribe_namespace_error
+        );
+    }
+}

--- a/moqt-core/src/modules/messages/control_messages/subscribe_namespace_ok.rs
+++ b/moqt-core/src/modules/messages/control_messages/subscribe_namespace_ok.rs
@@ -1,0 +1,104 @@
+use crate::messages::moqt_payload::MOQTPayload;
+use crate::variable_integer::{read_variable_integer_from_buffer, write_variable_integer};
+use crate::{
+    modules::variable_bytes::write_variable_bytes, variable_bytes::read_variable_bytes_from_buffer,
+};
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::any::Any;
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct SubscribeNamespaceOk {
+    track_namespace_prefix: Vec<String>,
+}
+
+impl SubscribeNamespaceOk {
+    pub fn new(track_namespace_prefix: Vec<String>) -> Self {
+        SubscribeNamespaceOk {
+            track_namespace_prefix,
+        }
+    }
+}
+
+impl MOQTPayload for SubscribeNamespaceOk {
+    fn depacketize(buf: &mut bytes::BytesMut) -> Result<Self> {
+        let track_namespace_prefix_tuple_length =
+            u8::try_from(read_variable_integer_from_buffer(buf)?)
+                .context("track namespace prefix length")?;
+        let mut track_namespace_prefix_tuple: Vec<String> = Vec::new();
+        for _ in 0..track_namespace_prefix_tuple_length {
+            let track_namespace_prefix = String::from_utf8(read_variable_bytes_from_buffer(buf)?)
+                .context("track namespace prefix")?;
+            track_namespace_prefix_tuple.push(track_namespace_prefix);
+        }
+
+        tracing::trace!("Depacketized subscribe namespace ok message.");
+
+        Ok(SubscribeNamespaceOk {
+            track_namespace_prefix: track_namespace_prefix_tuple,
+        })
+    }
+
+    fn packetize(&self, buf: &mut bytes::BytesMut) {
+        // Track Namespace Prefix Number of elements
+        let track_namespace_prefix_tuple_length = self.track_namespace_prefix.len();
+        buf.extend(write_variable_integer(
+            track_namespace_prefix_tuple_length as u64,
+        ));
+        for track_namespace_prefix in &self.track_namespace_prefix {
+            // Track Namespace Prefix
+            buf.extend(write_variable_bytes(
+                &track_namespace_prefix.as_bytes().to_vec(),
+            ));
+        }
+
+        tracing::trace!("Packetized subscribe namespace ok message.");
+    }
+    /// Method to enable downcasting from MOQTPayload to SubscribeNamespaceOk
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod success {
+    use crate::messages::moqt_payload::MOQTPayload;
+    use crate::modules::messages::control_messages::subscribe_namespace_ok::SubscribeNamespaceOk;
+    use bytes::BytesMut;
+
+    #[test]
+    fn packetize() {
+        let track_namespace_prefix = Vec::from(["test".to_string(), "test".to_string()]);
+        let subscribe_namespace_ok = SubscribeNamespaceOk::new(track_namespace_prefix.clone());
+        let mut buf = BytesMut::new();
+        subscribe_namespace_ok.packetize(&mut buf);
+
+        let expected_bytes_array = [
+            2, // Track Namespace Prefix(tuple): Number of elements
+            4, // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            4,   // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+        ];
+        assert_eq!(buf.as_ref(), expected_bytes_array.as_slice());
+    }
+
+    #[test]
+    fn depacketize() {
+        let bytes_array = [
+            2, // Track Namespace Prefix(tuple): Number of elements
+            4, // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+            4,   // Track Namespace Prefix(b): Length
+            116, 101, 115, 116, // Track Namespace Prefix(b): Value("test")
+        ];
+        let mut buf = BytesMut::with_capacity(bytes_array.len());
+        buf.extend_from_slice(&bytes_array);
+        let subscribe_namespace_ok = SubscribeNamespaceOk::depacketize(&mut buf).unwrap();
+
+        let track_namespace_prefix = Vec::from(["test".to_string(), "test".to_string()]);
+        let expected_subscribe_namespace_ok = SubscribeNamespaceOk::new(track_namespace_prefix);
+
+        assert_eq!(subscribe_namespace_ok, expected_subscribe_namespace_ok);
+    }
+}

--- a/moqt-core/src/modules/messages/control_messages/version_specific_parameters.rs
+++ b/moqt-core/src/modules/messages/control_messages/version_specific_parameters.rs
@@ -70,14 +70,6 @@ impl MOQTPayload for VersionSpecificParameter {
     }
 
     fn packetize(&self, buf: &mut bytes::BytesMut) {
-        /*
-            Parameter {
-                Parameter Type (i),
-                Parameter Length (i),
-                Parameter Value (..),
-            }
-        */
-
         match self {
             VersionSpecificParameter::AuthorizationInfo(param) => {
                 buf.extend(write_variable_integer(u64::from(param.parameter_type)));

--- a/moqt-server/src/modules/control_message_handler.rs
+++ b/moqt-server/src/modules/control_message_handler.rs
@@ -383,7 +383,7 @@ mod success {
         let bytes_array = [
             1,   // Number of Supported Versions (i)
             192, // Supported Version (i): Length(11 of 2MSB)
-            0, 0, 0, 255, 0, 0, 1, // Supported Version(i): Value(0xff000001) in 62bit
+            0, 0, 0, 255, 0, 0, 6, // Supported Version(i): Value(0xff000006) in 62bit
             1, // Number of Parameters (i)
             0, // SETUP Parameters (..): Type(Role)
             1, // SETUP Parameters (..): Length
@@ -410,7 +410,7 @@ mod success {
         let bytes_array = [
             1,   // Number of Supported Versions (i)
             192, // Supported Version (i): Length(11 of 2MSB)
-            0, 0, 0, 255, 0, 0, 1, // Supported Version(i): Value(0xff000001) in 62bit
+            0, 0, 0, 255, 0, 0, 6, // Supported Version(i): Value(0xff000006) in 62bit
             1, // Number of Parameters (i)
             0, // SETUP Parameters (..): Type(Role)
             1, // SETUP Parameters (..): Length
@@ -447,7 +447,7 @@ mod failure {
         let bytes_array = [
             1,   // Number of Supported Versions (i)
             192, // Supported Version (i): Length(11 of 2MSB)
-            0, 0, 0, 255, 0, 0, 1, // Supported Version(i): Value(0xff000001) in 62bit
+            0, 0, 0, 255, 0, 0, 6, // Supported Version(i): Value(0xff000006) in 62bit
             1, // Number of Parameters (i)
             0, // SETUP Parameters (..): Type(Role)
             1, // SETUP Parameters (..): Length


### PR DESCRIPTION
- Added message format:
  - SUBSCRIBE_NAMESPACE
  - SUBSCRIBE_NAMESPACE_OK
  - SUBSCRIBE_NAMESPACE_ERROR
- Deleted comments about the message structure
  - because they exist only some messages and we can understand the structure by its `struct` or test code