### PR TITLE
Propagate announce if the namespace was subscribed by subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supported version: draft-ietf-moq-transport-06
   - [x] ANNOUNCE_ERROR
   - [ ] ANNOUNCE_CANCEL
   - [ ] TRACK_STATUS_REQUEST
-  - [ ] SUBSCRIBE_NAMESPACE
+  - [x] SUBSCRIBE_NAMESPACE
   - [ ] UNSUBSCRIBE_NAMESPACE
   - [x] SUBSCRIBE_OK
   - [ ] SUBSCRIBE_ERROR
@@ -26,8 +26,8 @@ Supported version: draft-ietf-moq-transport-06
   - [x] ANNOUNCE
   - [ ] UNANNOUNCE
   - [ ] TRACK_STATUS
-  - [ ] SUBSCRIBE_NAMESPACE_OK
-  - [ ] SUBSCRIBE_NAMESPACE_ERROR
+  - [x] SUBSCRIBE_NAMESPACE_OK
+  - [x] SUBSCRIBE_NAMESPACE_ERROR
 - [ ] Data Streams
   - [ ] Object Datagram Message
   - [x] Track Stream

--- a/js/index.html
+++ b/js/index.html
@@ -32,6 +32,8 @@
           <br />
           <label><input type="radio" name="message-type" id="" value="subscribe" />SUBSCRIBE</label>
           <label><input type="radio" name="message-type" id="" value="unsubscribe" />UNSUBSCRIBE</label>
+          <br />
+          <label><input type="radio" name="message-type" id="" value="subscribe-namespace" />SUBSCRIBE_NAMESPACE</label>
           <div>
             <!-- <label>Supported versions: <input type="text" name="versions" id="" value="0xc0000000ff000001"></label> -->
             <label>Supported versions: <input type="text" name="versions" id="" value="0xff000006" /></label>

--- a/js/main.js
+++ b/js/main.js
@@ -24,6 +24,13 @@ init().then(async () => {
 
     client.onAnnounce(async (announceMessage) => {
       console.log({ announceMessage })
+      let announcedNamespace = announceMessage.track_namespace
+
+      await client.sendAnnounceOkMessage(announcedNamespace)
+    })
+
+    client.onAnnounceResponce(async (announceResponceMessage) => {
+      console.log({ announceResponceMessage })
     })
 
     client.onSubscribe(async (subscribeMessage, isSuccess, code) => {
@@ -43,6 +50,10 @@ init().then(async () => {
 
     client.onSubscribeResponse(async (subscribeResponse) => {
       console.log({ subscribeResponse })
+    })
+
+    client.onSubscribeNamespaceResponse(async (subscribeNamespaceResponse) => {
+      console.log({ subscribeNamespaceResponse })
     })
 
     client.onStreamHeaderTrack(async (streamHeaderTrack) => {
@@ -74,7 +85,7 @@ init().then(async () => {
           await client.sendSetupMessage(role, versions, maxSubscribeId)
           break
         case 'announce':
-          await client.sendAnnounceMessage(trackNamespace, 1, authInfo)
+          await client.sendAnnounceMessage(trackNamespace, authInfo)
           break
         case 'unannounce':
           await client.sendUnannounceMessage(trackNamespace)
@@ -84,6 +95,9 @@ init().then(async () => {
           break
         case 'unsubscribe':
           await client.sendUnsubscribeMessage(trackNamespace, trackName)
+          break
+        case 'subscribe-namespace':
+          await client.sendSubscribeNamespaceMessage(trackNamespace, authInfo)
           break
         case 'object-track':
           if (!headerSend) {

--- a/moqt-client-sample/src/lib.rs
+++ b/moqt-client-sample/src/lib.rs
@@ -17,6 +17,9 @@ use moqt_core::{
         setup_parameters::{MaxSubscribeID, Role, RoleCase, SetupParameter},
         subscribe::{FilterType, GroupOrder, Subscribe},
         subscribe_error::{SubscribeError, SubscribeErrorCode},
+        subscribe_namespace::SubscribeNamespace,
+        subscribe_namespace_error::SubscribeNamespaceError,
+        subscribe_namespace_ok::SubscribeNamespaceOk,
         subscribe_ok::SubscribeOk,
         unannounce::UnAnnounce,
         unsubscribe::Unsubscribe,
@@ -108,6 +111,13 @@ impl MOQTClient {
         self.callbacks.borrow_mut().set_announce_callback(callback);
     }
 
+    #[wasm_bindgen(js_name = onAnnounceResponce)]
+    pub fn set_announce_responce_callback(&mut self, callback: js_sys::Function) {
+        self.callbacks
+            .borrow_mut()
+            .set_announce_responce_callback(callback);
+    }
+
     #[wasm_bindgen(js_name = onSubscribe)]
     pub fn set_subscribe_callback(&mut self, callback: js_sys::Function) {
         self.callbacks.borrow_mut().set_subscribe_callback(callback);
@@ -118,6 +128,12 @@ impl MOQTClient {
         self.callbacks
             .borrow_mut()
             .set_subscribe_response_callback(callback);
+    }
+    #[wasm_bindgen(js_name = onSubscribeNamespaceResponse)]
+    pub fn set_subscribe_namespace_response_callback(&mut self, callback: js_sys::Function) {
+        self.callbacks
+            .borrow_mut()
+            .set_subscribe_namespace_response_callback(callback);
     }
 
     #[wasm_bindgen(js_name = onStreamHeaderTrack)]
@@ -175,6 +191,7 @@ impl MOQTClient {
             match JsFuture::from(writer.write_with_chunk(&buffer)).await {
                 // Setup nodes along with the role
                 Ok(ok) => {
+                    log(std::format!("sent: client_setup: {:#x?}", client_setup_message).as_str());
                     match role {
                         RoleCase::Publisher => {
                             self.subscription_node
@@ -209,7 +226,6 @@ impl MOQTClient {
     pub async fn send_announce_message(
         &self,
         track_namespace: js_sys::Array,
-        number_of_parameters: u8,
         auth_info: String, // param[0]
     ) -> Result<JsValue, JsValue> {
         if let Some(writer) = &*self.control_stream_writer.borrow() {
@@ -226,11 +242,8 @@ impl MOQTClient {
                 track_namespace_vec.push(string_element);
             }
 
-            let announce_message = Announce::new(
-                track_namespace_vec.clone(),
-                number_of_parameters,
-                vec![auth_info_parameter],
-            );
+            let announce_message =
+                Announce::new(track_namespace_vec.clone(), vec![auth_info_parameter]);
             let mut announce_message_buf = BytesMut::new();
             announce_message.packetize(&mut announce_message_buf);
 
@@ -248,11 +261,51 @@ impl MOQTClient {
             buffer.copy_from(&buf);
             match JsFuture::from(writer.write_with_chunk(&buffer)).await {
                 Ok(ok) => {
-                    // Register the announceing track
-                    self.subscription_node
-                        .borrow_mut()
-                        .set_namespace(track_namespace_vec);
+                    log(std::format!("sent: announce: {:#x?}", announce_message).as_str());
+                    Ok(ok)
+                }
+                Err(e) => Err(e),
+            }
+        } else {
+            Err(JsValue::from_str("control_stream_writer is None"))
+        }
+    }
 
+    #[wasm_bindgen(js_name = sendAnnounceOkMessage)]
+    pub async fn send_announce_ok_message(
+        &self,
+        track_namespace: js_sys::Array,
+    ) -> Result<JsValue, JsValue> {
+        if let Some(writer) = &*self.control_stream_writer.borrow() {
+            let length = track_namespace.length();
+            let mut track_namespace_vec: Vec<String> = Vec::with_capacity(length as usize);
+            for i in 0..length {
+                let js_element = track_namespace.get(i);
+                let string_element = js_element
+                    .as_string()
+                    .ok_or_else(|| JsValue::from_str("Array contains a non-string element"))?;
+                track_namespace_vec.push(string_element);
+            }
+
+            let announce_ok_message = AnnounceOk::new(track_namespace_vec.clone());
+            let mut announce_ok_message_buf = BytesMut::new();
+            announce_ok_message.packetize(&mut announce_ok_message_buf);
+
+            let mut buf = Vec::new();
+            // Message Type
+            buf.extend(write_variable_integer(
+                u8::from(ControlMessageType::AnnounceOk) as u64,
+            ));
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(announce_ok_message_buf.len() as u64));
+            buf.extend(announce_ok_message_buf);
+
+            // send
+            let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
+            buffer.copy_from(&buf);
+            match JsFuture::from(writer.write_with_chunk(&buffer)).await {
+                Ok(ok) => {
+                    log(std::format!("sent: announce_ok: {:#x?}", announce_ok_message).as_str());
                     Ok(ok)
                 }
                 Err(e) => Err(e),
@@ -295,7 +348,13 @@ impl MOQTClient {
             // send
             let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
             buffer.copy_from(&buf);
-            JsFuture::from(writer.write_with_chunk(&buffer)).await
+            match JsFuture::from(writer.write_with_chunk(&buffer)).await {
+                Ok(ok) => {
+                    log(std::format!("sent: unannounce: {:#x?}", unannounce_message).as_str());
+                    Ok(ok)
+                }
+                Err(e) => Err(e),
+            }
         } else {
             Err(JsValue::from_str("control_stream_writer is None"))
         }
@@ -373,6 +432,7 @@ impl MOQTClient {
 
             match JsFuture::from(writer.write_with_chunk(&buffer)).await {
                 Ok(ok) => {
+                    log(std::format!("sent: subscribe: {:#x?}", subscribe_message).as_str());
                     // Register the subscribing track
                     self.subscription_node
                         .borrow_mut()
@@ -444,6 +504,7 @@ impl MOQTClient {
 
             match JsFuture::from(writer.write_with_chunk(&buffer)).await {
                 Ok(ok) => {
+                    log(std::format!("sent: subscribe_ok: {:#x?}", subscribe_ok_message).as_str());
                     self.subscription_node
                         .borrow_mut()
                         .activate_as_publisher(subscribe_id);
@@ -464,6 +525,61 @@ impl MOQTClient {
                         .borrow_mut()
                         .insert(subscribe_id, send_uni_stream_writer);
 
+                    Ok(ok)
+                }
+                Err(e) => Err(e),
+            }
+        } else {
+            Err(JsValue::from_str("control_stream_writer is None"))
+        }
+    }
+
+    #[wasm_bindgen(js_name = sendSubscribeNamespaceMessage)]
+    pub async fn send_subscribe_namespace_message(
+        &self,
+        track_namespace_prefix: js_sys::Array,
+        auth_info: String,
+    ) -> Result<JsValue, JsValue> {
+        if let Some(writer) = &*self.control_stream_writer.borrow() {
+            let auth_info =
+                VersionSpecificParameter::AuthorizationInfo(AuthorizationInfo::new(auth_info));
+            let length = track_namespace_prefix.length();
+            let mut track_namespace_prefix_vec: Vec<String> = Vec::with_capacity(length as usize);
+            for i in 0..length {
+                let js_element = track_namespace_prefix.get(i);
+                let string_element = js_element
+                    .as_string()
+                    .ok_or_else(|| JsValue::from_str("Array contains a non-string element"))?;
+                track_namespace_prefix_vec.push(string_element);
+            }
+
+            let version_specific_parameters = vec![auth_info];
+            let subscribe_namespace_message =
+                SubscribeNamespace::new(track_namespace_prefix_vec, version_specific_parameters);
+            let mut subscribe_namespace_message_buf = BytesMut::new();
+            subscribe_namespace_message.packetize(&mut subscribe_namespace_message_buf);
+
+            let mut buf = Vec::new();
+            // Message Type
+            buf.extend(write_variable_integer(
+                u8::from(ControlMessageType::SubscribeNamespace) as u64,
+            ));
+            // Message Payload and Payload Length
+            buf.extend(write_variable_integer(
+                subscribe_namespace_message_buf.len() as u64,
+            ));
+            buf.extend(subscribe_namespace_message_buf);
+
+            let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
+            buffer.copy_from(&buf);
+
+            match JsFuture::from(writer.write_with_chunk(&buffer)).await {
+                Ok(ok) => {
+                    log(std::format!(
+                        "sent: subscribe_namespace: {:#x?}",
+                        subscribe_namespace_message
+                    )
+                    .as_str());
                     Ok(ok)
                 }
                 Err(e) => Err(e),
@@ -514,7 +630,16 @@ impl MOQTClient {
             let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
             buffer.copy_from(&buf);
 
-            JsFuture::from(writer.write_with_chunk(&buffer)).await
+            match JsFuture::from(writer.write_with_chunk(&buffer)).await {
+                Ok(ok) => {
+                    log(
+                        std::format!("sent: subscribe_error: {:#x?}", subscribe_error_message)
+                            .as_str(),
+                    );
+                    Ok(ok)
+                }
+                Err(e) => Err(e),
+            }
         } else {
             Err(JsValue::from_str("control_stream_writer is None"))
         }
@@ -552,7 +677,13 @@ impl MOQTClient {
             let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
             buffer.copy_from(&buf);
 
-            JsFuture::from(writer.write_with_chunk(&buffer)).await
+            match JsFuture::from(writer.write_with_chunk(&buffer)).await {
+                Ok(ok) => {
+                    log(std::format!("sent: unsubscribe: {:#x?}", unsubscribe_message).as_str());
+                    Ok(ok)
+                }
+                Err(e) => Err(e),
+            }
         } else {
             Err(JsValue::from_str("control_stream_writer is None"))
         }
@@ -581,7 +712,17 @@ impl MOQTClient {
 
             let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
             buffer.copy_from(&buf);
-            JsFuture::from(writer.write_with_chunk(&buffer)).await
+            match JsFuture::from(writer.write_with_chunk(&buffer)).await {
+                Ok(ok) => {
+                    log(std::format!(
+                        "sent: stream_header_track: {:#x?}",
+                        stream_header_track_message
+                    )
+                    .as_str());
+                    Ok(ok)
+                }
+                Err(e) => Err(e),
+            }
         } else {
             return Err(JsValue::from_str("object_stream_writer is None"));
         }
@@ -747,11 +888,15 @@ async fn bi_directional_stream_read_thread(
             buf.put_u8(i);
         }
 
-        if let Err(e) =
-            control_message_handler(callbacks.clone(), subscription_node.clone(), &mut buf).await
-        {
-            log(std::format!("error: {:#?}", e).as_str());
-            return Err(js_sys::Error::new(&e.to_string()).into());
+        while buf.has_remaining() {
+            if let Err(e) =
+                control_message_handler(callbacks.clone(), subscription_node.clone(), &mut buf)
+                    .await
+            {
+                log(std::format!("error: {:#?}", e).as_str());
+                break;
+                // return Err(js_sys::Error::new(&e.to_string()).into());
+            }
         }
     }
 
@@ -766,21 +911,23 @@ async fn control_message_handler(
     mut buf: &mut BytesMut,
 ) -> Result<()> {
     let message_type_value = read_variable_integer_from_buffer(&mut buf);
-    let _payload_length = read_variable_integer_from_buffer(&mut buf);
 
     // TODO: Check stream type
     match message_type_value {
         Ok(v) => {
             let message_type = ControlMessageType::try_from(v as u8)?;
+            let payload_length = read_variable_integer_from_buffer(&mut buf)?;
+            let mut payload_buf = buf.split_to(payload_length as usize);
 
             log(std::format!("message_type_value: {:#?}", message_type).as_str());
 
             match message_type {
                 ControlMessageType::ServerSetup => {
-                    let server_setup_message = ServerSetup::depacketize(&mut buf)?;
+                    let server_setup_message = ServerSetup::depacketize(&mut payload_buf)?;
 
                     log(
-                        std::format!("server_setup_message: {:#x?}", server_setup_message).as_str(),
+                        std::format!("recv: server_setup_message: {:#x?}", server_setup_message)
+                            .as_str(),
                     );
 
                     if let Some(callback) = callbacks.borrow().setup_callback() {
@@ -791,30 +938,49 @@ async fn control_message_handler(
                         callback.call1(&JsValue::null(), &(v)).unwrap();
                     }
                 }
-                ControlMessageType::AnnounceOk => {
-                    let announce_ok_message = AnnounceOk::depacketize(&mut buf)?;
-                    log(std::format!("announce_ok_message: {:#x?}", announce_ok_message).as_str());
+                ControlMessageType::Announce => {
+                    let announce_message = Announce::depacketize(&mut payload_buf)?;
+                    log(std::format!("recv: announce_message: {:#x?}", announce_message).as_str());
 
                     if let Some(callback) = callbacks.borrow().announce_callback() {
+                        let v = serde_wasm_bindgen::to_value(&announce_message).unwrap();
+                        callback.call1(&JsValue::null(), &(v)).unwrap();
+                    }
+                }
+                ControlMessageType::AnnounceOk => {
+                    let announce_ok_message = AnnounceOk::depacketize(&mut payload_buf)?;
+                    log(
+                        std::format!("recv: announce_ok_message: {:#x?}", announce_ok_message)
+                            .as_str(),
+                    );
+
+                    let _ = subscription_node
+                        .borrow_mut()
+                        .set_namespace(announce_ok_message.track_namespace().clone());
+
+                    if let Some(callback) = callbacks.borrow().announce_responce_callback() {
                         let v = serde_wasm_bindgen::to_value(&announce_ok_message).unwrap();
                         callback.call1(&JsValue::null(), &(v)).unwrap();
                     }
                 }
                 ControlMessageType::AnnounceError => {
-                    let announce_error_message = AnnounceError::depacketize(&mut buf)?;
-                    log(
-                        std::format!("announce_error_message: {:#x?}", announce_error_message)
-                            .as_str(),
-                    );
+                    let announce_error_message = AnnounceError::depacketize(&mut payload_buf)?;
+                    log(std::format!(
+                        "recv: announce_error_message: {:#x?}",
+                        announce_error_message
+                    )
+                    .as_str());
 
-                    if let Some(callback) = callbacks.borrow().announce_callback() {
+                    if let Some(callback) = callbacks.borrow().announce_responce_callback() {
                         let v = serde_wasm_bindgen::to_value(&announce_error_message).unwrap();
                         callback.call1(&JsValue::null(), &(v)).unwrap();
                     }
                 }
                 ControlMessageType::Subscribe => {
-                    let subscribe_message = Subscribe::depacketize(&mut buf)?;
-                    log(std::format!("subscribe_message: {:#x?}", subscribe_message).as_str());
+                    let subscribe_message = Subscribe::depacketize(&mut payload_buf)?;
+                    log(
+                        std::format!("recv: subscribe_message: {:#x?}", subscribe_message).as_str(),
+                    );
 
                     let result = subscription_node
                         .borrow_mut()
@@ -844,9 +1010,10 @@ async fn control_message_handler(
                     }
                 }
                 ControlMessageType::SubscribeOk => {
-                    let subscribe_ok_message = SubscribeOk::depacketize(&mut buf)?;
+                    let subscribe_ok_message = SubscribeOk::depacketize(&mut payload_buf)?;
                     log(
-                        std::format!("subscribe_ok_message: {:#x?}", subscribe_ok_message).as_str(),
+                        std::format!("recv: subscribe_ok_message: {:#x?}", subscribe_ok_message)
+                            .as_str(),
                     );
 
                     let _ = subscription_node
@@ -859,14 +1026,55 @@ async fn control_message_handler(
                     }
                 }
                 ControlMessageType::SubscribeError => {
-                    let subscribe_error_message = SubscribeError::depacketize(&mut buf)?;
-                    log(
-                        std::format!("subscribe_error_message: {:#x?}", subscribe_error_message)
-                            .as_str(),
-                    );
+                    let subscribe_error_message = SubscribeError::depacketize(&mut payload_buf)?;
+                    log(std::format!(
+                        "recv: subscribe_error_message: {:#x?}",
+                        subscribe_error_message
+                    )
+                    .as_str());
 
                     if let Some(callback) = callbacks.borrow().subscribe_response_callback() {
                         let v = serde_wasm_bindgen::to_value(&subscribe_error_message).unwrap();
+                        callback.call1(&JsValue::null(), &(v)).unwrap();
+                    }
+                }
+                ControlMessageType::SubscribeNamespaceOk => {
+                    let subscribe_namespace_ok_message =
+                        SubscribeNamespaceOk::depacketize(&mut payload_buf)?;
+                    log(std::format!(
+                        "recv: subscribe_namespace_ok_message: {:#x?}",
+                        subscribe_namespace_ok_message
+                    )
+                    .as_str());
+
+                    let _ = subscription_node.borrow_mut().set_namespace_prefix(
+                        subscribe_namespace_ok_message
+                            .track_namespace_prefix()
+                            .clone(),
+                    );
+
+                    if let Some(callback) =
+                        callbacks.borrow().subscribe_namespace_response_callback()
+                    {
+                        let v =
+                            serde_wasm_bindgen::to_value(&subscribe_namespace_ok_message).unwrap();
+                        callback.call1(&JsValue::null(), &(v)).unwrap();
+                    }
+                }
+                ControlMessageType::SubscribeNamespaceError => {
+                    let subscribe_namespace_error_message =
+                        SubscribeNamespaceError::depacketize(&mut payload_buf)?;
+                    log(std::format!(
+                        "recv: subscribe_namespace_error_message: {:#x?}",
+                        subscribe_namespace_error_message
+                    )
+                    .as_str());
+
+                    if let Some(callback) =
+                        callbacks.borrow().subscribe_namespace_response_callback()
+                    {
+                        let v = serde_wasm_bindgen::to_value(&subscribe_namespace_error_message)
+                            .unwrap();
                         callback.call1(&JsValue::null(), &(v)).unwrap();
                     }
                 }
@@ -972,7 +1180,10 @@ async fn object_header_handler(
                     let stream_header_track = StreamHeaderTrack::depacketize(&mut read_cur)?;
                     buf.advance(read_cur.position() as usize);
 
-                    log(std::format!("stream_header_track: {:#x?}", stream_header_track).as_str());
+                    log(
+                        std::format!("recv: stream_header_track: {:#x?}", stream_header_track)
+                            .as_str(),
+                    );
 
                     if let Some(callback) = callbacks.borrow().stream_header_track_callback() {
                         callback
@@ -1062,6 +1273,12 @@ impl SubscriptionNode {
     fn set_namespace(&mut self, track_namespace: Vec<String>) {
         if let Some(producer) = &mut self.producer {
             let _ = producer.set_namespace(track_namespace);
+        }
+    }
+
+    fn set_namespace_prefix(&mut self, track_namespace_prefix: Vec<String>) {
+        if let Some(consumer) = &mut self.consumer {
+            let _ = consumer.set_namespace_prefix(track_namespace_prefix);
         }
     }
 
@@ -1214,8 +1431,10 @@ impl SubscriptionNode {
 struct MOQTCallbacks {
     setup_callback: Option<js_sys::Function>,
     announce_callback: Option<js_sys::Function>,
+    announce_responce_callback: Option<js_sys::Function>,
     subscribe_callback: Option<js_sys::Function>,
     subscribe_response_callback: Option<js_sys::Function>,
+    subscribe_namespace_response_callback: Option<js_sys::Function>,
     stream_header_track_callback: Option<js_sys::Function>,
     object_stream_track_callback: Option<js_sys::Function>,
 }
@@ -1226,8 +1445,10 @@ impl MOQTCallbacks {
         MOQTCallbacks {
             setup_callback: None,
             announce_callback: None,
+            announce_responce_callback: None,
             subscribe_callback: None,
             subscribe_response_callback: None,
+            subscribe_namespace_response_callback: None,
             stream_header_track_callback: None,
             object_stream_track_callback: None,
         }
@@ -1249,6 +1470,14 @@ impl MOQTCallbacks {
         self.announce_callback = Some(callback);
     }
 
+    pub fn announce_responce_callback(&self) -> Option<js_sys::Function> {
+        self.announce_responce_callback.clone()
+    }
+
+    pub fn set_announce_responce_callback(&mut self, callback: js_sys::Function) {
+        self.announce_responce_callback = Some(callback);
+    }
+
     pub fn subscribe_callback(&self) -> Option<js_sys::Function> {
         self.subscribe_callback.clone()
     }
@@ -1263,6 +1492,14 @@ impl MOQTCallbacks {
 
     pub fn set_subscribe_response_callback(&mut self, callback: js_sys::Function) {
         self.subscribe_response_callback = Some(callback);
+    }
+
+    pub fn subscribe_namespace_response_callback(&self) -> Option<js_sys::Function> {
+        self.subscribe_namespace_response_callback.clone()
+    }
+
+    pub fn set_subscribe_namespace_response_callback(&mut self, callback: js_sys::Function) {
+        self.subscribe_namespace_response_callback = Some(callback);
     }
 
     pub fn stream_header_track_callback(&self) -> Option<js_sys::Function> {

--- a/moqt-core/src/modules/messages/control_messages/announce.rs
+++ b/moqt-core/src/modules/messages/control_messages/announce.rs
@@ -1,6 +1,6 @@
-use std::{any::Any, io::Cursor};
-
 use anyhow::{Context, Result};
+use serde::Serialize;
+use std::{any::Any, io::Cursor};
 
 use crate::{
     modules::{
@@ -13,7 +13,7 @@ use crate::{
 
 use crate::messages::moqt_payload::MOQTPayload;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct Announce {
     pub(crate) track_namespace: Vec<String>,
     pub(crate) number_of_parameters: u8,

--- a/moqt-core/src/modules/messages/control_messages/announce_error.rs
+++ b/moqt-core/src/modules/messages/control_messages/announce_error.rs
@@ -25,6 +25,14 @@ impl AnnounceError {
             reason_phrase,
         }
     }
+
+    pub fn track_namespace(&self) -> &Vec<String> {
+        &self.track_namespace
+    }
+
+    pub fn error_code(&self) -> u64 {
+        self.error_code
+    }
 }
 
 impl MOQTPayload for AnnounceError {

--- a/moqt-core/src/modules/messages/control_messages/subscribe_namespace_ok.rs
+++ b/moqt-core/src/modules/messages/control_messages/subscribe_namespace_ok.rs
@@ -18,6 +18,10 @@ impl SubscribeNamespaceOk {
             track_namespace_prefix,
         }
     }
+
+    pub fn track_namespace_prefix(&self) -> &Vec<String> {
+        &self.track_namespace_prefix
+    }
 }
 
 impl MOQTPayload for SubscribeNamespaceOk {

--- a/moqt-server/src/lib.rs
+++ b/moqt-server/src/lib.rs
@@ -20,7 +20,9 @@ use moqt_core::{
     data_stream_type::DataStreamType,
     messages::{
         control_messages::{
-            subscribe::FilterType, subscribe::Subscribe, subscribe_error::SubscribeError,
+            announce::Announce, announce_ok::AnnounceOk, subscribe::FilterType,
+            subscribe::Subscribe, subscribe_error::SubscribeError,
+            subscribe_namespace::SubscribeNamespace, subscribe_namespace_ok::SubscribeNamespaceOk,
             subscribe_ok::SubscribeOk,
         },
         data_streams::DataStreams,
@@ -940,6 +942,40 @@ async fn wait_and_relay_control_message(
             tracing::info!(
                 "Relayed Message Type: {:?}",
                 ControlMessageType::SubscribeError
+            );
+        } else if message.as_any().downcast_ref::<Announce>().is_some() {
+            message_buf.extend(write_variable_integer(
+                u8::from(ControlMessageType::Announce) as u64,
+            ));
+            tracing::info!("Relayed Message Type: {:?}", ControlMessageType::Announce);
+        } else if message.as_any().downcast_ref::<AnnounceOk>().is_some() {
+            message_buf.extend(write_variable_integer(
+                u8::from(ControlMessageType::AnnounceOk) as u64,
+            ));
+            tracing::info!("Relayed Message Type: {:?}", ControlMessageType::AnnounceOk);
+        } else if message
+            .as_any()
+            .downcast_ref::<SubscribeNamespace>()
+            .is_some()
+        {
+            message_buf.extend(write_variable_integer(u8::from(
+                ControlMessageType::SubscribeNamespace,
+            ) as u64));
+            tracing::info!(
+                "Relayed Message Type: {:?}",
+                ControlMessageType::SubscribeNamespace
+            );
+        } else if message
+            .as_any()
+            .downcast_ref::<SubscribeNamespaceOk>()
+            .is_some()
+        {
+            message_buf.extend(write_variable_integer(u8::from(
+                ControlMessageType::SubscribeNamespaceOk,
+            ) as u64));
+            tracing::info!(
+                "Relayed Message Type: {:?}",
+                ControlMessageType::SubscribeNamespaceOk
             );
         } else {
             tracing::warn!("Unsupported message type for bi-directional stream");

--- a/moqt-server/src/modules/control_message_handler.rs
+++ b/moqt-server/src/modules/control_message_handler.rs
@@ -1,9 +1,7 @@
 use std::io::Cursor;
 
 use crate::constants::TerminationErrorCode;
-use crate::modules::handlers::{
-    announce_handler::AnnounceResponse, unannounce_handler::unannounce_handler,
-};
+use crate::modules::handlers::unannounce_handler::unannounce_handler;
 use crate::modules::server_processes::announce_error_message::process_announce_error_message;
 use crate::modules::server_processes::announce_ok_message::process_announce_ok_message;
 use crate::modules::server_processes::subscribe_namespace_message::process_subscribe_namespace_message;
@@ -201,12 +199,15 @@ pub async fn control_message_handler(
                 client,
                 &mut write_buf,
                 pubsub_relation_manager_repository,
+                send_stream_dispatcher_repository,
             )
             .await
             {
-                Ok(announce_result) => match announce_result {
-                    AnnounceResponse::Success(_) => ControlMessageType::AnnounceOk,
-                    AnnounceResponse::Failure(_) => ControlMessageType::AnnounceError,
+                Ok(result) => match result {
+                    Some(_) => ControlMessageType::AnnounceError,
+                    None => {
+                        return MessageProcessResult::SuccessWithoutResponse;
+                    }
                 },
                 Err(err) => {
                     return MessageProcessResult::Failure(

--- a/moqt-server/src/modules/handlers/announce_handler.rs
+++ b/moqt-server/src/modules/handlers/announce_handler.rs
@@ -1,23 +1,19 @@
 use anyhow::Result;
+use moqt_core::constants::StreamDirection;
 use moqt_core::pubsub_relation_manager_repository::PubSubRelationManagerRepository;
 use moqt_core::{
     messages::control_messages::{
         announce::Announce, announce_error::AnnounceError, announce_ok::AnnounceOk,
     },
-    MOQTClient,
+    MOQTClient, SendStreamDispatcherRepository,
 };
-
-#[derive(Debug, PartialEq)]
-pub(crate) enum AnnounceResponse {
-    Success(AnnounceOk),
-    Failure(AnnounceError),
-}
 
 pub(crate) async fn announce_handler(
     announce_message: Announce,
     client: &mut MOQTClient,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
-) -> Result<AnnounceResponse> {
+    send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
+) -> Result<Option<AnnounceError>> {
     tracing::trace!("announce_handler start.");
     tracing::debug!("announce_message: {:#?}", announce_message);
 
@@ -31,20 +27,66 @@ pub(crate) async fn announce_handler(
             let track_namespace = announce_message.track_namespace();
 
             tracing::info!("announced track_namespace: {:#?}", track_namespace);
+
+            // Send AnnounceOk message to the publisher
+            // TODO: Unify the method to send a message to the opposite client itself
+            let announce_ok_message = Box::new(AnnounceOk::new(track_namespace.clone()));
+            let _ = send_stream_dispatcher_repository
+                .send_message_to_send_stream_thread(
+                    client.id,
+                    announce_ok_message,
+                    StreamDirection::Bi,
+                )
+                .await;
+
+            // Check if the namespace is subscribed by subscribers
+            let downstream_session_ids = match pubsub_relation_manager_repository
+                .get_downstream_session_ids_by_upstream_namespace(track_namespace.clone())
+                .await
+            {
+                Ok(downstream_session_ids) => downstream_session_ids,
+                Err(err) => {
+                    tracing::warn!("announce_handler: err: {:?}", err.to_string());
+                    return Ok(None);
+                }
+            };
+
+            for downstream_session_id in downstream_session_ids {
+                match pubsub_relation_manager_repository
+                    .is_namespace_already_announced(track_namespace.clone(), downstream_session_id)
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        // Send Announce message to the subscriber
+                        let announce_message =
+                            Box::new(Announce::new(track_namespace.clone(), vec![]));
+                        let _ = send_stream_dispatcher_repository
+                            .send_message_to_send_stream_thread(
+                                downstream_session_id,
+                                announce_message,
+                                StreamDirection::Bi,
+                            )
+                            .await;
+                    }
+                    Err(err) => {
+                        tracing::warn!("announce_handler: err: {:?}", err.to_string());
+                    }
+                }
+            }
+
             tracing::trace!("announce_handler complete.");
 
-            Ok(AnnounceResponse::Success(AnnounceOk::new(
-                track_namespace.clone(),
-            )))
+            Ok(None)
         }
-        // TODO: Check if “already exist” should turn into closing connection
+        // TODO: Allow namespace overlap
         Err(err) => {
             tracing::error!("announce_handler: err: {:?}", err.to_string());
 
-            Ok(AnnounceResponse::Failure(AnnounceError::new(
+            Ok(Some(AnnounceError::new(
                 announce_message.track_namespace().clone(),
                 1,
-                String::from("already exist"),
+                String::from("internal error"),
             )))
         }
     }
@@ -52,17 +94,22 @@ pub(crate) async fn announce_handler(
 
 #[cfg(test)]
 mod success {
-    use crate::modules::handlers::announce_handler::{announce_handler, AnnounceResponse};
+    use std::sync::Arc;
+
+    use crate::modules::handlers::announce_handler::announce_handler;
     use crate::modules::pubsub_relation_manager::{
         commands::PubSubRelationCommand, manager::pubsub_relation_manager,
         wrapper::PubSubRelationManagerWrapper,
     };
+    use crate::modules::send_stream_dispatcher::{
+        send_stream_dispatcher, SendStreamDispatchCommand, SendStreamDispatcher,
+    };
+    use moqt_core::constants::StreamDirection;
     use moqt_core::messages::moqt_payload::MOQTPayload;
     use moqt_core::pubsub_relation_manager_repository::PubSubRelationManagerRepository;
     use moqt_core::{
         messages::control_messages::{
             announce::Announce,
-            announce_ok::AnnounceOk,
             version_specific_parameters::{AuthorizationInfo, VersionSpecificParameter},
         },
         moqt_client::MOQTClient,
@@ -70,9 +117,10 @@ mod success {
     use tokio::sync::mpsc;
 
     #[tokio::test]
-    async fn normal_case() {
+    async fn announce_propagate_to_subscriber() {
         // Generate ANNOUNCE message
-        let track_namespace = Vec::from(["test".to_string(), "test".to_string()]);
+        let track_namespace = Vec::from(["aaa".to_string(), "bbb".to_string(), "ccc".to_string()]);
+        let track_namespace_prefix = Vec::from(["aaa".to_string(), "bbb".to_string()]);
 
         let parameter_value = "test".to_string();
         let parameter =
@@ -84,6 +132,7 @@ mod success {
 
         // Generate client
         let upstream_session_id = 0;
+        let downstream_session_id = 1;
         let mut client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
@@ -99,30 +148,148 @@ mod success {
             .setup_publisher(max_subscribe_id, upstream_session_id)
             .await;
 
+        let _ = pubsub_relation_manager
+            .setup_subscriber(max_subscribe_id, downstream_session_id)
+            .await;
+
+        let _ = pubsub_relation_manager
+            .set_downstream_subscribed_namespace_prefix(
+                track_namespace_prefix,
+                downstream_session_id,
+            )
+            .await;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: upstream_session_id,
+                stream_direction: StreamDirection::Bi,
+                sender: uni_relay_tx.clone(),
+            })
+            .await;
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: downstream_session_id,
+                stream_direction: StreamDirection::Bi,
+                sender: uni_relay_tx,
+            })
+            .await;
+
         // Execute announce_handler and get result
-        let result = announce_handler(announce_message, &mut client, &mut pubsub_relation_manager)
-            .await
-            .unwrap();
+        let result = announce_handler(
+            announce_message,
+            &mut client,
+            &mut pubsub_relation_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await
+        .unwrap();
 
-        let expected_result = AnnounceResponse::Success(AnnounceOk::new(track_namespace.clone()));
+        assert!(result.is_none());
+    }
 
-        assert_eq!(result, expected_result);
+    #[tokio::test]
+    async fn already_announced_to_subscriber() {
+        // Generate ANNOUNCE message
+        let track_namespace = Vec::from(["aaa".to_string(), "bbb".to_string(), "ccc".to_string()]);
+        let track_namespace_prefix = Vec::from(["aaa".to_string(), "bbb".to_string()]);
+
+        let parameter_value = "test".to_string();
+        let parameter =
+            VersionSpecificParameter::AuthorizationInfo(AuthorizationInfo::new(parameter_value));
+        let parameters = vec![parameter];
+        let announce_message = Announce::new(track_namespace.clone(), parameters);
+        let mut buf = bytes::BytesMut::new();
+        announce_message.packetize(&mut buf);
+
+        // Generate client
+        let upstream_session_id = 0;
+        let downstream_session_id = 1;
+        let mut client = MOQTClient::new(upstream_session_id);
+
+        // Generate PubSubRelationManagerWrapper
+        let (track_namespace_tx, mut track_namespace_rx) =
+            mpsc::channel::<PubSubRelationCommand>(1024);
+        tokio::spawn(async move { pubsub_relation_manager(&mut track_namespace_rx).await });
+        let mut pubsub_relation_manager: PubSubRelationManagerWrapper =
+            PubSubRelationManagerWrapper::new(track_namespace_tx);
+
+        let max_subscribe_id = 10;
+
+        let _ = pubsub_relation_manager
+            .setup_publisher(max_subscribe_id, upstream_session_id)
+            .await;
+
+        let _ = pubsub_relation_manager
+            .setup_subscriber(max_subscribe_id, downstream_session_id)
+            .await;
+
+        let _ = pubsub_relation_manager
+            .set_downstream_subscribed_namespace_prefix(
+                track_namespace_prefix,
+                downstream_session_id,
+            )
+            .await;
+
+        let _ = pubsub_relation_manager
+            .set_downstream_announced_namespace(track_namespace.clone(), downstream_session_id)
+            .await;
+
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: upstream_session_id,
+                stream_direction: StreamDirection::Bi,
+                sender: uni_relay_tx,
+            })
+            .await;
+
+        // Execute announce_handler and get result
+        let result = announce_handler(
+            announce_message,
+            &mut client,
+            &mut pubsub_relation_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_none());
     }
 }
 
 #[cfg(test)]
 mod failure {
-    use crate::modules::handlers::announce_handler::{announce_handler, AnnounceResponse};
+    use std::sync::Arc;
+
+    use crate::modules::handlers::announce_handler::announce_handler;
     use crate::modules::pubsub_relation_manager::{
         commands::PubSubRelationCommand, manager::pubsub_relation_manager,
         wrapper::PubSubRelationManagerWrapper,
     };
+    use crate::modules::send_stream_dispatcher::{
+        send_stream_dispatcher, SendStreamDispatchCommand, SendStreamDispatcher,
+    };
+    use moqt_core::constants::StreamDirection;
     use moqt_core::messages::moqt_payload::MOQTPayload;
     use moqt_core::pubsub_relation_manager_repository::PubSubRelationManagerRepository;
     use moqt_core::{
         messages::control_messages::{
             announce::Announce,
-            announce_error::AnnounceError,
             version_specific_parameters::{AuthorizationInfo, VersionSpecificParameter},
         },
         moqt_client::MOQTClient,
@@ -164,16 +331,37 @@ mod failure {
             .set_upstream_announced_namespace(announce_message.track_namespace().clone(), client.id)
             .await;
 
+        // Generate SendStreamDispacher
+        let (send_stream_tx, mut send_stream_rx) = mpsc::channel::<SendStreamDispatchCommand>(1024);
+
+        tokio::spawn(async move { send_stream_dispatcher(&mut send_stream_rx).await });
+        let mut send_stream_dispatcher: SendStreamDispatcher =
+            SendStreamDispatcher::new(send_stream_tx.clone());
+
+        let (uni_relay_tx, _) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
+        let _ = send_stream_tx
+            .send(SendStreamDispatchCommand::Set {
+                session_id: upstream_session_id,
+                stream_direction: StreamDirection::Bi,
+                sender: uni_relay_tx,
+            })
+            .await;
+
         // Execute announce_handler and get result
-        let result = announce_handler(announce_message, &mut client, &mut pubsub_relation_manager)
-            .await
-            .unwrap();
+        let result = announce_handler(
+            announce_message,
+            &mut client,
+            &mut pubsub_relation_manager,
+            &mut send_stream_dispatcher,
+        )
+        .await;
 
-        let code = 1;
-        let message = "already exist".to_string();
-        let expected_result =
-            AnnounceResponse::Failure(AnnounceError::new(track_namespace.clone(), code, message));
-
-        assert_eq!(result, expected_result);
+        match result {
+            Ok(Some(announce_error)) => {
+                assert_eq!(*announce_error.track_namespace(), track_namespace);
+                assert_eq!(announce_error.error_code(), 1);
+            }
+            _ => panic!("Unexpected result: {:?}", result),
+        }
     }
 }

--- a/moqt-server/src/modules/handlers/announce_handler.rs
+++ b/moqt-server/src/modules/handlers/announce_handler.rs
@@ -81,12 +81,13 @@ pub(crate) async fn announce_handler(
         }
         // TODO: Allow namespace overlap
         Err(err) => {
-            tracing::error!("announce_handler: err: {:?}", err.to_string());
+            let msg = std::format!("announce_handler: set namespace err: {:?}", err.to_string());
+            tracing::error!(msg);
 
             Ok(Some(AnnounceError::new(
                 announce_message.track_namespace().clone(),
                 1,
-                String::from("internal error"),
+                msg,
             )))
         }
     }

--- a/moqt-server/src/modules/handlers/subscribe_namespace_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_namespace_handler.rs
@@ -80,6 +80,8 @@ pub(crate) async fn subscribe_namespace_handler(
 
             Ok(None)
         }
+
+        // TODO: Separate namespace prefix overlap error
         Err(err) => {
             tracing::error!("subscribe_namespace_handler: err: {:?}", err.to_string());
 

--- a/moqt-server/src/modules/handlers/subscribe_namespace_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_namespace_handler.rs
@@ -83,12 +83,16 @@ pub(crate) async fn subscribe_namespace_handler(
 
         // TODO: Separate namespace prefix overlap error
         Err(err) => {
-            tracing::error!("subscribe_namespace_handler: err: {:?}", err.to_string());
+            let msg = std::format!(
+                "subscribe_namespace_handler: set namespace prefix err: {:?}",
+                err.to_string()
+            );
+            tracing::error!(msg);
 
             Ok(Some(SubscribeNamespaceError::new(
                 track_namespace_prefix,
                 1,
-                String::from("internal error"),
+                msg,
             )))
         }
     }

--- a/moqt-server/src/modules/server_processes/announce_message.rs
+++ b/moqt-server/src/modules/server_processes/announce_message.rs
@@ -1,7 +1,9 @@
-use crate::modules::handlers::announce_handler::{announce_handler, AnnounceResponse};
+use crate::modules::handlers::announce_handler::announce_handler;
 use anyhow::{bail, Result};
 use bytes::BytesMut;
+use moqt_core::messages::control_messages::announce_error::AnnounceError;
 use moqt_core::pubsub_relation_manager_repository::PubSubRelationManagerRepository;
+use moqt_core::send_stream_dispatcher_repository;
 use moqt_core::{
     messages::{control_messages::announce::Announce, moqt_payload::MOQTPayload},
     MOQTClient,
@@ -12,7 +14,8 @@ pub(crate) async fn process_announce_message(
     client: &mut MOQTClient,
     write_buf: &mut BytesMut,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
-) -> Result<AnnounceResponse> {
+    send_stream_dispatcher_repository: &mut dyn send_stream_dispatcher_repository::SendStreamDispatcherRepository,
+) -> Result<Option<AnnounceError>> {
     let announce_message = match Announce::depacketize(payload_buf) {
         Ok(announce_message) => announce_message,
         Err(err) => {
@@ -21,22 +24,23 @@ pub(crate) async fn process_announce_message(
         }
     };
 
-    let announce_response =
-        announce_handler(announce_message, client, pubsub_relation_manager_repository).await;
+    let result = announce_handler(
+        announce_message,
+        client,
+        pubsub_relation_manager_repository,
+        send_stream_dispatcher_repository,
+    )
+    .await;
 
-    match announce_response {
-        Ok(announce_response_message) => match announce_response_message {
-            AnnounceResponse::Success(ok_message) => {
-                ok_message.packetize(write_buf);
-                Ok(AnnounceResponse::Success(ok_message))
-            }
-            AnnounceResponse::Failure(err_message) => {
-                err_message.packetize(write_buf);
-                Ok(AnnounceResponse::Failure(err_message))
-            }
-        },
+    match result.as_ref() {
+        Ok(Some(announce_error)) => {
+            announce_error.packetize(write_buf);
+
+            result
+        }
+        Ok(None) => result,
         Err(err) => {
-            tracing::error!("{:#?}", err);
+            tracing::error!("announce_handler: err: {:?}", err.to_string());
             bail!(err.to_string());
         }
     }


### PR DESCRIPTION
This feature was TODO of https://github.com/nttcom/moq-wasm/pull/115

### Note
- Contain the refactor of error messages in AnnounceError and SubscribeNamespaceError
- About changed return value to Result<Option<AnnounceError>>
  - Due to the constraints of the current control_message_handler, any processes are not allowed after returning the ok message
  - This implementation is not good so I will refactor this later