### PR TITLE
Fixed client freeze issue

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -92,7 +92,6 @@ init().then(async () => {
           }
           let groupId = 0n
           let objectPayload = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
-          // let objectPayload = new Uint8Array([0x00, 0x01, 0x02, 0x03])
           await client.sendObjectStreamTrack(subscribeId, groupId, objectId++, objectPayload)
           break
       }


### PR DESCRIPTION
I fixed the read error on the subscriber side, and fortunately the freeze issue on the publisher side was fixed.
I don't know the reason, but it may be that WebTransport process is syncing on Chrome.