### PR TITLE
Support stream per subgroup on server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Supported version: draft-ietf-moq-transport-06
 - [ ] Data Streams
   - [ ] Object Datagram Message
   - [x] Track Stream
-  - [ ] Subgroup Stream
+  - [x] Subgroup Stream
 - [ ] Features
   - [x] Manage Publisher / Subscriber
   - [x] Forword Messages

--- a/js/index.html
+++ b/js/index.html
@@ -27,6 +27,8 @@
           <br />
           <label><input type="radio" name="message-type" id="" value="object-track" />OBJECT TRACK</label>
           <br />
+          <label><input type="radio" name="message-type" id="" value="object-subgroup" />OBJECT SUBGROUP</label>
+          <br />
           <label><input type="radio" name="message-type" id="" value="announce" />ANNOUNCE</label>
           <label><input type="radio" name="message-type" id="" value="unannounce" />UNANNOUNCE</label>
           <br />

--- a/js/main.js
+++ b/js/main.js
@@ -53,6 +53,14 @@ init().then(async () => {
       console.log({ objectStreamTrack })
     })
 
+    client.onStreamHeaderSubgroup(async (streamHeaderSubgroup) => {
+      console.log({ streamHeaderSubgroup })
+    })
+
+    client.onObjectStreamSubgroup(async (objectStreamSubgroup) => {
+      console.log({ objectStreamSubgroup })
+    })
+
     const sendBtn = document.getElementById('sendBtn')
 
     const send = async () => {
@@ -65,6 +73,7 @@ init().then(async () => {
       const versions = form['versions'].value.split(',').map(BigInt)
       const role = Array.from(form['role']).filter((elem) => elem.checked)[0].value
       const isAddPath = !!form['add-path'].checked
+      let objectPayload
 
       console.log({ streamDatagram, messageType, versions, role, isAddPath })
 
@@ -91,9 +100,20 @@ init().then(async () => {
             headerSend = true
           }
           let groupId = 0n
-          let objectPayload = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+          objectPayload = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
           // let objectPayload = new Uint8Array([0x00, 0x01, 0x02, 0x03])
           await client.sendObjectStreamTrack(subscribeId, groupId, objectId++, objectPayload)
+          break
+        case 'object-subgroup':
+          if (!headerSend) {
+            let groupId = 0n
+            let subgroupId = 0n
+            await client.sendStreamHeaderSubgroupMessage(subscribeId, trackAlias, groupId, subgroupId, 0)
+            headerSend = true
+          }
+
+          objectPayload = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+          await client.sendObjectStreamSubgroup(subscribeId, objectId++, objectPayload)
           break
       }
     }

--- a/js/main.js
+++ b/js/main.js
@@ -117,12 +117,7 @@ init().then(async () => {
             headerSend = true
           }
           let groupId = 0n
-<<<<<<< HEAD
-          objectPayload = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
-          // let objectPayload = new Uint8Array([0x00, 0x01, 0x02, 0x03])
-=======
           let objectPayload = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
->>>>>>> draft-06
           await client.sendObjectStreamTrack(subscribeId, groupId, objectId++, objectPayload)
           break
         case 'object-subgroup':

--- a/moqt-client-sample/src/lib.rs
+++ b/moqt-client-sample/src/lib.rs
@@ -24,7 +24,8 @@ use moqt_core::{
     },
     messages::{
         data_streams::{
-            object_stream_track::ObjectStreamTrack, stream_header_track::StreamHeaderTrack,
+            object_stream_subgroup::ObjectStreamSubgroup, object_stream_track::ObjectStreamTrack,
+            stream_header_subgroup::StreamHeaderSubgroup, stream_header_track::StreamHeaderTrack,
             DataStreams,
         },
         moqt_payload::MOQTPayload,
@@ -132,6 +133,20 @@ impl MOQTClient {
         self.callbacks
             .borrow_mut()
             .set_object_stream_track_callback(callback);
+    }
+
+    #[wasm_bindgen(js_name = onStreamHeaderSubgroup)]
+    pub fn set_stream_header_subgroup_callback(&mut self, callback: js_sys::Function) {
+        self.callbacks
+            .borrow_mut()
+            .set_stream_header_subgroup_callback(callback);
+    }
+
+    #[wasm_bindgen(js_name = onObjectStreamSubgroup)]
+    pub fn set_object_stream_subgroup_callback(&mut self, callback: js_sys::Function) {
+        self.callbacks
+            .borrow_mut()
+            .set_object_stream_subgroup_callback(callback);
     }
 
     #[wasm_bindgen(js_name = sendSetupMessage)]
@@ -626,6 +641,79 @@ impl MOQTClient {
         }
     }
 
+    #[wasm_bindgen(js_name = sendStreamHeaderSubgroupMessage)]
+    pub async fn send_stream_header_subgroup_message(
+        &self,
+        subscribe_id: u64,
+        track_alias: u64,
+        group_id: u64,
+        subgroup_id: u64,
+        publisher_priority: u8,
+    ) -> Result<JsValue, JsValue> {
+        let object_stream_writers = self.object_stream_writers.borrow();
+        if let Some(writer) = object_stream_writers.get(&subscribe_id) {
+            let stream_header_subgroup_message = StreamHeaderSubgroup::new(
+                subscribe_id,
+                track_alias,
+                group_id,
+                subgroup_id,
+                publisher_priority,
+            )
+            .unwrap();
+            let mut stream_header_subgroup_message_buf = BytesMut::new();
+            let _ =
+                stream_header_subgroup_message.packetize(&mut stream_header_subgroup_message_buf);
+
+            let mut buf = Vec::new();
+            // Message Type
+            buf.extend(write_variable_integer(
+                u8::from(DataStreamType::StreamHeaderSubgroup) as u64,
+            ));
+            buf.extend(stream_header_subgroup_message_buf);
+
+            let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
+            buffer.copy_from(&buf);
+            JsFuture::from(writer.write_with_chunk(&buffer)).await
+        } else {
+            return Err(JsValue::from_str("object_stream_writer is None"));
+        }
+    }
+
+    #[wasm_bindgen(js_name = sendObjectStreamSubgroup)]
+    pub async fn send_object_stream_subgroup(
+        &self,
+        subscribe_id: u64,
+        object_id: u64,
+        object_payload: Vec<u8>,
+    ) -> Result<JsValue, JsValue> {
+        let object_stream_writers = self.object_stream_writers.borrow();
+        if let Some(writer) = object_stream_writers.get(&subscribe_id) {
+            let object_stream_subgroup =
+                ObjectStreamSubgroup::new(object_id, None, object_payload).unwrap();
+            let mut object_stream_subgroup_buf = BytesMut::new();
+            let _ = object_stream_subgroup.packetize(&mut object_stream_subgroup_buf);
+
+            let mut buf = Vec::new();
+            // Message Payload and Payload Length
+            buf.extend(object_stream_subgroup_buf);
+
+            let buffer = js_sys::Uint8Array::new_with_length(buf.len() as u32);
+            buffer.copy_from(&buf);
+            match JsFuture::from(writer.write_with_chunk(&buffer)).await {
+                Ok(ok) => {
+                    log(std::format!("sent: object id: {:#?}", object_id).as_str());
+                    Ok(ok)
+                }
+                Err(e) => {
+                    log(std::format!("err: {:?}", e).as_str());
+                    Err(e)
+                }
+            }
+        } else {
+            return Err(JsValue::from_str("object_stream_writer is None"));
+        }
+    }
+
     pub async fn start(&self) -> Result<JsValue, JsValue> {
         let transport = web_sys::WebTransport::new(self.url.as_str());
         match &transport {
@@ -890,6 +978,8 @@ async fn uni_directional_stream_read_thread(
     callbacks: Rc<RefCell<MOQTCallbacks>>,
     reader: &ReadableStreamDefaultReader,
 ) -> Result<(), JsValue> {
+    use moqt_core::data_stream_type::DataStreamType;
+
     log("uni_directional_stream_read_thread");
 
     let mut header_read = false;
@@ -942,6 +1032,14 @@ async fn uni_directional_stream_read_thread(
                             return Err(js_sys::Error::new(&e.to_string()).into());
                         }
                     }
+                    DataStreamType::StreamHeaderSubgroup => {
+                        if let Err(e) =
+                            object_stream_subgroup_handler(callbacks.clone(), &mut buf).await
+                        {
+                            log(std::format!("error: {:#?}", e).as_str());
+                            return Err(js_sys::Error::new(&e.to_string()).into());
+                        }
+                    }
                     _ => {
                         unimplemented!()
                     }
@@ -983,7 +1081,21 @@ async fn object_header_handler(
                     }
                 }
                 DataStreamType::StreamHeaderSubgroup => {
-                    unimplemented!();
+                    let stream_header_subgroup = StreamHeaderSubgroup::depacketize(&mut read_cur)?;
+                    buf.advance(read_cur.position() as usize);
+
+                    log(
+                        std::format!("stream_header_subgroup: {:#x?}", stream_header_subgroup)
+                            .as_str(),
+                    );
+
+                    if let Some(callback) = callbacks.borrow().stream_header_subgroup_callback() {
+                        callback
+                            .call1(&JsValue::null(), &JsValue::from("called2"))
+                            .unwrap();
+                        let v = serde_wasm_bindgen::to_value(&stream_header_subgroup).unwrap();
+                        callback.call1(&JsValue::null(), &(v)).unwrap();
+                    }
                 }
                 _ => {
                     // TODO: impl rest of message type
@@ -1007,8 +1119,6 @@ async fn object_stream_track_handler(
     callbacks: Rc<RefCell<MOQTCallbacks>>,
     buf: &mut BytesMut,
 ) -> Result<()> {
-    // log(std::format!("object_stream_track_handler: {:#?}", buf).as_str());
-
     let mut read_cur = Cursor::new(&buf[..]);
     let object_stream_track = match ObjectStreamTrack::depacketize(&mut read_cur) {
         Ok(v) => {
@@ -1023,13 +1133,41 @@ async fn object_stream_track_handler(
         }
     };
 
-    //log(std::format!("object_stream_track: {:#x?}", object_stream_track).as_str());
-
     if let Some(callback) = callbacks.borrow().object_stream_track_callback() {
         callback
             .call1(&JsValue::null(), &JsValue::from("called2"))
             .unwrap();
         let v = serde_wasm_bindgen::to_value(&object_stream_track).unwrap();
+        callback.call1(&JsValue::null(), &(v)).unwrap();
+    }
+
+    Ok(())
+}
+
+#[cfg(web_sys_unstable_apis)]
+async fn object_stream_subgroup_handler(
+    callbacks: Rc<RefCell<MOQTCallbacks>>,
+    buf: &mut BytesMut,
+) -> Result<()> {
+    let mut read_cur = Cursor::new(&buf[..]);
+    let object_stream_subgroup = match ObjectStreamSubgroup::depacketize(&mut read_cur) {
+        Ok(v) => {
+            log(std::format!("object_id: {:#?}", v.object_id()).as_str());
+            buf.advance(read_cur.position() as usize);
+            v
+        }
+        Err(e) => {
+            read_cur.set_position(0);
+            log(std::format!("retry because: {:#?}", e).as_str());
+            return Err(e);
+        }
+    };
+
+    if let Some(callback) = callbacks.borrow().object_stream_subgroup_callback() {
+        callback
+            .call1(&JsValue::null(), &JsValue::from("called2"))
+            .unwrap();
+        let v = serde_wasm_bindgen::to_value(&object_stream_subgroup).unwrap();
         callback.call1(&JsValue::null(), &(v)).unwrap();
     }
 
@@ -1218,6 +1356,8 @@ struct MOQTCallbacks {
     subscribe_response_callback: Option<js_sys::Function>,
     stream_header_track_callback: Option<js_sys::Function>,
     object_stream_track_callback: Option<js_sys::Function>,
+    stream_header_subgroup_callback: Option<js_sys::Function>,
+    object_stream_subgroup_callback: Option<js_sys::Function>,
 }
 
 #[cfg(web_sys_unstable_apis)]
@@ -1230,6 +1370,8 @@ impl MOQTCallbacks {
             subscribe_response_callback: None,
             stream_header_track_callback: None,
             object_stream_track_callback: None,
+            stream_header_subgroup_callback: None,
+            object_stream_subgroup_callback: None,
         }
     }
 
@@ -1279,5 +1421,21 @@ impl MOQTCallbacks {
 
     pub fn set_object_stream_track_callback(&mut self, callback: js_sys::Function) {
         self.object_stream_track_callback = Some(callback);
+    }
+
+    pub fn stream_header_subgroup_callback(&self) -> Option<js_sys::Function> {
+        self.stream_header_subgroup_callback.clone()
+    }
+
+    pub fn set_stream_header_subgroup_callback(&mut self, callback: js_sys::Function) {
+        self.stream_header_subgroup_callback = Some(callback);
+    }
+
+    pub fn object_stream_subgroup_callback(&self) -> Option<js_sys::Function> {
+        self.object_stream_subgroup_callback.clone()
+    }
+
+    pub fn set_object_stream_subgroup_callback(&mut self, callback: js_sys::Function) {
+        self.object_stream_subgroup_callback = Some(callback);
     }
 }

--- a/moqt-core/src/modules/messages/data_streams/stream_header_subgroup.rs
+++ b/moqt-core/src/modules/messages/data_streams/stream_header_subgroup.rs
@@ -33,12 +33,24 @@ impl StreamHeaderSubgroup {
         })
     }
 
+    pub fn subscribe_id(&self) -> u64 {
+        self.subscribe_id
+    }
+
     pub fn track_alias(&self) -> u64 {
         self.track_alias
     }
 
     pub fn group_id(&self) -> u64 {
         self.group_id
+    }
+
+    pub fn subgroup_id(&self) -> u64 {
+        self.subgroup_id
+    }
+
+    pub fn publisher_priority(&self) -> u8 {
+        self.publisher_priority
     }
 }
 

--- a/moqt-server/src/lib.rs
+++ b/moqt-server/src/lib.rs
@@ -20,10 +20,11 @@ use moqt_core::{
     data_stream_type::DataStreamType,
     messages::{
         control_messages::{
-            subscribe::FilterType, subscribe::Subscribe, subscribe_error::SubscribeError,
+            subscribe::{FilterType, Subscribe},
+            subscribe_error::SubscribeError,
             subscribe_ok::SubscribeOk,
         },
-        data_streams::DataStreams,
+        data_streams::{stream_header_subgroup::StreamHeaderSubgroup, DataStreams},
         moqt_payload::MOQTPayload,
     },
     models::tracks::ForwardingPreference,
@@ -338,10 +339,10 @@ async fn handle_connection(
                 }
 
                 match data_stream_type {
-                    DataStreamType::StreamHeaderTrack => {
+                    DataStreamType::StreamHeaderTrack | DataStreamType::StreamHeaderSubgroup => {
                         let session_span = tracing::info_span!("Session", stable_id);
                         session_span.in_scope(|| {
-                            tracing::info!("Open UNI Send stream");
+                            tracing::info!("Open UNI Send stream for stream type: {:?}", data_stream_type);
                         });
 
                         let buffer_tx = buffer_tx.clone();
@@ -360,15 +361,12 @@ async fn handle_connection(
                             subscribe_id,
                             send_stream,
                         };
-                        relaying_track_stream(&mut stream, buffer_tx, pubsub_relation_tx, close_connection_tx, object_cache_tx).instrument(session_span_clone).await
+                        relaying_object_stream(&mut stream, data_stream_type, buffer_tx, pubsub_relation_tx, close_connection_tx, object_cache_tx).instrument(session_span_clone).await
 
                         // Propagate the current span (Connection)
                         }.in_current_span());
 
 
-                    }
-                    DataStreamType::StreamHeaderSubgroup => {
-                        unimplemented!();
                     }
                     DataStreamType::ObjectDatagram => {
                         // TODO: Open datagram thread
@@ -606,17 +604,20 @@ struct UniSendStream {
     send_stream: SendStream,
 }
 
-async fn relaying_track_stream(
+async fn relaying_object_stream(
     stream: &mut UniSendStream,
-    _buffer_tx: Sender<BufferCommand>,
+    data_stream_type: DataStreamType,
+    buffer_tx: Sender<BufferCommand>,
     pubsub_relation_tx: Sender<PubSubRelationCommand>,
     close_connection_tx: Sender<(u64, String)>,
     object_cache_tx: Sender<ObjectCacheStorageCommand>,
 ) -> Result<()> {
     let sleep_time = Duration::from_millis(10);
 
+    let mut subgroup_header: Option<StreamHeaderSubgroup> = None; // For end group of AbsoluteRange
+
     let downstream_session_id = stream.stable_id;
-    let _downstream_stream_id = stream.stream_id;
+    let downstream_stream_id = stream.stream_id;
     let downstream_subscribe_id = stream.subscribe_id;
     let send_stream = &mut stream.send_stream;
 
@@ -647,6 +648,19 @@ async fn relaying_track_stream(
         .await?
     {
         Some(ForwardingPreference::Track) => {
+            if data_stream_type != DataStreamType::StreamHeaderTrack {
+                let msg = std::format!(
+                    "uni send stream's data stream type is wrong (expected Track, but got {:?})",
+                    data_stream_type
+                );
+                close_connection_tx
+                    .send((
+                        u8::from(constants::TerminationErrorCode::InternalError) as u64,
+                        msg.clone(),
+                    ))
+                    .await?;
+                bail!(msg)
+            }
             pubsub_relation_manager
                 .set_downstream_forwarding_preference(
                     downstream_session_id,
@@ -654,7 +668,28 @@ async fn relaying_track_stream(
                     ForwardingPreference::Track,
                 )
                 .await?;
-            ForwardingPreference::Track
+        }
+        Some(ForwardingPreference::Subgroup) => {
+            if data_stream_type != DataStreamType::StreamHeaderSubgroup {
+                let msg = std::format!(
+                    "uni send stream's data stream type is wrong (expected Subgroup, but got {:?})",
+                    data_stream_type
+                );
+                close_connection_tx
+                    .send((
+                        u8::from(constants::TerminationErrorCode::InternalError) as u64,
+                        msg.clone(),
+                    ))
+                    .await?;
+                bail!(msg)
+            }
+            pubsub_relation_manager
+                .set_downstream_forwarding_preference(
+                    downstream_session_id,
+                    downstream_subscribe_id,
+                    ForwardingPreference::Subgroup,
+                )
+                .await?;
         }
         _ => {
             let msg = "Invalid forwarding preference";
@@ -692,6 +727,32 @@ async fn relaying_track_stream(
                 bail!(e);
             }
         }
+        CacheHeader::Subgroup(header) => {
+            let mut buf = BytesMut::new();
+            let header = StreamHeaderSubgroup::new(
+                downstream_subscribe_id,
+                downstream_track_alias,
+                header.group_id(),
+                header.subgroup_id(),
+                header.publisher_priority(),
+            )
+            .unwrap();
+
+            subgroup_header = Some(header.clone());
+
+            header.packetize(&mut buf);
+
+            let mut message_buf = BytesMut::with_capacity(buf.len() + 8);
+            message_buf.extend(write_variable_integer(
+                u8::from(DataStreamType::StreamHeaderSubgroup) as u64,
+            ));
+            message_buf.extend(buf);
+
+            if let Err(e) = send_stream.write_all(&message_buf).await {
+                tracing::warn!("Failed to write to stream: {:?}", e);
+                bail!(e);
+            }
+        }
         _ => {
             let msg = "cache header not matched";
             close_connection_tx
@@ -707,9 +768,7 @@ async fn relaying_track_stream(
     let mut object_cache_id: Option<usize> = None;
 
     while object_cache_id.is_none() {
-        // TODO: Change the method of obtaining objects according to the subscribe request
-        // Get the first object from the cache storage and send it to the client
-
+        // Get the first object from the cache storage
         let result = match filter_type {
             FilterType::LatestGroup => {
                 object_cache_storage
@@ -734,6 +793,7 @@ async fn relaying_track_stream(
         };
 
         object_cache_id = match result {
+            // Send the object to the client if the first cache is exist as track
             Ok(Some((id, CacheObject::Track(object)))) => {
                 let mut buf = BytesMut::new();
                 object.packetize(&mut buf);
@@ -748,6 +808,22 @@ async fn relaying_track_stream(
 
                 Some(id)
             }
+            // Send the object to the client if the first cache is exist as subgroup
+            Ok(Some((id, CacheObject::Subgroup(object)))) => {
+                let mut buf = BytesMut::new();
+                object.packetize(&mut buf);
+
+                let mut message_buf = BytesMut::with_capacity(buf.len());
+                message_buf.extend(buf);
+
+                if let Err(e) = send_stream.write_all(&message_buf).await {
+                    tracing::warn!("Failed to write to stream: {:?}", e);
+                    bail!(e);
+                }
+
+                Some(id)
+            }
+            // Will be retried if the first cache is not exist
             Ok(None) => {
                 thread::sleep(sleep_time);
                 object_cache_id
@@ -766,8 +842,7 @@ async fn relaying_track_stream(
     }
 
     loop {
-        // TODO: Implement the processing when the content ends
-        // Get the first object from the cache storage and send it to the client
+        // Get the next object from the cache storage
         object_cache_id = match object_cache_storage
             .get_next_object(
                 upstream_session_id,
@@ -776,6 +851,7 @@ async fn relaying_track_stream(
             )
             .await
         {
+            // Send the object to the client if the next cache is exist as track
             Ok(Some((id, CacheObject::Track(object)))) => {
                 let mut buf = BytesMut::new();
                 object.packetize(&mut buf);
@@ -788,6 +864,7 @@ async fn relaying_track_stream(
                     bail!(e);
                 }
 
+                // Judge whether ids are reached to end of the range if the filter type is AbsoluteRange
                 if filter_type == FilterType::AbsoluteRange {
                     let is_end = (object.group_id() == end_group.unwrap()
                         && object.object_id() == end_object.unwrap())
@@ -800,6 +877,34 @@ async fn relaying_track_stream(
 
                 Some(id)
             }
+            // Send the object to the client if the next cache is exist as subgroup
+            Ok(Some((id, CacheObject::Subgroup(object)))) => {
+                let mut buf = BytesMut::new();
+                object.packetize(&mut buf);
+
+                let mut message_buf = BytesMut::with_capacity(buf.len());
+                message_buf.extend(buf);
+
+                if let Err(e) = send_stream.write_all(&message_buf).await {
+                    tracing::warn!("Failed to write to stream: {:?}", e);
+                    bail!(e);
+                }
+
+                // Judge whether ids are reached to end of the range if the filter type is AbsoluteRange
+                let header = subgroup_header.as_ref().unwrap();
+                if filter_type == FilterType::AbsoluteRange {
+                    let is_end = (header.group_id() == end_group.unwrap()
+                        && object.object_id() == end_object.unwrap())
+                        || (header.group_id() > end_group.unwrap());
+
+                    if is_end {
+                        break;
+                    }
+                }
+
+                Some(id)
+            }
+            // Will be retried if the next cache is not exist
             Ok(None) => {
                 thread::sleep(sleep_time);
                 object_cache_id
@@ -817,10 +922,10 @@ async fn relaying_track_stream(
         };
     }
 
-    _buffer_tx
+    buffer_tx
         .send(BufferCommand::ReleaseStream {
             session_id: downstream_session_id,
-            stream_id: _downstream_stream_id,
+            stream_id: downstream_stream_id,
         })
         .await?;
 

--- a/moqt-server/src/modules/handlers.rs
+++ b/moqt-server/src/modules/handlers.rs
@@ -1,5 +1,6 @@
 pub(crate) mod announce_handler;
 pub(crate) mod server_setup_handler;
+pub(crate) mod stream_subgroup_header_handler;
 pub(crate) mod stream_track_header_handler;
 pub(crate) mod subscribe_handler;
 pub(crate) mod subscribe_ok_handler;

--- a/moqt-server/src/modules/handlers/stream_subgroup_header_handler.rs
+++ b/moqt-server/src/modules/handlers/stream_subgroup_header_handler.rs
@@ -1,37 +1,36 @@
 use crate::modules::object_cache_storage::{CacheHeader, ObjectCacheStorageWrapper};
 use anyhow::Result;
 use moqt_core::{
-    messages::data_streams::stream_header_track::StreamHeaderTrack,
+    messages::data_streams::stream_header_subgroup::StreamHeaderSubgroup,
     models::tracks::ForwardingPreference,
     pubsub_relation_manager_repository::PubSubRelationManagerRepository, MOQTClient,
 };
 
-pub(crate) async fn stream_header_track_handler(
-    stream_header_track_message: StreamHeaderTrack,
+pub(crate) async fn stream_header_subgroup_handler(
+    stream_header_subgroup_message: StreamHeaderSubgroup,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     object_cache_storage: &mut ObjectCacheStorageWrapper,
     client: &mut MOQTClient,
 ) -> Result<u64> {
-    tracing::trace!("stream_header_track_handler start.");
+    tracing::trace!("stream_header_subgroup_handler start.");
 
     tracing::debug!(
-        "stream_header_track_message: {:#?}",
-        stream_header_track_message
+        "stream_header_subgroup_message: {:#?}",
+        stream_header_subgroup_message
     );
 
     let upstream_session_id = client.id;
-    let upstream_subscribe_id = stream_header_track_message.subscribe_id();
+    let upstream_subscribe_id = stream_header_subgroup_message.subscribe_id();
 
     pubsub_relation_manager_repository
         .set_upstream_forwarding_preference(
             upstream_session_id,
             upstream_subscribe_id,
-            ForwardingPreference::Track,
+            ForwardingPreference::Subgroup,
         )
         .await?;
 
-    // Prepare the cache for stream track
-    let cache_header = CacheHeader::Track(stream_header_track_message);
+    let cache_header = CacheHeader::Subgroup(stream_header_subgroup_message);
     object_cache_storage
         .set_subscription(upstream_session_id, upstream_subscribe_id, cache_header)
         .await?;

--- a/moqt-server/src/modules/server_processes.rs
+++ b/moqt-server/src/modules/server_processes.rs
@@ -1,5 +1,6 @@
 pub(crate) mod announce_message;
 pub(crate) mod client_setup_message;
 pub(crate) mod stream_track_header;
+pub(crate) mod stream_track_subgroup;
 pub(crate) mod subscribe_message;
 pub(crate) mod subscribe_ok_message;

--- a/moqt-server/src/modules/server_processes/stream_track_subgroup.rs
+++ b/moqt-server/src/modules/server_processes/stream_track_subgroup.rs
@@ -1,0 +1,29 @@
+use crate::modules::handlers::stream_subgroup_header_handler::stream_header_subgroup_handler;
+use crate::modules::object_cache_storage::ObjectCacheStorageWrapper;
+use anyhow::{bail, Result};
+use moqt_core::messages::data_streams::stream_header_subgroup::StreamHeaderSubgroup;
+use moqt_core::messages::data_streams::DataStreams;
+use moqt_core::pubsub_relation_manager_repository::PubSubRelationManagerRepository;
+use moqt_core::MOQTClient;
+
+pub(crate) async fn process_stream_header_subgroup(
+    read_cur: &mut std::io::Cursor<&[u8]>,
+    pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
+    object_cache_storage: &mut ObjectCacheStorageWrapper,
+    client: &mut MOQTClient,
+) -> Result<u64> {
+    let stream_header_subgroup = match StreamHeaderSubgroup::depacketize(read_cur) {
+        Ok(stream_header_subgroup) => stream_header_subgroup,
+        Err(err) => {
+            tracing::error!("{:#?}", err);
+            bail!(err.to_string());
+        }
+    };
+    stream_header_subgroup_handler(
+        stream_header_subgroup,
+        pubsub_relation_manager_repository,
+        object_cache_storage,
+        client,
+    )
+    .await
+}


### PR DESCRIPTION
- Client 
  - Send header/object as subgroup
  - Recv subgroup header/object
- Server 
  - Relay subgroup header/object



### Note
Sorry but it includes #119 and #121 copy. So I recommend to review after their merge.