### PR TITLE
Fix the problem that cannot send object  bi-directionally

### DIFF
--- a/moqt-server/src/lib.rs
+++ b/moqt-server/src/lib.rs
@@ -987,16 +987,19 @@ async fn handle_incoming_bi_stream(
         let mut buf = buf.lock().await;
         buf.extend_from_slice(&read_buf);
 
-        let mut client = client.lock().await;
-        // TODO: Move the implementation of control_message_handler to the server side since it is only used by the server
-        let message_result = control_message_handler(
-            &mut buf,
-            UnderlayType::WebTransport,
-            &mut client,
-            &mut pubsub_relation_manager,
-            &mut send_stream_dispatcher,
-        )
-        .await;
+        let message_result: MessageProcessResult;
+        {
+            let mut client = client.lock().await;
+            // TODO: Move the implementation of control_message_handler to the server side since it is only used by the server
+            message_result = control_message_handler(
+                &mut buf,
+                UnderlayType::WebTransport,
+                &mut client,
+                &mut pubsub_relation_manager,
+                &mut send_stream_dispatcher,
+            )
+            .await;
+        }
 
         tracing::debug!("message_result: {:?}", message_result);
 

--- a/moqt-server/src/lib.rs
+++ b/moqt-server/src/lib.rs
@@ -508,11 +508,11 @@ async fn handle_incoming_uni_stream(
             let result: StreamHeaderProcessResult;
             {
                 let mut process_buf = buf.lock().await;
-                let mut client = client.lock().await;
+                let client = client.lock().await;
 
                 result = stream_header_handler(
                     &mut process_buf,
-                    &mut client,
+                    &client,
                     &mut pubsub_relation_manager,
                     &mut object_cache_storage,
                 )
@@ -565,13 +565,13 @@ async fn handle_incoming_uni_stream(
         // Read Object Stream
         {
             let mut process_buf = buf.lock().await;
-            let mut client = client.lock().await;
+            let client = client.lock().await;
 
             result = object_stream_handler(
                 stream_header_type.clone(),
                 upstream_subscribe_id,
                 &mut process_buf,
-                &mut client,
+                &client,
                 &mut object_cache_storage,
             )
             .await;

--- a/moqt-server/src/lib.rs
+++ b/moqt-server/src/lib.rs
@@ -268,7 +268,7 @@ async fn handle_connection(
                 let pubsub_relation_tx = pubsub_relation_tx.clone();
                 let send_stream_tx = send_stream_tx.clone();
                 let close_connection_tx = close_connection_tx.clone();
-                let client= client.clone();
+                let client = Arc::clone(&client);
 
                 let (message_tx, message_rx) = mpsc::channel::<Arc<Box<dyn MOQTPayload>>>(1024);
                 send_stream_tx.send(SendStreamDispatchCommand::Set {
@@ -320,7 +320,8 @@ async fn handle_connection(
                 let object_cache_tx = object_cache_tx.clone();
                 let open_subscription_txes = open_subscription_txes.clone();
                 let close_connection_tx = close_connection_tx.clone();
-                let client = client.clone();
+                let client = Arc::clone(&client);
+
                 let session_span_clone = session_span.clone();
 
                 tokio::spawn(async move {
@@ -448,7 +449,6 @@ async fn handle_incoming_uni_stream(
     let mut upstream_subscribe_id: u64 = 0;
     let mut stream_header_type: DataStreamType = DataStreamType::ObjectDatagram;
     let stream_id = stream.stream_id;
-    let mut client = client.lock().await;
     let close_connection_tx_clone = close_connection_tx.clone();
     let buffer_tx_clone = buffer_tx.clone();
     let shared_recv_stream = &mut stream.shared_recv_stream;
@@ -508,6 +508,8 @@ async fn handle_incoming_uni_stream(
             let result: StreamHeaderProcessResult;
             {
                 let mut process_buf = buf.lock().await;
+                let mut client = client.lock().await;
+
                 result = stream_header_handler(
                     &mut process_buf,
                     &mut client,
@@ -563,6 +565,7 @@ async fn handle_incoming_uni_stream(
         // Read Object Stream
         {
             let mut process_buf = buf.lock().await;
+            let mut client = client.lock().await;
 
             result = object_stream_handler(
                 stream_header_type.clone(),

--- a/moqt-server/src/modules/handlers/announce_handler.rs
+++ b/moqt-server/src/modules/handlers/announce_handler.rs
@@ -134,7 +134,7 @@ mod success {
         // Generate client
         let upstream_session_id = 0;
         let downstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -186,7 +186,7 @@ mod success {
         // Execute announce_handler and get result
         let result = announce_handler(
             announce_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -213,7 +213,7 @@ mod success {
         // Generate client
         let upstream_session_id = 0;
         let downstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -262,7 +262,7 @@ mod success {
         // Execute announce_handler and get result
         let result = announce_handler(
             announce_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -312,7 +312,7 @@ mod failure {
 
         // Generate client
         let upstream_session_id = 0;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -351,7 +351,7 @@ mod failure {
         // Execute announce_handler and get result
         let result = announce_handler(
             announce_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )

--- a/moqt-server/src/modules/handlers/announce_handler.rs
+++ b/moqt-server/src/modules/handlers/announce_handler.rs
@@ -10,7 +10,7 @@ use moqt_core::{
 
 pub(crate) async fn announce_handler(
     announce_message: Announce,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
 ) -> Result<Option<AnnounceError>> {

--- a/moqt-server/src/modules/handlers/announce_ok_handler.rs
+++ b/moqt-server/src/modules/handlers/announce_ok_handler.rs
@@ -43,7 +43,7 @@ mod success {
 
         // Generate client
         let downstream_session_id = 0;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -59,12 +59,8 @@ mod success {
             .await;
 
         // Execute announce_ok_handler and get result
-        let result = announce_ok_handler(
-            announce_ok_message,
-            &mut client,
-            &mut pubsub_relation_manager,
-        )
-        .await;
+        let result =
+            announce_ok_handler(announce_ok_message, &client, &mut pubsub_relation_manager).await;
 
         assert!(result.is_ok());
     }

--- a/moqt-server/src/modules/handlers/announce_ok_handler.rs
+++ b/moqt-server/src/modules/handlers/announce_ok_handler.rs
@@ -4,7 +4,7 @@ use moqt_core::{messages::control_messages::announce_ok::AnnounceOk, MOQTClient}
 
 pub(crate) async fn announce_ok_handler(
     announce_ok_message: AnnounceOk,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
 ) -> Result<()> {
     tracing::trace!("announce_ok_handler start.");

--- a/moqt-server/src/modules/handlers/stream_subgroup_header_handler.rs
+++ b/moqt-server/src/modules/handlers/stream_subgroup_header_handler.rs
@@ -10,7 +10,7 @@ pub(crate) async fn stream_header_subgroup_handler(
     stream_header_subgroup_message: StreamHeaderSubgroup,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     object_cache_storage: &mut ObjectCacheStorageWrapper,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
 ) -> Result<u64> {
     tracing::trace!("stream_header_subgroup_handler start.");
 

--- a/moqt-server/src/modules/handlers/stream_track_header_handler.rs
+++ b/moqt-server/src/modules/handlers/stream_track_header_handler.rs
@@ -10,7 +10,7 @@ pub(crate) async fn stream_header_track_handler(
     stream_header_track_message: StreamHeaderTrack,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     object_cache_storage: &mut ObjectCacheStorageWrapper,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
 ) -> Result<u64> {
     tracing::trace!("stream_header_track_handler start.");
 

--- a/moqt-server/src/modules/handlers/subscribe_error_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_error_handler.rs
@@ -10,7 +10,7 @@ pub(crate) async fn subscribe_error_handler(
     subscribe_error_message: SubscribeError,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
 ) -> Result<()> {
     tracing::trace!("subscribe_error_handler start.");
 

--- a/moqt-server/src/modules/handlers/subscribe_error_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_error_handler.rs
@@ -148,7 +148,7 @@ mod success {
 
         // Generate client
         let upstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -242,7 +242,7 @@ mod success {
             subscribe_error,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
-            &mut client,
+            &client,
         )
         .await;
 
@@ -285,7 +285,7 @@ mod failure {
 
         // Generate client
         let upstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -370,7 +370,7 @@ mod failure {
             subscribe_error,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
-            &mut client,
+            &client,
         )
         .await;
 

--- a/moqt-server/src/modules/handlers/subscribe_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_handler.rs
@@ -420,7 +420,7 @@ mod success {
 
         // Generate client
         let downstream_session_id = 0;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -463,7 +463,7 @@ mod success {
         // Execute subscribe_handler and get result
         let result = subscribe_handler(
             subscribe,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -528,7 +528,7 @@ mod success {
 
         // Generate client
         let downstream_session_id = 0;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -586,7 +586,7 @@ mod success {
         // Execute subscribe_handler and get result
         let result = subscribe_handler(
             subscribe,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -676,7 +676,7 @@ mod failure {
 
         // Generate client
         let downstream_session_id = 0;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper (register subscriber in advance)
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -734,7 +734,7 @@ mod failure {
         // Execute subscribe_handler and get result
         let result = subscribe_handler(
             subscribe,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -780,7 +780,7 @@ mod failure {
 
         // Generate client
         let downstream_session_id = 0;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -813,7 +813,7 @@ mod failure {
         // Execute subscribe_handler and get result
         let result = subscribe_handler(
             subscribe,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -865,7 +865,7 @@ mod failure {
 
         // Generate client
         let downstream_session_id = 0;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper (without set publisher)
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -900,7 +900,7 @@ mod failure {
         // Execute subscribe_handler and get result
         let result = subscribe_handler(
             subscribe,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -958,7 +958,7 @@ mod failure {
 
         // Generate client
         let downstream_session_id = 0;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -1001,7 +1001,7 @@ mod failure {
         // Execute subscribe_handler and get result
         let _ = subscribe_handler(
             subscribes[0].clone(),
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -1009,7 +1009,7 @@ mod failure {
 
         let result = subscribe_handler(
             subscribes[1].clone(),
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -1060,7 +1060,7 @@ mod failure {
 
         // Generate client
         let downstream_session_id = 0;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -1103,7 +1103,7 @@ mod failure {
         // Execute subscribe_handler and get result
         let _ = subscribe_handler(
             subscribes[0].clone(),
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -1111,7 +1111,7 @@ mod failure {
 
         let result = subscribe_handler(
             subscribes[1].clone(),
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )

--- a/moqt-server/src/modules/handlers/subscribe_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_handler.rs
@@ -21,7 +21,7 @@ pub(crate) enum SubscribeResponse {
 
 pub(crate) async fn subscribe_handler(
     subscribe_message: Subscribe,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
 ) -> Result<Option<SubscribeResponse>> {

--- a/moqt-server/src/modules/handlers/subscribe_namespace_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_namespace_handler.rs
@@ -143,7 +143,7 @@ mod success {
         // Generate client
         let upstream_session_id = 0;
         let downstream_session_id = 1;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -183,7 +183,7 @@ mod success {
         // Execute subscribe_namespace_handler and get result
         let result = subscribe_namespace_handler(
             subscribe_namespace_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -239,7 +239,7 @@ mod failure {
         // Generate client
         let upstream_session_id = 0;
         let downstream_session_id = 1;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper (register track_namespace_prefix in advance)
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -283,7 +283,7 @@ mod failure {
         // Execute subscribe_namespace_handler and get result
         let result = subscribe_namespace_handler(
             subscribe_namespace_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -320,7 +320,7 @@ mod failure {
         // Generate client
         let upstream_session_id = 0;
         let downstream_session_id = 1;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper (register track_namespace_prefix that has same prefix in advance)
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -367,7 +367,7 @@ mod failure {
         // Execute subscribe_namespace_handler and get result
         let result = subscribe_namespace_handler(
             subscribe_namespace_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -405,7 +405,7 @@ mod failure {
         // Generate client
         let upstream_session_id = 0;
         let downstream_session_id = 1;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper (register track_namespace_prefix that has same prefix in advance)
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -452,7 +452,7 @@ mod failure {
         // Execute subscribe_namespace_handler and get result
         let result = subscribe_namespace_handler(
             subscribe_namespace_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -488,7 +488,7 @@ mod failure {
         // Generate client
         let upstream_session_id = 0;
         let downstream_session_id = 1;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -519,7 +519,7 @@ mod failure {
         // Execute subscribe_namespace_handler and get result
         let result = subscribe_namespace_handler(
             subscribe_namespace_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )
@@ -547,7 +547,7 @@ mod failure {
         // Generate client
         let upstream_session_id = 0;
         let downstream_session_id = 1;
-        let mut client = MOQTClient::new(downstream_session_id);
+        let client = MOQTClient::new(downstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -587,7 +587,7 @@ mod failure {
         // Execute subscribe_namespace_handler and get result
         let result = subscribe_namespace_handler(
             subscribe_namespace_message,
-            &mut client,
+            &client,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
         )

--- a/moqt-server/src/modules/handlers/subscribe_namespace_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_namespace_handler.rs
@@ -15,7 +15,7 @@ use moqt_core::{
 
 pub(crate) async fn subscribe_namespace_handler(
     subscribe_namespace_message: SubscribeNamespace,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
 ) -> Result<Option<SubscribeNamespaceError>> {

--- a/moqt-server/src/modules/handlers/subscribe_ok_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_ok_handler.rs
@@ -144,7 +144,7 @@ mod success {
 
         // Generate client
         let upstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -227,7 +227,7 @@ mod success {
             subscribe_ok,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
-            &mut client,
+            &client,
         )
         .await;
 
@@ -294,7 +294,7 @@ mod failure {
 
         // Generate client
         let upstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -368,7 +368,7 @@ mod failure {
             subscribe_ok,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
-            &mut client,
+            &client,
         )
         .await;
 
@@ -410,7 +410,7 @@ mod failure {
 
         // Generate client
         let upstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -465,7 +465,7 @@ mod failure {
             subscribe_ok,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
-            &mut client,
+            &client,
         )
         .await;
 
@@ -508,7 +508,7 @@ mod failure {
 
         // Generate client
         let upstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -595,7 +595,7 @@ mod failure {
             subscribe_ok,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
-            &mut client,
+            &client,
         )
         .await;
 
@@ -638,7 +638,7 @@ mod failure {
 
         // Generate client
         let upstream_session_id = 1;
-        let mut client = MOQTClient::new(upstream_session_id);
+        let client = MOQTClient::new(upstream_session_id);
 
         // Generate PubSubRelationManagerWrapper
         let (track_namespace_tx, mut track_namespace_rx) =
@@ -725,7 +725,7 @@ mod failure {
             subscribe_ok,
             &mut pubsub_relation_manager,
             &mut send_stream_dispatcher,
-            &mut client,
+            &client,
         )
         .await;
 

--- a/moqt-server/src/modules/handlers/subscribe_ok_handler.rs
+++ b/moqt-server/src/modules/handlers/subscribe_ok_handler.rs
@@ -10,7 +10,7 @@ pub(crate) async fn subscribe_ok_handler(
     subscribe_ok_message: SubscribeOk,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
 ) -> Result<()> {
     tracing::trace!("subscribe_ok_handler start.");
 

--- a/moqt-server/src/modules/handlers/unannounce_handler.rs
+++ b/moqt-server/src/modules/handlers/unannounce_handler.rs
@@ -4,7 +4,7 @@ use moqt_core::{messages::control_messages::unannounce::UnAnnounce, MOQTClient};
 
 pub(crate) async fn unannounce_handler(
     unannounce_message: UnAnnounce,
-    _client: &mut MOQTClient, // TODO: Not implemented yet
+    _client: &MOQTClient, // TODO: Not implemented yet
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
 ) -> Result<()> {
     tracing::trace!("unannounce_handler start.");

--- a/moqt-server/src/modules/handlers/unsubscribe_handler.rs
+++ b/moqt-server/src/modules/handlers/unsubscribe_handler.rs
@@ -13,7 +13,7 @@ pub(crate) enum UnSubscribeResponse {
 // TODO: Define the behavior if the last subscriber unsubscribes from the track
 pub(crate) async fn _unsubscribe_handler(
     unsubscribe_message: Unsubscribe,
-    _client: &mut MOQTClient, // TODO: Not implemented yet
+    _client: &MOQTClient, // TODO: Not implemented yet
     _pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository, // TODO: Not implemented yet
 ) -> Result<UnSubscribeResponse> {
     tracing::trace!("unsubscribe_handler start.");

--- a/moqt-server/src/modules/object_stream_handler.rs
+++ b/moqt-server/src/modules/object_stream_handler.rs
@@ -20,7 +20,7 @@ pub async fn object_stream_handler(
     header_type: DataStreamType,
     subscribe_id: u64,
     read_buf: &mut BytesMut,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     object_cache_storage: &mut ObjectCacheStorageWrapper,
 ) -> ObjectStreamProcessResult {
     let payload_length = read_buf.len();

--- a/moqt-server/src/modules/server_processes/announce_message.rs
+++ b/moqt-server/src/modules/server_processes/announce_message.rs
@@ -11,7 +11,7 @@ use moqt_core::{
 
 pub(crate) async fn process_announce_message(
     payload_buf: &mut BytesMut,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     write_buf: &mut BytesMut,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn send_stream_dispatcher_repository::SendStreamDispatcherRepository,

--- a/moqt-server/src/modules/server_processes/announce_ok_message.rs
+++ b/moqt-server/src/modules/server_processes/announce_ok_message.rs
@@ -9,7 +9,7 @@ use moqt_core::{
 
 pub(crate) async fn process_announce_ok_message(
     payload_buf: &mut BytesMut,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
 ) -> Result<()> {
     let announce_ok_message = match AnnounceOk::depacketize(payload_buf) {

--- a/moqt-server/src/modules/server_processes/stream_track_header.rs
+++ b/moqt-server/src/modules/server_processes/stream_track_header.rs
@@ -10,7 +10,7 @@ pub(crate) async fn process_stream_header_track(
     read_cur: &mut std::io::Cursor<&[u8]>,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     object_cache_storage: &mut ObjectCacheStorageWrapper,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
 ) -> Result<u64> {
     let stream_header_track = match StreamHeaderTrack::depacketize(read_cur) {
         Ok(stream_header_track) => stream_header_track,

--- a/moqt-server/src/modules/server_processes/stream_track_subgroup.rs
+++ b/moqt-server/src/modules/server_processes/stream_track_subgroup.rs
@@ -10,7 +10,7 @@ pub(crate) async fn process_stream_header_subgroup(
     read_cur: &mut std::io::Cursor<&[u8]>,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     object_cache_storage: &mut ObjectCacheStorageWrapper,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
 ) -> Result<u64> {
     let stream_header_subgroup = match StreamHeaderSubgroup::depacketize(read_cur) {
         Ok(stream_header_subgroup) => stream_header_subgroup,

--- a/moqt-server/src/modules/server_processes/subscribe_error_message.rs
+++ b/moqt-server/src/modules/server_processes/subscribe_error_message.rs
@@ -11,7 +11,7 @@ pub(crate) async fn process_subscribe_error_message(
     payload_buf: &mut BytesMut,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
 ) -> Result<()> {
     let subscribe_error_message = match SubscribeError::depacketize(payload_buf) {
         Ok(subscribe_error_message) => subscribe_error_message,

--- a/moqt-server/src/modules/server_processes/subscribe_message.rs
+++ b/moqt-server/src/modules/server_processes/subscribe_message.rs
@@ -9,7 +9,7 @@ use moqt_core::{
 
 pub(crate) async fn process_subscribe_message(
     payload_buf: &mut BytesMut,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     write_buf: &mut BytesMut,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,

--- a/moqt-server/src/modules/server_processes/subscribe_namespace_message.rs
+++ b/moqt-server/src/modules/server_processes/subscribe_namespace_message.rs
@@ -13,7 +13,7 @@ use moqt_core::{
 
 pub(crate) async fn process_subscribe_namespace_message(
     payload_buf: &mut BytesMut,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     write_buf: &mut BytesMut,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,

--- a/moqt-server/src/modules/server_processes/subscribe_ok_message.rs
+++ b/moqt-server/src/modules/server_processes/subscribe_ok_message.rs
@@ -11,7 +11,7 @@ pub(crate) async fn process_subscribe_ok_message(
     payload_buf: &mut BytesMut,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     send_stream_dispatcher_repository: &mut dyn SendStreamDispatcherRepository,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
 ) -> Result<()> {
     let subscribe_ok_message = match SubscribeOk::depacketize(payload_buf) {
         Ok(subscribe_ok_message) => subscribe_ok_message,

--- a/moqt-server/src/modules/stream_header_handler.rs
+++ b/moqt-server/src/modules/stream_header_handler.rs
@@ -42,7 +42,7 @@ fn read_header_type(read_cur: &mut std::io::Cursor<&[u8]>) -> Result<DataStreamT
 
 pub async fn stream_header_handler(
     read_buf: &mut BytesMut,
-    client: &mut MOQTClient,
+    client: &MOQTClient,
     pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
     object_cache_storage: &mut ObjectCacheStorageWrapper,
 ) -> StreamHeaderProcessResult {


### PR DESCRIPTION
- Fixed the problem caused by holding client mutex in `handle_incoming_uni_stream`
- Removed unnecessary mutable for the `client`