### PR TITLE
Fix downstream MAX_SUBSCRIBE_ID value

### DIFF
--- a/moqt-server/src/modules/handlers/server_setup_handler.rs
+++ b/moqt-server/src/modules/handlers/server_setup_handler.rs
@@ -1,5 +1,6 @@
 use crate::constants;
 use anyhow::{bail, Result};
+use moqt_core::messages::control_messages::setup_parameters::MaxSubscribeID;
 use moqt_core::pubsub_relation_manager_repository::PubSubRelationManagerRepository;
 use moqt_core::{
     constants::UnderlayType,
@@ -13,32 +14,19 @@ use moqt_core::{
     MOQTClient,
 };
 
-pub(crate) async fn setup_handler(
-    client_setup_message: ClientSetup,
-    underlay_type: UnderlayType,
-    client: &mut MOQTClient,
-    pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
-) -> Result<ServerSetup> {
-    tracing::trace!("setup_handler start.");
-
-    tracing::debug!("client_setup_message: {:#?}", client_setup_message);
-
-    tracing::debug!(
-        "supported_versions: {:#x?}",
-        client_setup_message.supported_versions
-    );
-
-    if !client_setup_message
-        .supported_versions
+fn is_requested_version_supported(supported_versions: Vec<u32>) -> bool {
+    supported_versions
         .iter()
         .any(|v| *v == constants::MOQ_TRANSPORT_VERSION)
-    {
-        bail!("Supported version is not included");
-    }
+}
 
+fn handle_setup_parameter(
+    client: &mut MOQTClient,
+    setup_parameters: Vec<SetupParameter>,
+    underlay_type: UnderlayType,
+) -> Result<u64> {
     let mut max_subscribe_id: u64 = 0;
-
-    for setup_parameter in &client_setup_message.setup_parameters {
+    for setup_parameter in &setup_parameters {
         match setup_parameter {
             SetupParameter::Role(param) => {
                 client.set_role(param.value)?;
@@ -56,41 +44,103 @@ pub(crate) async fn setup_handler(
             }
         }
     }
+    Ok(max_subscribe_id)
+}
 
+async fn setup_subscription_node(
+    client: &MOQTClient,
+    pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
+    upstream_max_subscribe_id: u64,
+    downstream_max_subscribe_id: u64,
+) -> Result<()> {
     match client.role() {
         Some(RoleCase::Publisher) => {
             // Generate consumer that manages namespaces and subscriptions with producers.
             pubsub_relation_manager_repository
-                .setup_publisher(max_subscribe_id, client.id)
+                .setup_publisher(upstream_max_subscribe_id, client.id)
                 .await?;
         }
         Some(RoleCase::Subscriber) => {
             // Generate producer that manages namespaces and subscriptions with subscribers.
-            // FIXME: max_subscribe_id for subscriber is fixed at 100 for now.
             pubsub_relation_manager_repository
-                .setup_subscriber(100, client.id)
+                .setup_subscriber(downstream_max_subscribe_id, client.id)
                 .await?;
         }
         Some(RoleCase::PubSub) => {
             // Generate producer and consumer that manages namespaces and subscriptions with publishers and subscribers.
             pubsub_relation_manager_repository
-                .setup_publisher(max_subscribe_id, client.id)
+                .setup_publisher(upstream_max_subscribe_id, client.id)
                 .await?;
-            // FIXME: max_subscribe_id for subscriber is fixed at 100 for now.
             pubsub_relation_manager_repository
-                .setup_subscriber(100, client.id)
+                .setup_subscriber(downstream_max_subscribe_id, client.id)
                 .await?;
         }
         None => {
             bail!("Role parameter is required in SETUP parameter from client.");
         }
     }
+    Ok(())
+}
+
+fn create_setup_parameters(
+    client: &MOQTClient,
+    downstream_max_subscribe_id: u64,
+) -> Vec<SetupParameter> {
+    let mut setup_parameters = vec![];
 
     // Create a setup parameter with role set to 3 and assign it.
     // Normally, the server should determine the role here, but for now, let's set it to 3.
     let role_parameter = SetupParameter::Role(Role::new(RoleCase::PubSub));
-    let server_setup_message =
-        ServerSetup::new(constants::MOQ_TRANSPORT_VERSION, vec![role_parameter]);
+    setup_parameters.push(role_parameter);
+
+    if client.role() == Some(RoleCase::Subscriber) || client.role() == Some(RoleCase::PubSub) {
+        let max_subscribe_id_parameter =
+            SetupParameter::MaxSubscribeID(MaxSubscribeID::new(downstream_max_subscribe_id));
+        setup_parameters.push(max_subscribe_id_parameter);
+    }
+    let max_subscribe_id_parameter =
+        SetupParameter::MaxSubscribeID(MaxSubscribeID::new(downstream_max_subscribe_id));
+    setup_parameters.push(max_subscribe_id_parameter);
+
+    setup_parameters
+}
+
+pub(crate) async fn setup_handler(
+    client_setup_message: ClientSetup,
+    underlay_type: UnderlayType,
+    client: &mut MOQTClient,
+    pubsub_relation_manager_repository: &mut dyn PubSubRelationManagerRepository,
+) -> Result<ServerSetup> {
+    tracing::trace!("setup_handler start.");
+
+    tracing::debug!("client_setup_message: {:#?}", client_setup_message);
+
+    tracing::debug!(
+        "supported_versions: {:#x?}",
+        client_setup_message.supported_versions
+    );
+
+    if !is_requested_version_supported(client_setup_message.supported_versions) {
+        bail!("Supported version is not included");
+    }
+
+    // If max_subscribe_id is not included in the CLIENT_SETUP message, upstream_max_subscribe_id is set to 0.
+    let upstream_max_subscribe_id: u64 =
+        handle_setup_parameter(client, client_setup_message.setup_parameters, underlay_type)?;
+
+    // FIXME: downstream_max_subscribe_id for subscriber is fixed at 100 for now.
+    let downstream_max_subscribe_id: u64 = 100;
+
+    setup_subscription_node(
+        client,
+        pubsub_relation_manager_repository,
+        upstream_max_subscribe_id,
+        downstream_max_subscribe_id,
+    )
+    .await?;
+
+    let setup_parameters = create_setup_parameters(client, downstream_max_subscribe_id);
+    let server_setup_message = ServerSetup::new(constants::MOQ_TRANSPORT_VERSION, setup_parameters);
     // State: Connected -> Setup
     client.update_status(MOQTClientStatus::SetUp);
 


### PR DESCRIPTION
- Separated each process to small functions
- Change `downstream_max_subscribe_id` value from 0 to 100
  - According the draft, if it is 0, the peer cannot create subscriptions