### PR TITLE
Fix publisher Group Order can be 0x0

### DIFF
--- a/moqt-client-sample/src/lib.rs
+++ b/moqt-client-sample/src/lib.rs
@@ -497,7 +497,14 @@ impl MOQTClient {
                 .get_publishing_subscription(subscribe_id)
                 .unwrap();
 
-            let group_order = subscription.get_group_order();
+            let requested_group_order = subscription.get_group_order();
+            let group_order = if requested_group_order == GroupOrder::Original {
+                // If requested_group_order is Original, use Ascending as its response
+                GroupOrder::Ascending
+            } else {
+                // Otherwise, return the requested_group_order as is
+                requested_group_order
+            };
 
             let version_specific_parameters = vec![auth_info];
             let subscribe_ok_message = SubscribeOk::new(


### PR DESCRIPTION
- According to the draft, publisher cannot use Group Order 0x0 as SUBSCRIBE_OK parameter.
- The client is currently just a testing tool and has no expected behavior, so it was changed to return `GroupOrder::Ascending` (0x1) when `GroupOrder::Original` (0x0) is requested.