### PR TITLE
Refactor ObjectCacheStorage to use object_id for object storage

### DIFF
--- a/moqt-server/src/modules/object_cache_storage/cache.rs
+++ b/moqt-server/src/modules/object_cache_storage/cache.rs
@@ -4,7 +4,6 @@ pub(crate) mod subgroup_stream;
 use datagram::DatagramCache;
 use subgroup_stream::SubgroupStreamsCache;
 
-pub(crate) type CacheId = usize;
 type GroupId = u64;
 pub(crate) type SubgroupId = u64;
 pub(crate) type SubgroupStreamId = (GroupId, SubgroupId);

--- a/moqt-server/src/modules/object_cache_storage/cache/datagram.rs
+++ b/moqt-server/src/modules/object_cache_storage/cache/datagram.rs
@@ -1,139 +1,240 @@
-use super::CacheId;
 use moqt_core::messages::data_streams::DatagramObject;
 use std::time::Duration;
 use ttl_cache::TtlCache;
 
 #[derive(Clone)]
 pub(crate) struct DatagramCache {
-    objects: TtlCache<CacheId, DatagramObject>,
-    next_cache_id: CacheId,
+    objects: TtlCache<(u64, u64), DatagramObject>,
 }
 
 impl DatagramCache {
     pub(crate) fn new(max_store_size: usize) -> Self {
         let objects = TtlCache::new(max_store_size);
 
-        Self {
-            objects,
-            next_cache_id: 0,
-        }
+        Self { objects }
     }
 
     pub(crate) fn insert_object(&mut self, object: DatagramObject, duration: u64) {
         let ttl = Duration::from_millis(duration);
-        self.objects.insert(self.next_cache_id, object, ttl);
-        self.next_cache_id += 1;
+        let group_id = match &object {
+            DatagramObject::ObjectDatagram(obj) => obj.group_id(),
+            DatagramObject::ObjectDatagramStatus(obj) => obj.group_id(),
+        };
+        let object_id = match &object {
+            DatagramObject::ObjectDatagram(obj) => obj.object_id(),
+            DatagramObject::ObjectDatagramStatus(obj) => obj.object_id(),
+        };
+        self.objects.insert((group_id, object_id), object, ttl);
     }
 
     pub(crate) fn get_object(
         &mut self,
         group_id: u64,
         object_id: u64,
-    ) -> Option<(CacheId, DatagramObject)> {
-        self.objects.iter().find_map(|(k, v)| {
-            let g_id = match v {
-                DatagramObject::ObjectDatagram(obj) => obj.group_id(),
-                DatagramObject::ObjectDatagramStatus(obj) => obj.group_id(),
-            };
-
-            let o_id = match v {
-                DatagramObject::ObjectDatagram(obj) => obj.object_id(),
-                DatagramObject::ObjectDatagramStatus(obj) => obj.object_id(),
-            };
-
-            if g_id == group_id && o_id == object_id {
-                Some((*k, v.clone()))
-            } else {
-                None
-            }
-        })
+    ) -> Option<DatagramObject> {
+        self.objects.get(&(group_id, object_id)).cloned()
     }
 
     pub(crate) fn get_next_object(
         &mut self,
-        cache_id: CacheId,
-    ) -> Option<(CacheId, DatagramObject)> {
-        let next_cache_id = cache_id + 1;
-        self.objects.iter().find_map(|(k, v)| {
-            if *k == next_cache_id {
-                Some((*k, v.clone()))
-            } else {
-                None
-            }
-        })
-    }
-
-    pub(crate) fn get_latest_group(&mut self) -> Option<(CacheId, DatagramObject)> {
-        let latest_group_id = self
-            .objects
-            .iter()
-            .next_back()
-            .map(|(_, v)| match v {
-                DatagramObject::ObjectDatagram(obj) => obj.group_id(),
-                DatagramObject::ObjectDatagramStatus(obj) => obj.group_id(),
-            })
-            .unwrap();
-
-        let latest_group = self.objects.iter().filter_map(|(k, v)| {
-            let g_id = match v {
-                DatagramObject::ObjectDatagram(obj) => obj.group_id(),
-                DatagramObject::ObjectDatagramStatus(obj) => obj.group_id(),
-            };
-            if g_id == latest_group_id {
-                Some((*k, v.clone()))
-            } else {
-                None
-            }
-        });
-
-        latest_group.min_by_key(|(k, v)| {
-            let o_id = match v {
-                DatagramObject::ObjectDatagram(obj) => obj.object_id(),
-                DatagramObject::ObjectDatagramStatus(obj) => obj.object_id(),
-            };
-            (o_id, *k)
-        })
-    }
-
-    pub(crate) fn get_latest_object(&mut self) -> Option<(CacheId, DatagramObject)> {
+        group_id: u64,
+        current_object_id: u64,
+    ) -> Option<DatagramObject> {
         self.objects
             .iter()
-            .next_back()
-            .map(|(k, v)| (*k, v.clone()))
+            .filter_map(|((g_id, o_id), obj)| {
+                if *g_id == group_id && *o_id > current_object_id {
+                    Some((*o_id, obj.clone()))
+                } else {
+                    None
+                }
+            })
+            .min_by_key(|(o_id, _)| *o_id)
+            .map(|(_, obj)| obj)
+    }
+
+    pub(crate) fn get_latest_group(&mut self) -> Option<DatagramObject> {
+        let latest_group_id = self.objects.iter().map(|((g_id, _), _)| g_id).max();
+
+        match latest_group_id {
+            Some(lg_id) => self
+                .objects
+                .iter()
+                .filter_map(|((g_id, o_id), obj)| {
+                    if g_id == lg_id {
+                        Some((*o_id, obj.clone()))
+                    } else {
+                        None
+                    }
+                })
+                .min_by_key(|(o_id, _)| *o_id)
+                .map(|(_, obj)| obj),
+            None => None,
+        }
+    }
+
+    pub(crate) fn get_latest_object(&mut self) -> Option<DatagramObject> {
+        self.objects
+            .iter()
+            .max_by_key(|((g_id, o_id), _)| (*g_id, *o_id))
+            .map(|(_, v)| v.clone())
     }
 
     pub(crate) fn get_largest_group_id(&mut self) -> Option<u64> {
-        self.objects
-            .iter()
-            .map(|(_, v)| match v {
-                DatagramObject::ObjectDatagram(obj) => obj.group_id(),
-                DatagramObject::ObjectDatagramStatus(obj) => obj.group_id(),
-            })
-            .max()
+        self.objects.iter().map(|((g_id, _), _)| *g_id).max()
     }
 
     pub(crate) fn get_largest_object_id(&mut self) -> Option<u64> {
-        let largest_group_id = self.get_largest_group_id()?;
+        let largest_group_id = match self.get_largest_group_id() {
+            Some(id) => id,
+            None => return None,
+        };
 
         self.objects
             .iter()
-            .filter_map(|(_, v)| {
-                let g_id = match v {
-                    DatagramObject::ObjectDatagram(obj) => obj.group_id(),
-                    DatagramObject::ObjectDatagramStatus(obj) => obj.group_id(),
-                };
-
-                let o_id = match v {
-                    DatagramObject::ObjectDatagram(obj) => obj.object_id(),
-                    DatagramObject::ObjectDatagramStatus(obj) => obj.object_id(),
-                };
-
-                if g_id == largest_group_id {
-                    Some(o_id)
+            .filter_map(|((g_id, o_id), _)| {
+                if *g_id == largest_group_id {
+                    Some(*o_id)
                 } else {
                     None
                 }
             })
             .max()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moqt_core::messages::data_streams::datagram;
+
+    fn create_test_datagram_object(group_id: u64, object_id: u64, payload_byte: u8) -> DatagramObject {
+        DatagramObject::ObjectDatagram(
+            datagram::Object::new(
+                0, // track_alias
+                group_id,
+                object_id,
+                0, // publisher_priority
+                vec![], // extension_headers
+                vec![payload_byte], // object_payload
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_insert_and_get_object() {
+        let mut cache = DatagramCache::new(10);
+        let obj1_g1 = create_test_datagram_object(1, 1, 101);
+        let obj2_g1 = create_test_datagram_object(1, 2, 102);
+        let obj1_g2 = create_test_datagram_object(2, 1, 201);
+
+        cache.insert_object(obj1_g1.clone(), 1000);
+        cache.insert_object(obj2_g1.clone(), 1000);
+        cache.insert_object(obj1_g2.clone(), 1000);
+
+        // Test getting existing objects
+        assert_eq!(cache.get_object(1, 1), Some(obj1_g1.clone()));
+        assert_eq!(cache.get_object(1, 2), Some(obj2_g1.clone()));
+        assert_eq!(cache.get_object(2, 1), Some(obj1_g2.clone()));
+
+        // Test getting non-existent objects
+        assert_eq!(cache.get_object(1, 3), None); // Non-existent object_id in group 1
+        assert_eq!(cache.get_object(3, 1), None); // Non-existent group_id
+        assert_eq!(cache.get_object(2, 2), None); // Non-existent object_id in group 2
+    }
+
+    #[test]
+    fn test_get_next_object() {
+        let mut cache = DatagramCache::new(10);
+        let obj1_g1 = create_test_datagram_object(1, 1, 101);
+        let obj2_g1 = create_test_datagram_object(1, 3, 103); // Note: object_id 3, not 2
+        let obj3_g1 = create_test_datagram_object(1, 5, 105);
+        let obj1_g2 = create_test_datagram_object(2, 1, 201);
+
+        cache.insert_object(obj1_g1.clone(), 1000);
+        cache.insert_object(obj2_g1.clone(), 1000);
+        cache.insert_object(obj3_g1.clone(), 1000);
+        cache.insert_object(obj1_g2.clone(), 1000);
+
+        // Next object in the same group
+        assert_eq!(cache.get_next_object(1, 1), Some(obj2_g1.clone()));
+        assert_eq!(cache.get_next_object(1, 3), Some(obj3_g1.clone()));
+
+        // No next object in the same group (current is last)
+        assert_eq!(cache.get_next_object(1, 5), None);
+
+        // No next object if current_object_id doesn't exist but is within range
+        assert_eq!(cache.get_next_object(1, 2), Some(obj2_g1.clone())); 
+        assert_eq!(cache.get_next_object(1, 4), Some(obj3_g1.clone()));
+
+
+        // No objects in the group or group doesn't exist
+        assert_eq!(cache.get_next_object(3, 1), None);
+
+        // Next object when other groups exist
+        assert_eq!(cache.get_next_object(2, 0), Some(obj1_g2.clone()));
+        assert_eq!(cache.get_next_object(2, 1), None);
+    }
+
+    #[test]
+    fn test_get_latest_group() {
+        let mut cache = DatagramCache::new(10);
+        
+        // Empty cache
+        assert_eq!(cache.get_latest_group(), None);
+
+        let obj1_g1 = create_test_datagram_object(1, 1, 101);
+        let obj2_g1 = create_test_datagram_object(1, 5, 105); // larger object_id
+        cache.insert_object(obj1_g1.clone(), 1000);
+        cache.insert_object(obj2_g1.clone(), 1000);
+        // Expected: obj1_g1 (smallest object_id in group 1)
+        assert_eq!(cache.get_latest_group(), Some(obj1_g1.clone()));
+
+
+        let obj1_g2 = create_test_datagram_object(2, 2, 202);
+        let obj2_g2 = create_test_datagram_object(2, 3, 203);
+        cache.insert_object(obj1_g2.clone(), 1000);
+        cache.insert_object(obj2_g2.clone(), 1000);
+        // Expected: obj1_g2 (smallest object_id in group 2, which is the latest group)
+        assert_eq!(cache.get_latest_group(), Some(obj1_g2.clone()));
+
+        let obj1_g0 = create_test_datagram_object(0, 10, 10); // Earlier group
+        cache.insert_object(obj1_g0.clone(), 1000);
+        assert_eq!(cache.get_latest_group(), Some(obj1_g2.clone())); // Still obj1_g2 from group 2
+
+        // Add to a new, even later group
+        let obj1_g3 = create_test_datagram_object(3, 1, 301);
+        cache.insert_object(obj1_g3.clone(), 1000);
+        assert_eq!(cache.get_latest_group(), Some(obj1_g3.clone()));
+    }
+
+    #[test]
+    fn test_get_latest_object() {
+        let mut cache = DatagramCache::new(10);
+
+        // Empty cache
+        assert_eq!(cache.get_latest_object(), None);
+
+        let obj1_g1 = create_test_datagram_object(1, 1, 101);
+        cache.insert_object(obj1_g1.clone(), 1000);
+        assert_eq!(cache.get_latest_object(), Some(obj1_g1.clone()));
+
+        let obj2_g1 = create_test_datagram_object(1, 5, 105); // Same group, larger object_id
+        cache.insert_object(obj2_g1.clone(), 1000);
+        assert_eq!(cache.get_latest_object(), Some(obj2_g1.clone()));
+
+        let obj1_g2 = create_test_datagram_object(2, 2, 202); // New group, smaller object_id but larger group_id
+        cache.insert_object(obj1_g2.clone(), 1000);
+        assert_eq!(cache.get_latest_object(), Some(obj1_g2.clone()));
+        
+        let obj2_g2 = create_test_datagram_object(2, 6, 206); // Same new group, larger object_id
+        cache.insert_object(obj2_g2.clone(), 1000);
+        assert_eq!(cache.get_latest_object(), Some(obj2_g2.clone()));
+
+        // Object in an earlier group, but with a very large object_id
+        let obj3_g1 = create_test_datagram_object(1, 100, 199);
+        cache.insert_object(obj3_g1.clone(), 1000);
+        assert_eq!(cache.get_latest_object(), Some(obj2_g2.clone())); // Still obj2_g2 because group_id 2 > 1
     }
 }

--- a/moqt-server/src/modules/object_cache_storage/cache/subgroup_stream.rs
+++ b/moqt-server/src/modules/object_cache_storage/cache/subgroup_stream.rs
@@ -1,4 +1,4 @@
-use super::{CacheId, SubgroupId, SubgroupStreamId};
+use super::{SubgroupId, SubgroupStreamId};
 use moqt_core::messages::data_streams::subgroup_stream;
 use std::{collections::HashMap, time::Duration};
 use ttl_cache::TtlCache;
@@ -53,7 +53,7 @@ impl SubgroupStreamsCache {
         group_id: u64,
         subgroup_id: u64,
         object_id: u64,
-    ) -> Option<(CacheId, subgroup_stream::Object)> {
+    ) -> Option<subgroup_stream::Object> {
         let subgroup_stream_id = (group_id, subgroup_id);
         let subgroup_stream_cache = self.streams.get_mut(&subgroup_stream_id).unwrap();
         subgroup_stream_cache.get_absolute_or_next_object(object_id)
@@ -63,18 +63,18 @@ impl SubgroupStreamsCache {
         &mut self,
         group_id: u64,
         subgroup_id: u64,
-        cache_id: CacheId,
-    ) -> Option<(CacheId, subgroup_stream::Object)> {
+        current_object_id: u64,
+    ) -> Option<subgroup_stream::Object> {
         let subgroup_stream_id = (group_id, subgroup_id);
         let subgroup_stream_cache = self.streams.get_mut(&subgroup_stream_id).unwrap();
-        subgroup_stream_cache.get_next_object(cache_id)
+        subgroup_stream_cache.get_next_object(current_object_id)
     }
 
     pub(crate) fn get_first_object(
         &mut self,
         group_id: u64,
         subgroup_id: u64,
-    ) -> Option<(CacheId, subgroup_stream::Object)> {
+    ) -> Option<subgroup_stream::Object> {
         let subgroup_stream_id = (group_id, subgroup_id);
         let subgroup_stream_cache = self.streams.get_mut(&subgroup_stream_id).unwrap();
         subgroup_stream_cache.get_first_object()
@@ -84,7 +84,7 @@ impl SubgroupStreamsCache {
         &mut self,
         group_id: u64,
         subgroup_id: u64,
-    ) -> Option<(CacheId, subgroup_stream::Object)> {
+    ) -> Option<subgroup_stream::Object> {
         let subgroup_stream_id = (group_id, subgroup_id);
         let subgroup_stream_cache = self.streams.get_mut(&subgroup_stream_id).unwrap();
         subgroup_stream_cache.get_latest_object()
@@ -99,20 +99,20 @@ impl SubgroupStreamsCache {
 
         let subgroup_ids = self.get_all_subgroup_ids(largest_group_id);
 
-        let mut largest_object_id = None;
+        let mut largest_object_id: Option<u64> = None;
         for subgroup_id in subgroup_ids.iter().rev() {
             let subgroup_stream_id = (largest_group_id, *subgroup_id);
-            let object_id = self
+            if let Some(object_id) = self
                 .streams
                 .get_mut(&subgroup_stream_id)
                 .unwrap()
-                .get_largest_object_id();
-
-            if largest_object_id.is_none() || object_id > largest_object_id.unwrap() {
-                largest_object_id = Some(object_id);
+                .get_largest_object_id()
+            {
+                if largest_object_id.is_none() || object_id > largest_object_id.unwrap() {
+                    largest_object_id = Some(object_id);
+                }
             }
         }
-
         largest_object_id
     }
 
@@ -135,25 +135,19 @@ impl SubgroupStreamsCache {
 #[derive(Clone)]
 struct SubgroupStreamCache {
     header: subgroup_stream::Header,
-    objects: TtlCache<CacheId, subgroup_stream::Object>,
-    next_cache_id: CacheId,
+    objects: TtlCache<u64, subgroup_stream::Object>,
 }
 
 impl SubgroupStreamCache {
     fn new(header: subgroup_stream::Header, max_cache_size: usize) -> Self {
         let objects = TtlCache::new(max_cache_size);
 
-        Self {
-            header,
-            objects,
-            next_cache_id: 0,
-        }
+        Self { header, objects }
     }
 
     fn insert_object(&mut self, object: subgroup_stream::Object, duration: u64) {
         let ttl = Duration::from_millis(duration);
-        self.objects.insert(self.next_cache_id, object, ttl);
-        self.next_cache_id += 1;
+        self.objects.insert(object.object_id(), object, ttl);
     }
 
     fn get_header(&self) -> subgroup_stream::Header {
@@ -163,43 +157,202 @@ impl SubgroupStreamCache {
     fn get_absolute_or_next_object(
         &mut self,
         object_id: u64,
-    ) -> Option<(CacheId, subgroup_stream::Object)> {
-        self.objects.iter().find_map(|(k, v)| {
-            if v.object_id() >= object_id {
-                Some((*k, v.clone()))
-            } else {
-                None
-            }
-        })
-    }
-
-    fn get_next_object(&mut self, cache_id: CacheId) -> Option<(CacheId, subgroup_stream::Object)> {
-        let next_cache_id = cache_id + 1;
-        self.objects.iter().find_map(|(k, v)| {
-            if *k == next_cache_id {
-                Some((*k, v.clone()))
-            } else {
-                None
-            }
-        })
-    }
-
-    fn get_first_object(&mut self) -> Option<(CacheId, subgroup_stream::Object)> {
-        self.objects.iter().next().map(|(k, v)| (*k, v.clone()))
-    }
-
-    fn get_latest_object(&mut self) -> Option<(CacheId, subgroup_stream::Object)> {
+    ) -> Option<subgroup_stream::Object> {
+        if let Some(obj) = self.objects.get(&object_id) {
+            return Some(obj.clone());
+        }
         self.objects
             .iter()
-            .next_back()
-            .map(|(k, v)| (*k, v.clone()))
+            .filter_map(|(o_id, obj)| {
+                if *o_id > object_id {
+                    Some((*o_id, obj.clone()))
+                } else {
+                    None
+                }
+            })
+            .min_by_key(|(o_id, _)| *o_id)
+            .map(|(_, obj)| obj)
     }
 
-    fn get_largest_object_id(&mut self) -> u64 {
+    fn get_next_object(&mut self, current_object_id: u64) -> Option<subgroup_stream::Object> {
         self.objects
             .iter()
-            .map(|(_, v)| v.object_id())
-            .max()
-            .unwrap()
+            .filter_map(|(o_id, obj)| {
+                if *o_id > current_object_id {
+                    Some((*o_id, obj.clone()))
+                } else {
+                    None
+                }
+            })
+            .min_by_key(|(o_id, _)| *o_id)
+            .map(|(_, obj)| obj)
+    }
+
+    fn get_first_object(&mut self) -> Option<subgroup_stream::Object> {
+        self.objects
+            .iter()
+            .min_by_key(|(o_id, _)| *o_id)
+            .map(|(_, obj)| obj.clone())
+    }
+
+    fn get_latest_object(&mut self) -> Option<subgroup_stream::Object> {
+        self.objects
+            .iter()
+            .max_by_key(|(o_id, _)| *o_id)
+            .map(|(_, obj)| obj.clone())
+    }
+
+    fn get_largest_object_id(&mut self) -> Option<u64> {
+        self.objects.keys().max().cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moqt_core::messages::data_streams::subgroup_stream::{Header, Object};
+
+    fn create_test_header(group_id: u64, subgroup_id: u64) -> Header {
+        Header::new(0, group_id, subgroup_id, 0).unwrap()
+    }
+
+    fn create_test_subgroup_object(object_id: u64, payload_byte: u8) -> Object {
+        Object::new(object_id, vec![], None, vec![payload_byte]).unwrap()
+    }
+
+    #[test]
+    fn test_subgroup_cache_insert_and_get_header() {
+        let header = create_test_header(1, 1);
+        let cache = SubgroupStreamCache::new(header.clone(), 10);
+        assert_eq!(cache.get_header(), header);
+    }
+
+    #[test]
+    fn test_subgroup_cache_insert_and_get_simple() {
+        let header = create_test_header(1, 1);
+        let mut cache = SubgroupStreamCache::new(header.clone(), 10);
+        
+        let obj1 = create_test_subgroup_object(1, 101);
+        cache.insert_object(obj1.clone(), 1000);
+
+        // TtlCache get is not directly exposed, we test via other methods
+        assert_eq!(cache.get_absolute_or_next_object(1), Some(obj1.clone()));
+        assert_eq!(cache.get_latest_object(), Some(obj1.clone()));
+    }
+
+    #[test]
+    fn test_subgroup_cache_get_absolute_or_next_object() {
+        let header = create_test_header(1, 1);
+        let mut cache = SubgroupStreamCache::new(header.clone(), 10);
+
+        let obj1 = create_test_subgroup_object(1, 101);
+        let obj3 = create_test_subgroup_object(3, 103);
+        let obj5 = create_test_subgroup_object(5, 105);
+
+        cache.insert_object(obj1.clone(), 1000);
+        cache.insert_object(obj3.clone(), 1000);
+        cache.insert_object(obj5.clone(), 1000);
+
+        // Absolute match
+        assert_eq!(cache.get_absolute_or_next_object(1), Some(obj1.clone()));
+        assert_eq!(cache.get_absolute_or_next_object(3), Some(obj3.clone()));
+        assert_eq!(cache.get_absolute_or_next_object(5), Some(obj5.clone()));
+
+        // Next object when absolute match fails
+        assert_eq!(cache.get_absolute_or_next_object(0), Some(obj1.clone())); // Next is obj1
+        assert_eq!(cache.get_absolute_or_next_object(2), Some(obj3.clone())); // Next is obj3
+        assert_eq!(cache.get_absolute_or_next_object(4), Some(obj5.clone())); // Next is obj5
+        
+        // No object if requested object_id is greater than all existing
+        assert_eq!(cache.get_absolute_or_next_object(6), None);
+        
+        // Empty cache
+        let mut empty_cache = SubgroupStreamCache::new(header.clone(), 10);
+        assert_eq!(empty_cache.get_absolute_or_next_object(1), None);
+    }
+    
+    #[test]
+    fn test_subgroup_cache_get_next_object() {
+        let header = create_test_header(1, 1);
+        let mut cache = SubgroupStreamCache::new(header.clone(), 10);
+
+        let obj1 = create_test_subgroup_object(1, 101);
+        let obj3 = create_test_subgroup_object(3, 103);
+        let obj5 = create_test_subgroup_object(5, 105);
+
+        cache.insert_object(obj1.clone(), 1000);
+        cache.insert_object(obj3.clone(), 1000);
+        cache.insert_object(obj5.clone(), 1000);
+
+        assert_eq!(cache.get_next_object(0), Some(obj1.clone()));
+        assert_eq!(cache.get_next_object(1), Some(obj3.clone()));
+        assert_eq!(cache.get_next_object(2), Some(obj3.clone())); // Next after 2 is 3
+        assert_eq!(cache.get_next_object(3), Some(obj5.clone()));
+        assert_eq!(cache.get_next_object(4), Some(obj5.clone())); // Next after 4 is 5
+        assert_eq!(cache.get_next_object(5), None); // No object after 5
+
+        // Empty cache
+        let mut empty_cache = SubgroupStreamCache::new(header.clone(), 10);
+        assert_eq!(empty_cache.get_next_object(1), None);
+    }
+
+    #[test]
+    fn test_subgroup_cache_get_first_object() {
+        let header = create_test_header(1, 1);
+        let mut cache = SubgroupStreamCache::new(header.clone(), 10);
+
+        assert_eq!(cache.get_first_object(), None); // Empty cache
+
+        let obj3 = create_test_subgroup_object(3, 103);
+        let obj1 = create_test_subgroup_object(1, 101); // Inserted out of order
+        let obj5 = create_test_subgroup_object(5, 105);
+
+        cache.insert_object(obj3.clone(), 1000);
+        cache.insert_object(obj1.clone(), 1000);
+        cache.insert_object(obj5.clone(), 1000);
+        
+        assert_eq!(cache.get_first_object(), Some(obj1.clone()));
+    }
+
+    #[test]
+    fn test_subgroup_cache_get_latest_object() {
+        let header = create_test_header(1, 1);
+        let mut cache = SubgroupStreamCache::new(header.clone(), 10);
+
+        assert_eq!(cache.get_latest_object(), None); // Empty cache
+
+        let obj3 = create_test_subgroup_object(3, 103);
+        let obj1 = create_test_subgroup_object(1, 101);
+        let obj5 = create_test_subgroup_object(5, 105); // Inserted out of order
+
+        cache.insert_object(obj3.clone(), 1000);
+        assert_eq!(cache.get_latest_object(), Some(obj3.clone()));
+
+        cache.insert_object(obj1.clone(), 1000);
+        assert_eq!(cache.get_latest_object(), Some(obj3.clone())); // Still 3, as 1 < 3
+
+        cache.insert_object(obj5.clone(), 1000);
+        assert_eq!(cache.get_latest_object(), Some(obj5.clone())); // Now 5 is the latest
+    }
+
+    #[test]
+    fn test_subgroup_cache_get_largest_object_id() {
+        let header = create_test_header(1, 1);
+        let mut cache = SubgroupStreamCache::new(header.clone(), 10);
+
+        assert_eq!(cache.get_largest_object_id(), None); // Empty cache
+
+        let obj3 = create_test_subgroup_object(3, 103);
+        let obj1 = create_test_subgroup_object(1, 101);
+        let obj5 = create_test_subgroup_object(5, 105);
+
+        cache.insert_object(obj3.clone(), 1000);
+        assert_eq!(cache.get_largest_object_id(), Some(3));
+
+        cache.insert_object(obj1.clone(), 1000);
+        assert_eq!(cache.get_largest_object_id(), Some(3));
+
+        cache.insert_object(obj5.clone(), 1000);
+        assert_eq!(cache.get_largest_object_id(), Some(5));
     }
 }

--- a/moqt-server/src/modules/object_cache_storage/commands.rs
+++ b/moqt-server/src/modules/object_cache_storage/commands.rs
@@ -1,4 +1,4 @@
-use super::cache::{CacheId, CacheKey, SubgroupId};
+use super::cache::{CacheKey, SubgroupId};
 use anyhow::Result;
 use moqt_core::messages::data_streams::{DatagramObject, subgroup_stream};
 use tokio::sync::oneshot;
@@ -44,34 +44,35 @@ pub(crate) enum ObjectCacheStorageCommand {
         cache_key: CacheKey,
         group_id: u64,
         object_id: u64,
-        resp: oneshot::Sender<Result<Option<(CacheId, DatagramObject)>>>,
+        resp: oneshot::Sender<Result<Option<DatagramObject>>>,
     },
     GetAbsoluteOrNextSubgroupStreamObject {
         cache_key: CacheKey,
         group_id: u64,
         subgroup_id: u64,
         object_id: u64,
-        resp: oneshot::Sender<Result<Option<(CacheId, subgroup_stream::Object)>>>,
+        resp: oneshot::Sender<Result<Option<subgroup_stream::Object>>>,
     },
     GetNextDatagramObject {
         cache_key: CacheKey,
-        cache_id: CacheId,
-        resp: oneshot::Sender<Result<Option<(CacheId, DatagramObject)>>>,
+        group_id: u64,
+        current_object_id: u64,
+        resp: oneshot::Sender<Result<Option<DatagramObject>>>,
     },
     GetNextSubgroupStreamObject {
         cache_key: CacheKey,
         group_id: u64,
         subgroup_id: u64,
-        cache_id: CacheId,
-        resp: oneshot::Sender<Result<Option<(CacheId, subgroup_stream::Object)>>>,
+        current_object_id: u64,
+        resp: oneshot::Sender<Result<Option<subgroup_stream::Object>>>,
     },
     GetLatestDatagramObject {
         cache_key: CacheKey,
-        resp: oneshot::Sender<Result<Option<(CacheId, DatagramObject)>>>,
+        resp: oneshot::Sender<Result<Option<DatagramObject>>>,
     },
     GetLatestDatagramGroup {
         cache_key: CacheKey,
-        resp: oneshot::Sender<Result<Option<(CacheId, DatagramObject)>>>,
+        resp: oneshot::Sender<Result<Option<DatagramObject>>>,
     },
     // Since current Forwarder is generated for each Group,
     // LatestGroup is never used for SubgroupCache.
@@ -80,7 +81,7 @@ pub(crate) enum ObjectCacheStorageCommand {
         cache_key: CacheKey,
         group_id: u64,
         subgroup_id: u64,
-        resp: oneshot::Sender<Result<Option<(CacheId, subgroup_stream::Object)>>>,
+        resp: oneshot::Sender<Result<Option<subgroup_stream::Object>>>,
     },
     // TODO: Remove LatestGroup since it is not exist in the draft-10
     #[allow(dead_code)]
@@ -88,7 +89,7 @@ pub(crate) enum ObjectCacheStorageCommand {
         cache_key: CacheKey,
         group_id: u64,
         subgroup_id: u64,
-        resp: oneshot::Sender<Result<Option<(CacheId, subgroup_stream::Object)>>>,
+        resp: oneshot::Sender<Result<Option<subgroup_stream::Object>>>,
     },
     GetAllSubgroupIds {
         cache_key: CacheKey,

--- a/moqt-server/src/modules/object_cache_storage/storage.rs
+++ b/moqt-server/src/modules/object_cache_storage/storage.rs
@@ -172,7 +172,8 @@ pub(crate) async fn object_cache_storage(rx: &mut mpsc::Receiver<ObjectCacheStor
             }
             ObjectCacheStorageCommand::GetNextDatagramObject {
                 cache_key,
-                cache_id,
+                group_id,
+                current_object_id,
                 resp,
             } => {
                 let cache = storage.get_mut(&cache_key);
@@ -185,14 +186,14 @@ pub(crate) async fn object_cache_storage(rx: &mut mpsc::Receiver<ObjectCacheStor
                     }
                 };
 
-                let object_with_cache_id = datagram_cache.get_next_object(cache_id);
-                resp.send(Ok(object_with_cache_id)).unwrap();
+                let object_option = datagram_cache.get_next_object(group_id, current_object_id);
+                resp.send(Ok(object_option)).unwrap();
             }
             ObjectCacheStorageCommand::GetNextSubgroupStreamObject {
                 cache_key,
                 group_id,
                 subgroup_id,
-                cache_id,
+                current_object_id,
                 resp,
             } => {
                 let cache = storage.get_mut(&cache_key);
@@ -205,9 +206,12 @@ pub(crate) async fn object_cache_storage(rx: &mut mpsc::Receiver<ObjectCacheStor
                     }
                 };
 
-                let object_with_cache_id =
-                    subgroup_streams_cache.get_next_object(group_id, subgroup_id, cache_id);
-                resp.send(Ok(object_with_cache_id)).unwrap();
+                let object_option = subgroup_streams_cache.get_next_object(
+                    group_id,
+                    subgroup_id,
+                    current_object_id,
+                );
+                resp.send(Ok(object_option)).unwrap();
             }
             ObjectCacheStorageCommand::GetLatestDatagramGroup { cache_key, resp } => {
                 let cache = storage.get_mut(&cache_key);


### PR DESCRIPTION
This change modifies the ObjectCacheStorage to use `object_id` (and `group_id` where applicable) as the primary key for storing and retrieving objects in `DatagramCache` and `SubgroupStreamCache`, instead of an internally generated `CacheId`.

Key changes:
- Modified `DatagramCache` to use `(group_id, object_id)` as the key for its `TtlCache`.
- Modified `SubgroupStreamCache` to use `object_id` as the key for its `TtlCache`.
- Removed the auto-incrementing `CacheId` mechanism from both cache types.
- Updated `get_next_object` methods in both caches to find the next object based on `object_id` sequence rather than `CacheId`.
- Adjusted `ObjectCacheStorageCommand` variants and the main `object_cache_storage` logic to reflect these changes in parameters and return types.
- Updated `ObjectCacheStorageWrapper` and its call sites (primarily in datagram and subgroup stream forwarders) to align with the new API.
- Added new unit tests for `DatagramCache` and `SubgroupStreamCache` to cover the new keying and retrieval logic, including tests for non-sequential `object_id`s.