### PR TITLE
Add WebTransport support and fix Extension Headers for draft-14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "ttl_cache",
+ "wtransport",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,12 +164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,16 +356,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cfg-expr"
-version = "0.20.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a"
-dependencies = [
- "smallvec",
- "target-lexicon",
-]
 
 [[package]]
 name = "cfg-if"
@@ -714,12 +698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,218 +839,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "gio-sys"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "glib"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
-dependencies = [
- "bitflags 2.9.1",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-task",
- "futures-util",
- "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
- "libc",
- "memchr",
- "smallvec",
-]
-
-[[package]]
-name = "glib-macros"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
-dependencies = [
- "heck",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "glib-sys"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c"
-dependencies = [
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gobject-sys"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294"
-dependencies = [
- "glib-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gstreamer"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8251db223ca38d9aefaf3d19f6f11581a9123cd12dacebd8b9e182da965023"
-dependencies = [
- "cfg-if",
- "futures-channel",
- "futures-core",
- "futures-util",
- "glib",
- "gstreamer-sys",
- "itertools",
- "kstring",
- "libc",
- "muldiv",
- "num-integer",
- "num-rational",
- "option-operations",
- "pastey",
- "pin-project-lite",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gstreamer-app"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da7017b2a2fa5cdf9123b1603947ea24174f6d8cea0ea673411df824c811921"
-dependencies = [
- "futures-core",
- "futures-sink",
- "glib",
- "gstreamer",
- "gstreamer-app-sys",
- "gstreamer-base",
- "libc",
-]
-
-[[package]]
-name = "gstreamer-app-sys"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa9f1b12b546aea543c15a0fdbc5a53617902a74f6d357a32b6a9fb4bc4725c"
-dependencies = [
- "glib-sys",
- "gstreamer-base-sys",
- "gstreamer-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gstreamer-base"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9375f9a12120a8ee17b765c816c9b23861ce258def77b0ee40a05acb00c74972"
-dependencies = [
- "atomic_refcell",
- "cfg-if",
- "glib",
- "gstreamer",
- "gstreamer-base-sys",
- "libc",
-]
-
-[[package]]
-name = "gstreamer-base-sys"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b844f3559b6ab0379b4b771261643783ae4e0ffa71d5f5f46e33b7acf66b752"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "gstreamer-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gstreamer-sys"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d37c1a599ae57b8186948bd5699f2dbfc044baea9d400228b489a85bcf2759"
-dependencies = [
- "cfg-if",
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gstreamer-uni-receiver"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "gstreamer",
- "gstreamer-app",
- "moqt",
- "rcgen 0.14.7",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "gstreamer-uni-sender"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "gstreamer",
- "gstreamer-app",
- "moqt",
- "rcgen 0.14.7",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "url",
-]
 
 [[package]]
 name = "h2"
@@ -1110,9 +880,6 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hdrhistogram"
@@ -1332,12 +1099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,7 +1137,6 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
- "serde",
 ]
 
 [[package]]
@@ -1433,25 +1193,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1672,12 +1417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "muldiv"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
-
-[[package]]
 name = "nix"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,16 +1471,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-integer",
  "num-traits",
 ]
 
@@ -1812,15 +1541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "option-operations"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca39cf52b03268400c16eeb9b56382ea3c3353409309b63f5c8f0b1faf42754"
-dependencies = [
- "pastey",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,12 +1568,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pem"
@@ -1904,12 +1618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,16 +1665,6 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -2279,7 +1977,6 @@ dependencies = [
  "tracing-appender",
  "tracing-panic",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
@@ -2469,12 +2166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,15 +2216,6 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -2619,12 +2301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,25 +2339,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "system-deps"
-version = "7.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
-dependencies = [
- "cfg-expr",
- "heck",
- "pkg-config",
- "toml",
- "version-compare",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "termtree"
@@ -2849,34 +2506,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
-dependencies = [
- "indexmap 2.9.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "toml_edit"
@@ -2885,24 +2518,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.9.0",
- "toml_datetime 0.6.9",
+ "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
-dependencies = [
- "winnow",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -3137,12 +2755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,27 +2785,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
-dependencies = [
- "getrandom 0.4.1",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version-compare"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -3233,24 +2828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
 ]
 
 [[package]]
@@ -3322,40 +2899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.9.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.9.1",
- "hashbrown 0.15.3",
- "indexmap 2.9.0",
- "semver",
 ]
 
 [[package]]
@@ -3684,100 +3227,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.1",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.9.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.9.1",
- "indexmap 2.9.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.9.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use anyhow::bail;
-use moqt::{DatagramField, Endpoint, TransportProtocol, Session, SubscribeOption};
+use moqt::{DatagramField, Endpoint, Session, SubscribeOption, TransportProtocol};
 
 use crate::stream_runner::StreamTaskRunner;
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use anyhow::bail;
-use moqt::{DatagramField, Endpoint, QUIC, Session, SubscribeOption};
+use moqt::{DatagramField, Endpoint, TransportProtocol, Session, SubscribeOption};
 
 use crate::stream_runner::StreamTaskRunner;
 
@@ -18,20 +18,18 @@ use crate::stream_runner::StreamTaskRunner;
 // We can remove the dead code when we have implemented the test cases that use these functionalities.
 
 #[allow(dead_code)]
-pub struct Client {
-    // pub(crate) -> pub
+pub struct Client<T: TransportProtocol> {
     label: String,
     join_handle: tokio::task::JoinHandle<()>,
     track_alias: Arc<AtomicU64>,
-    publisher: Arc<moqt::Publisher<moqt::QUIC>>,
-    subscriber: Arc<moqt::Subscriber<moqt::QUIC>>,
+    publisher: Arc<moqt::Publisher<T>>,
+    subscriber: Arc<moqt::Subscriber<T>>,
     runner: StreamTaskRunner,
 }
 
-impl Client {
+impl<T: TransportProtocol> Client<T> {
     pub async fn new(cert_path: String, label: String) -> anyhow::Result<Self> {
-        // pub(crate) -> pub
-        let endpoint = Endpoint::<QUIC>::create_client_with_custom_cert(0, &cert_path)?;
+        let endpoint = Endpoint::<T>::create_client_with_custom_cert(0, &cert_path)?;
         let url = url::Url::from_str("moqt://localhost:4434")?; // ここも変更
         let host = url.host_str().unwrap();
         let remote_address = (host, url.port().unwrap_or(4433))
@@ -71,8 +69,8 @@ impl Client {
     pub fn create_receiver(
         // pub(crate) -> pub
         label: String,
-        publisher: Arc<moqt::Publisher<moqt::QUIC>>,
-        session: Session<moqt::QUIC>,
+        publisher: Arc<moqt::Publisher<T>>,
+        session: Session<T>,
         track_alias: Arc<AtomicU64>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::task::Builder::new()
@@ -225,7 +223,7 @@ impl Client {
 
     async fn create_stream(
         label: String,
-        publisher: &moqt::Publisher<moqt::QUIC>,
+        publisher: &moqt::Publisher<T>,
         publication: moqt::PublishedResource,
         runner: &StreamTaskRunner,
     ) {
@@ -275,7 +273,7 @@ impl Client {
     #[allow(dead_code)]
     async fn create_datagram(
         label: String,
-        publisher: &moqt::Publisher<moqt::QUIC>,
+        publisher: &moqt::Publisher<T>,
         publication: moqt::PublishedResource,
         runner: &StreamTaskRunner,
     ) {
@@ -370,7 +368,7 @@ impl Client {
     }
 }
 
-impl Drop for Client {
+impl<T: TransportProtocol> Drop for Client<T> {
     fn drop(&mut self) {
         tracing::info!("Client dropped.");
         self.join_handle.abort();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -12,7 +12,7 @@ fn create_client_thread(
     mut signal_receiver: tokio::sync::broadcast::Receiver<()>,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     tokio::task::spawn(async move {
-        let client = Client::new(cert_path, "user1".to_string()).await?;
+        let client = Client::<moqt::QUIC>::new(cert_path, "user1".to_string()).await?;
         let _ = client.publish_namespace("room1/user1".to_string()).await;
         let _ = client.subscribe_namespace("room".to_string()).await;
         // client
@@ -31,7 +31,7 @@ fn create_client_thread2(
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     tokio::task::spawn(async move {
         sleep(Duration::from_secs(5)).await;
-        let client = Client::new(cert_path, "user2".to_string()).await?;
+        let client = Client::<moqt::QUIC>::new(cert_path, "user2".to_string()).await?;
         let _ = client.publish_namespace("room2/user2".to_string()).await;
         let _ = client.subscribe_namespace("room1".to_string()).await;
         client

--- a/integration-test/src/client.rs
+++ b/integration-test/src/client.rs
@@ -8,22 +8,22 @@ use std::{
 };
 
 use anyhow::bail;
-use moqt::{DatagramField, Endpoint, QUIC, Session, SubscribeOption};
+use moqt::{DatagramField, Endpoint, TransportProtocol, Session, SubscribeOption};
 use crate::stream_runner::StreamTaskRunner;
 use tokio::sync::mpsc::UnboundedSender;
 
-pub struct Client {
+pub struct Client<T: TransportProtocol> {
     label: String,
     join_handle: tokio::task::JoinHandle<()>,
     track_alias: Arc<AtomicU64>,
-    publisher: moqt::Publisher<moqt::QUIC>,
-    subscriber: moqt::Subscriber<moqt::QUIC>,
+    publisher: moqt::Publisher<T>,
+    subscriber: moqt::Subscriber<T>,
     runner: StreamTaskRunner,
 }
 
-impl Client {
-    pub async fn new(cert_path: String, port: u16, label: String, notification_sender: Option<UnboundedSender<String>>) -> anyhow::Result<Self> { // pub(crate) -> pub
-        let endpoint = Endpoint::<QUIC>::create_client_with_custom_cert(0, &cert_path)?;
+impl<T: TransportProtocol> Client<T> {
+    pub async fn new(cert_path: String, port: u16, label: String, notification_sender: Option<UnboundedSender<String>>) -> anyhow::Result<Self> {
+        let endpoint = Endpoint::<T>::create_client_with_custom_cert(0, &cert_path)?;
         let url_str = format!("moqt://localhost:{}", port);
         let url = url::Url::from_str(&url_str)?;
         let host = url.host_str().unwrap();
@@ -56,7 +56,7 @@ impl Client {
 
     pub fn create_receiver( // pub(crate) -> pub
         label: String,
-        session: Session<moqt::QUIC>,
+        session: Session<T>,
         track_alias: Arc<AtomicU64>,
         notification_sender: Option<UnboundedSender<String>>,
     ) -> tokio::task::JoinHandle<()> {
@@ -165,7 +165,7 @@ impl Client {
 
     async fn subscribe(
         label: String,
-        publish_handler: moqt::PublishHandler<moqt::QUIC>,
+        publish_handler: moqt::PublishHandler<T>,
         runner: &StreamTaskRunner,
     ) {
         let full_name = format!(
@@ -197,7 +197,7 @@ impl Client {
 
     async fn create_stream(
         label: String,
-        publication: moqt::PublishedResource<moqt::QUIC>,
+        publication: moqt::PublishedResource<T>,
         runner: &StreamTaskRunner,
     ) {
         tracing::info!("{} :create stream", label);
@@ -276,7 +276,7 @@ impl Client {
     }
 }
 
-impl Drop for Client {
+impl<T: TransportProtocol> Drop for Client<T> {
     fn drop(&mut self) {
         tracing::info!("Client has been dropped.");
         self.join_handle.abort();

--- a/integration-test/src/client.rs
+++ b/integration-test/src/client.rs
@@ -7,9 +7,9 @@ use std::{
     },
 };
 
-use anyhow::bail;
-use moqt::{DatagramField, Endpoint, TransportProtocol, Session, SubscribeOption};
 use crate::stream_runner::StreamTaskRunner;
+use anyhow::bail;
+use moqt::{DatagramField, Endpoint, Session, SubscribeOption, TransportProtocol};
 use tokio::sync::mpsc::UnboundedSender;
 
 pub struct Client<T: TransportProtocol> {
@@ -22,7 +22,12 @@ pub struct Client<T: TransportProtocol> {
 }
 
 impl<T: TransportProtocol> Client<T> {
-    pub async fn new(cert_path: String, port: u16, label: String, notification_sender: Option<UnboundedSender<String>>) -> anyhow::Result<Self> {
+    pub async fn new(
+        cert_path: String,
+        port: u16,
+        label: String,
+        notification_sender: Option<UnboundedSender<String>>,
+    ) -> anyhow::Result<Self> {
         let endpoint = Endpoint::<T>::create_client_with_custom_cert(0, &cert_path)?;
         let url_str = format!("moqt://localhost:{}", port);
         let url = url::Url::from_str(&url_str)?;
@@ -42,7 +47,12 @@ impl<T: TransportProtocol> Client<T> {
         };
         let track_alias = Arc::new(AtomicU64::new(0));
         let (publisher, subscriber) = session.create_publisher_subscriber_pair();
-        let join_handle = Self::create_receiver(label.clone(), session, track_alias.clone(), notification_sender);
+        let join_handle = Self::create_receiver(
+            label.clone(),
+            session,
+            track_alias.clone(),
+            notification_sender,
+        );
 
         Ok(Self {
             label,
@@ -54,7 +64,8 @@ impl<T: TransportProtocol> Client<T> {
         })
     }
 
-    pub fn create_receiver( // pub(crate) -> pub
+    pub fn create_receiver(
+        // pub(crate) -> pub
         label: String,
         session: Session<T>,
         track_alias: Arc<AtomicU64>,
@@ -78,7 +89,10 @@ impl<T: TransportProtocol> Client<T> {
                                 &publish_namespace_handler.track_namespace
                             );
                             if let Some(sender) = &notification_sender {
-                                if sender.send(publish_namespace_handler.track_namespace.clone()).is_err() {
+                                if sender
+                                    .send(publish_namespace_handler.track_namespace.clone())
+                                    .is_err()
+                                {
                                     tracing::error!("Failed to send notification");
                                 }
                             }
@@ -123,7 +137,8 @@ impl<T: TransportProtocol> Client<T> {
             .unwrap()
     }
 
-    pub async fn publish_namespace(&self, track_namespace: String) -> anyhow::Result<()> { // pub(crate) -> pub
+    pub async fn publish_namespace(&self, track_namespace: String) -> anyhow::Result<()> {
+        // pub(crate) -> pub
         let result = self.publisher.publish_namespace(track_namespace).await;
         if result.is_err() {
             tracing::info!("{}: publish namespace error", self.label);
@@ -134,7 +149,8 @@ impl<T: TransportProtocol> Client<T> {
         Ok(())
     }
 
-    pub async fn subscribe_namespace(&self, track_namespace_prefix: String) -> anyhow::Result<()> { // pub(crate) -> pub
+    pub async fn subscribe_namespace(&self, track_namespace_prefix: String) -> anyhow::Result<()> {
+        // pub(crate) -> pub
         let result = self
             .subscriber
             .subscribe_namespace(track_namespace_prefix)
@@ -148,7 +164,8 @@ impl<T: TransportProtocol> Client<T> {
         Ok(())
     }
 
-    pub async fn publish(&self, track_namespace: String, track_name: String) { // pub(crate) -> pub
+    pub async fn publish(&self, track_namespace: String, track_name: String) {
+        // pub(crate) -> pub
         let option = moqt::PublishOption::default();
         let pub_result = self
             .publisher
@@ -229,7 +246,8 @@ impl<T: TransportProtocol> Client<T> {
         runner.add_task(Box::pin(task)).await;
     }
 
-    pub async fn active_subscribe( // pub(crate) -> pub
+    pub async fn active_subscribe(
+        // pub(crate) -> pub
         &self,
         label: String,
         track_namespace: String,

--- a/integration-test/src/lib.rs
+++ b/integration-test/src/lib.rs
@@ -1,4 +1,4 @@
-mod client;
+pub mod client;
 mod stream_runner;
 
 pub use client::Client;

--- a/integration-test/tests/scenarios.rs
+++ b/integration-test/tests/scenarios.rs
@@ -2,10 +2,12 @@ mod integration_test {
 
     use anyhow::Result;
     use integration_test::Client;
+    use integration_test::WtClient;
     use std::path::PathBuf;
     use std::time::Duration;
 
     use relay::run_relay_server; // relayクレートのrun_relay_server関数をインポート
+    use relay::run_wt_relay_server;
     use tokio::sync::oneshot; // oneshot::SenderとReceiverのために追加
     use tracing_test::traced_test;
 
@@ -44,6 +46,21 @@ mod integration_test {
         let cert_path = get_cert_path();
         log_init();
         run_relay_server(
+            port_num,
+            receiver,
+            key_path.to_str().unwrap(),
+            cert_path.to_str().unwrap(),
+        )
+    }
+
+    fn activate_wt_server(
+        port_num: u16,
+        receiver: tokio::sync::oneshot::Receiver<()>,
+    ) -> tokio::task::JoinHandle<()> {
+        let key_path = get_key_path();
+        let cert_path = get_cert_path();
+        log_init();
+        run_wt_relay_server(
             port_num,
             receiver,
             key_path.to_str().unwrap(),
@@ -126,6 +143,32 @@ mod integration_test {
         // relayサーバーをシャットダウン
         let _ = relay_shutdown_tx.send(());
         relay_handle.await?; // relayタスクの終了を待つ
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn wt_publish_namespace() -> Result<()> {
+        let port_num = get_port();
+        let (relay_shutdown_tx, relay_shutdown_rx) = oneshot::channel();
+        activate_wt_server(port_num, relay_shutdown_rx);
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let client = WtClient::new(
+            get_cert_path().to_str().unwrap().to_string(),
+            port_num,
+            "Client A".to_string(),
+            None,
+        )
+        .await?;
+        let result = client.publish_namespace("room/member".to_string()).await;
+        assert!(result.is_ok(), "wt publish_namespace should return Ok");
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // relayサーバーをシャットダウン
+        let _ = relay_shutdown_tx.send(());
 
         Ok(())
     }

--- a/integration-test/tests/scenarios.rs
+++ b/integration-test/tests/scenarios.rs
@@ -2,12 +2,10 @@ mod integration_test {
 
     use anyhow::Result;
     use integration_test::Client;
-    use integration_test::WtClient;
     use std::path::PathBuf;
     use std::time::Duration;
 
-    use relay::run_relay_server; // relayクレートのrun_relay_server関数をインポート
-    use relay::run_wt_relay_server;
+    use relay::run_relay_server;
     use tokio::sync::oneshot; // oneshot::SenderとReceiverのために追加
     use tracing_test::traced_test;
 
@@ -38,29 +36,14 @@ mod integration_test {
         current.join("keys").join("key.pem")
     }
 
-    fn activate_server(
+    fn activate_server<T: moqt::TransportProtocol>(
         port_num: u16,
         receiver: tokio::sync::oneshot::Receiver<()>,
     ) -> tokio::task::JoinHandle<()> {
         let key_path = get_key_path();
         let cert_path = get_cert_path();
         log_init();
-        run_relay_server(
-            port_num,
-            receiver,
-            key_path.to_str().unwrap(),
-            cert_path.to_str().unwrap(),
-        )
-    }
-
-    fn activate_wt_server(
-        port_num: u16,
-        receiver: tokio::sync::oneshot::Receiver<()>,
-    ) -> tokio::task::JoinHandle<()> {
-        let key_path = get_key_path();
-        let cert_path = get_cert_path();
-        log_init();
-        run_wt_relay_server(
+        run_relay_server::<T>(
             port_num,
             receiver,
             key_path.to_str().unwrap(),
@@ -73,10 +56,10 @@ mod integration_test {
     async fn publish_namespace() -> Result<()> {
         let port_num = get_port();
         let (relay_shutdown_tx, relay_shutdown_rx) = oneshot::channel();
-        activate_server(port_num, relay_shutdown_rx);
+        activate_server::<moqt::QUIC>(port_num, relay_shutdown_rx);
         tokio::time::sleep(Duration::from_secs(1)).await; // relayの起動を待つ
 
-        let client = Client::new(
+        let client = Client::<moqt::QUIC>::new(
             get_cert_path().to_str().unwrap().to_string(),
             port_num,
             "Client A".to_string(),
@@ -99,11 +82,11 @@ mod integration_test {
     async fn publish_namespace_already_subscribe_namespace() -> Result<()> {
         let port_num = get_port();
         let (relay_shutdown_tx, relay_shutdown_rx) = oneshot::channel();
-        let relay_handle = activate_server(port_num, relay_shutdown_rx);
+        let relay_handle = activate_server::<moqt::QUIC>(port_num, relay_shutdown_rx);
         tokio::time::sleep(Duration::from_secs(1)).await; // relayの起動を待つ
 
         // Client Aのインスタンス化と名前空間の公開
-        let client_a = Client::new(
+        let client_a = Client::<moqt::QUIC>::new(
             get_cert_path().to_str().unwrap().to_string(),
             port_num,
             "Client A".to_string(),
@@ -119,7 +102,7 @@ mod integration_test {
 
         // Client Bのインスタンス化と名前空間の購読
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        let client_b = Client::new(
+        let client_b = Client::<moqt::QUIC>::new(
             get_cert_path().to_str().unwrap().to_string(),
             port_num,
             "Client B".to_string(),
@@ -152,10 +135,10 @@ mod integration_test {
     async fn wt_publish_namespace() -> Result<()> {
         let port_num = get_port();
         let (relay_shutdown_tx, relay_shutdown_rx) = oneshot::channel();
-        activate_wt_server(port_num, relay_shutdown_rx);
+        activate_server::<moqt::WEBTRANSPORT>(port_num, relay_shutdown_rx);
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        let client = WtClient::new(
+        let client = Client::<moqt::WEBTRANSPORT>::new(
             get_cert_path().to_str().unwrap().to_string(),
             port_num,
             "Client A".to_string(),

--- a/integration-test/tests/scenarios.rs
+++ b/integration-test/tests/scenarios.rs
@@ -155,4 +155,57 @@ mod integration_test {
 
         Ok(())
     }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn wt_publish_namespace_already_subscribe_namespace() -> Result<()> {
+        let port_num = get_port();
+        let (relay_shutdown_tx, relay_shutdown_rx) = oneshot::channel();
+        let relay_handle = activate_server::<moqt::WEBTRANSPORT>(port_num, relay_shutdown_rx);
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Client Aのインスタンス化と名前空間の公開
+        let client_a = Client::<moqt::WEBTRANSPORT>::new(
+            get_cert_path().to_str().unwrap().to_string(),
+            port_num,
+            "Client A".to_string(),
+            None,
+        )
+        .await?;
+        let publish_namespace_a_result =
+            client_a.publish_namespace("room/member".to_string()).await;
+        assert!(
+            publish_namespace_a_result.is_ok(),
+            "Client A publish_namespace should return Ok"
+        );
+
+        // Client Bのインスタンス化と名前空間の購読
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let client_b = Client::<moqt::WEBTRANSPORT>::new(
+            get_cert_path().to_str().unwrap().to_string(),
+            port_num,
+            "Client B".to_string(),
+            Some(tx),
+        )
+        .await?;
+        let subscribe_namespace_b_result = client_b.subscribe_namespace("room".to_string()).await;
+        assert!(
+            subscribe_namespace_b_result.is_ok(),
+            "Client B subscribe_namespace should return Ok"
+        );
+
+        // Client BがPublishNamespace通知を受け取ったことをアサート
+        let received_namespace = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
+        assert!(received_namespace.is_ok(), "Did not receive notification in time");
+        assert_eq!(
+            received_namespace.unwrap().unwrap(),
+            "room/member".to_string()
+        );
+
+        // relayサーバーをシャットダウン
+        let _ = relay_shutdown_tx.send(());
+        relay_handle.await?;
+
+        Ok(())
+    }
 }

--- a/integration-test/tests/scenarios.rs
+++ b/integration-test/tests/scenarios.rs
@@ -117,7 +117,10 @@ mod integration_test {
 
         // Client BがPublishNamespace通知を受け取ったことをアサート
         let received_namespace = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
-        assert!(received_namespace.is_ok(), "Did not receive notification in time");
+        assert!(
+            received_namespace.is_ok(),
+            "Did not receive notification in time"
+        );
         assert_eq!(
             received_namespace.unwrap().unwrap(),
             "room/member".to_string()
@@ -196,7 +199,10 @@ mod integration_test {
 
         // Client BがPublishNamespace通知を受け取ったことをアサート
         let received_namespace = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
-        assert!(received_namespace.is_ok(), "Did not receive notification in time");
+        assert!(
+            received_namespace.is_ok(),
+            "Did not receive notification in time"
+        );
         assert_eq!(
             received_namespace.unwrap().unwrap(),
             "room/member".to_string()

--- a/moqt/Cargo.toml
+++ b/moqt/Cargo.toml
@@ -15,6 +15,7 @@ tracing = "0.1.37"
 once_cell = "1.21.3"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 quinn = "0.11.8"
+wtransport = { version = "0.6.1", features = ["quinn"] }
 bytes = "1"
 async-trait = "0.1.74"
 ttl_cache = "0.5.1"

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -35,5 +35,5 @@ pub use modules::moqt::domains::subscriber::Subscriber;
 pub use modules::moqt::domains::subscription::DataReceiver;
 pub use modules::moqt::domains::subscription::Subscription;
 pub use modules::moqt::protocol::QUIC;
-pub use modules::moqt::protocol::WEBTRANSPORT;
 pub use modules::moqt::protocol::TransportProtocol;
+pub use modules::moqt::protocol::WEBTRANSPORT;

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -35,4 +35,5 @@ pub use modules::moqt::domains::subscriber::Subscriber;
 pub use modules::moqt::domains::subscription::DataReceiver;
 pub use modules::moqt::domains::subscription::Subscription;
 pub use modules::moqt::protocol::QUIC;
+pub use modules::moqt::protocol::WEBTRANSPORT;
 pub use modules::moqt::protocol::TransportProtocol;

--- a/moqt/src/modules/moqt/data_plane/object/extension_headers.rs
+++ b/moqt/src/modules/moqt/data_plane/object/extension_headers.rs
@@ -21,11 +21,15 @@ pub struct ExtensionHeaders {
 impl ExtensionHeaders {
     pub fn decode(cursor: &mut impl Buf) -> Option<Self> {
         let mut kv_pairs = Vec::new();
-        let number_of_parameters = cursor
+        let byte_length = cursor
             .try_get_varint()
-            .log_context("number of parameters")
-            .ok()?;
-        for _ in 0..number_of_parameters {
+            .log_context("extension headers length")
+            .ok()? as usize;
+        if cursor.remaining() < byte_length {
+            return None;
+        }
+        let end_remaining = cursor.remaining() - byte_length;
+        while cursor.remaining() > end_remaining {
             let key_value_pair = KeyValuePair::decode(cursor)?;
             kv_pairs.push(key_value_pair);
         }
@@ -62,24 +66,23 @@ impl ExtensionHeaders {
     }
 
     pub fn encode(&self) -> bytes::BytesMut {
-        let mut buf = bytes::BytesMut::new();
-        let total_parameters = self.prior_group_id_gap.len()
-            + self.prior_object_id_gap.len()
-            + self.immutable_extensions.len();
-        buf.put_varint(total_parameters as u64);
+        let mut kv_buf = bytes::BytesMut::new();
         for gap in &self.prior_group_id_gap {
-            buf.put_varint(ExtensionHeaderType::PriorGroupIdGap as u64);
-            buf.put_varint(*gap);
+            kv_buf.put_varint(ExtensionHeaderType::PriorGroupIdGap as u64);
+            kv_buf.put_varint(*gap);
         }
         for gap in &self.prior_object_id_gap {
-            buf.put_varint(ExtensionHeaderType::PriorObjectIdGap as u64);
-            buf.put_varint(*gap);
+            kv_buf.put_varint(ExtensionHeaderType::PriorObjectIdGap as u64);
+            kv_buf.put_varint(*gap);
         }
         for ext in &self.immutable_extensions {
-            buf.put_varint(ExtensionHeaderType::ImmutableExtensions as u64);
-            buf.put_varint(ext.len() as u64);
-            buf.extend_from_slice(ext);
+            kv_buf.put_varint(ExtensionHeaderType::ImmutableExtensions as u64);
+            kv_buf.put_varint(ext.len() as u64);
+            kv_buf.extend_from_slice(ext);
         }
+        let mut buf = bytes::BytesMut::new();
+        buf.put_varint(kv_buf.len() as u64);
+        buf.unsplit(kv_buf);
         buf
     }
 }

--- a/moqt/src/modules/moqt/data_plane/streams/stream/bi_stream_sender.rs
+++ b/moqt/src/modules/moqt/data_plane/streams/stream/bi_stream_sender.rs
@@ -38,6 +38,6 @@ impl<T: TransportProtocol> BiStreamSender<T> {
     #[allow(dead_code)]
     pub(crate) async fn close(&self) -> anyhow::Result<()> {
         let mut stream_sender = self.stream_sender.lock().await;
-        stream_sender.close()
+        stream_sender.close().await
     }
 }

--- a/moqt/src/modules/moqt/data_plane/streams/stream/stream_sender.rs
+++ b/moqt/src/modules/moqt/data_plane/streams/stream/stream_sender.rs
@@ -22,6 +22,6 @@ impl<T: TransportProtocol> StreamSender<T> {
     }
 
     pub async fn close(&self) -> anyhow::Result<()> {
-        self.send_stream.lock().await.close()
+        self.send_stream.lock().await.close().await
     }
 }

--- a/moqt/src/modules/moqt/protocol.rs
+++ b/moqt/src/modules/moqt/protocol.rs
@@ -5,6 +5,10 @@ use crate::modules::transport::{
         quic_connection::QUICConnection, quic_connection_creator::QUICConnectionCreator,
         quic_receive_stream::QUICReceiveStream, quic_send_stream::QUICSendStream,
     },
+    webtransport::{
+        wt_connection::WtConnection, wt_connection_creator::WtConnectionCreator,
+        wt_receive_stream::WtReceiveStream, wt_send_stream::WtSendStream,
+    },
     transport_connection::TransportConnection,
     transport_connection_creator::TransportConnectionCreator,
     transport_receive_stream::TransportReceiveStream,
@@ -30,4 +34,15 @@ impl TransportProtocol for QUIC {
     type Connection = QUICConnection;
     type SendStream = QUICSendStream;
     type ReceiveStream = QUICReceiveStream;
+}
+
+#[allow(warnings)]
+#[derive(Debug)]
+pub struct WEBTRANSPORT;
+
+impl TransportProtocol for WEBTRANSPORT {
+    type ConnectionCreator = WtConnectionCreator;
+    type Connection = WtConnection;
+    type SendStream = WtSendStream;
+    type ReceiveStream = WtReceiveStream;
 }

--- a/moqt/src/modules/moqt/protocol.rs
+++ b/moqt/src/modules/moqt/protocol.rs
@@ -5,14 +5,14 @@ use crate::modules::transport::{
         quic_connection::QUICConnection, quic_connection_creator::QUICConnectionCreator,
         quic_receive_stream::QUICReceiveStream, quic_send_stream::QUICSendStream,
     },
-    webtransport::{
-        wt_connection::WtConnection, wt_connection_creator::WtConnectionCreator,
-        wt_receive_stream::WtReceiveStream, wt_send_stream::WtSendStream,
-    },
     transport_connection::TransportConnection,
     transport_connection_creator::TransportConnectionCreator,
     transport_receive_stream::TransportReceiveStream,
     transport_send_stream::TransportSendStream,
+    webtransport::{
+        wt_connection::WtConnection, wt_connection_creator::WtConnectionCreator,
+        wt_receive_stream::WtReceiveStream, wt_send_stream::WtSendStream,
+    },
 };
 
 // Prevent `TransportConnectionCreator` from public

--- a/moqt/src/modules/transport.rs
+++ b/moqt/src/modules/transport.rs
@@ -1,5 +1,6 @@
 pub(crate) mod quic;
 pub(crate) mod read_error;
+pub(crate) mod webtransport;
 pub(crate) mod transport_connection;
 pub(crate) mod transport_connection_creator;
 pub(crate) mod transport_receive_stream;

--- a/moqt/src/modules/transport.rs
+++ b/moqt/src/modules/transport.rs
@@ -1,7 +1,7 @@
 pub(crate) mod quic;
 pub(crate) mod read_error;
-pub(crate) mod webtransport;
 pub(crate) mod transport_connection;
 pub(crate) mod transport_connection_creator;
 pub(crate) mod transport_receive_stream;
 pub(crate) mod transport_send_stream;
+pub(crate) mod webtransport;

--- a/moqt/src/modules/transport/quic/quic_send_stream.rs
+++ b/moqt/src/modules/transport/quic/quic_send_stream.rs
@@ -5,6 +5,7 @@ use quinn::{self};
 use crate::modules::transport::transport_send_stream::TransportSendStream;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct QUICSendStream {
     pub(crate) send_stream: quinn::SendStream,
 }

--- a/moqt/src/modules/transport/quic/quic_send_stream.rs
+++ b/moqt/src/modules/transport/quic/quic_send_stream.rs
@@ -15,7 +15,7 @@ impl TransportSendStream for QUICSendStream {
         Ok(self.send_stream.write_all(buffer).await?)
     }
 
-    fn close(&mut self) -> anyhow::Result<()> {
+    async fn close(&mut self) -> anyhow::Result<()> {
         Ok(self.send_stream.finish()?)
     }
 }

--- a/moqt/src/modules/transport/transport_send_stream.rs
+++ b/moqt/src/modules/transport/transport_send_stream.rs
@@ -8,5 +8,5 @@ use mockall::automock;
 #[async_trait]
 pub(crate) trait TransportSendStream: Send + Sync + 'static + Debug {
     async fn send(&mut self, buffer: &BytesMut) -> anyhow::Result<()>;
-    fn close(&mut self) -> anyhow::Result<()>;
+    async fn close(&mut self) -> anyhow::Result<()>;
 }

--- a/moqt/src/modules/transport/webtransport.rs
+++ b/moqt/src/modules/transport/webtransport.rs
@@ -1,0 +1,4 @@
+pub(crate) mod wt_connection;
+pub(crate) mod wt_connection_creator;
+pub(crate) mod wt_receive_stream;
+pub(crate) mod wt_send_stream;

--- a/moqt/src/modules/transport/webtransport/wt_connection.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection.rs
@@ -5,7 +5,15 @@ use super::wt_receive_stream::WtReceiveStream;
 use super::wt_send_stream::WtSendStream;
 
 #[derive(Debug)]
-pub struct WtConnection;
+pub struct WtConnection {
+    connection: wtransport::Connection,
+}
+
+impl WtConnection {
+    pub(crate) fn new(connection: wtransport::Connection) -> Self {
+        Self { connection }
+    }
+}
 
 #[async_trait]
 impl TransportConnection for WtConnection {

--- a/moqt/src/modules/transport/webtransport/wt_connection.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+
+use crate::modules::transport::transport_connection::TransportConnection;
+use super::wt_receive_stream::WtReceiveStream;
+use super::wt_send_stream::WtSendStream;
+
+#[derive(Debug)]
+pub struct WtConnection;
+
+#[async_trait]
+impl TransportConnection for WtConnection {
+    type SendStream = WtSendStream;
+    type ReceiveStream = WtReceiveStream;
+
+    fn id(&self) -> usize {
+        todo!("WebTransport connection id not yet implemented")
+    }
+
+    async fn open_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
+        todo!("WebTransport open_bi not yet implemented")
+    }
+
+    async fn accept_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
+        todo!("WebTransport accept_bi not yet implemented")
+    }
+
+    async fn open_uni(&self) -> anyhow::Result<Self::SendStream> {
+        todo!("WebTransport open_uni not yet implemented")
+    }
+
+    async fn accept_uni(&self) -> anyhow::Result<Self::ReceiveStream> {
+        todo!("WebTransport accept_uni not yet implemented")
+    }
+
+    fn send_datagram(&self, _bytes: bytes::BytesMut) -> anyhow::Result<()> {
+        todo!("WebTransport send_datagram not yet implemented")
+    }
+
+    async fn receive_datagram(&self) -> anyhow::Result<bytes::BytesMut> {
+        todo!("WebTransport receive_datagram not yet implemented")
+    }
+}

--- a/moqt/src/modules/transport/webtransport/wt_connection.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection.rs
@@ -20,10 +20,6 @@ impl TransportConnection for WtConnection {
     type SendStream = WtSendStream;
     type ReceiveStream = WtReceiveStream;
 
-    fn id(&self) -> usize {
-        self.connection.stable_id()
-    }
-
     async fn open_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
         let (send, recv) = self.connection.open_bi().await?.await?;
         let send_stream = WtSendStream {

--- a/moqt/src/modules/transport/webtransport/wt_connection.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection.rs
@@ -21,30 +21,68 @@ impl TransportConnection for WtConnection {
     type ReceiveStream = WtReceiveStream;
 
     fn id(&self) -> usize {
-        todo!("WebTransport connection id not yet implemented")
+        self.connection.stable_id()
     }
 
     async fn open_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
-        todo!("WebTransport open_bi not yet implemented")
+        let (send, recv) = self.connection.open_bi().await?.await?;
+        let send_stream = WtSendStream {
+            stable_id: self.connection.stable_id(),
+            stream_id: recv.id().into_u64(),
+            send_stream: send,
+        };
+        let receive_stream = WtReceiveStream {
+            stable_id: self.connection.stable_id(),
+            stream_id: recv.id().into_u64(),
+            recv_stream: recv,
+        };
+        Ok((send_stream, receive_stream))
     }
 
     async fn accept_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
-        todo!("WebTransport accept_bi not yet implemented")
+        let (send, recv) = self.connection.accept_bi().await?;
+        let send_stream = WtSendStream {
+            stable_id: self.connection.stable_id(),
+            stream_id: recv.id().into_u64(),
+            send_stream: send,
+        };
+        let receive_stream = WtReceiveStream {
+            stable_id: self.connection.stable_id(),
+            stream_id: recv.id().into_u64(),
+            recv_stream: recv,
+        };
+        Ok((send_stream, receive_stream))
     }
 
     async fn open_uni(&self) -> anyhow::Result<Self::SendStream> {
-        todo!("WebTransport open_uni not yet implemented")
+        let send = self.connection.open_uni().await?.await?;
+        Ok(WtSendStream {
+            stable_id: self.connection.stable_id(),
+            stream_id: send.id().into_u64(),
+            send_stream: send,
+        })
     }
 
     async fn accept_uni(&self) -> anyhow::Result<Self::ReceiveStream> {
-        todo!("WebTransport accept_uni not yet implemented")
+        let recv = self.connection.accept_uni().await?;
+        Ok(WtReceiveStream {
+            stable_id: self.connection.stable_id(),
+            stream_id: recv.id().into_u64(),
+            recv_stream: recv,
+        })
     }
 
-    fn send_datagram(&self, _bytes: bytes::BytesMut) -> anyhow::Result<()> {
-        todo!("WebTransport send_datagram not yet implemented")
+    fn send_datagram(&self, bytes: bytes::BytesMut) -> anyhow::Result<()> {
+        Ok(self.connection.send_datagram(bytes)?)
     }
 
     async fn receive_datagram(&self) -> anyhow::Result<bytes::BytesMut> {
-        todo!("WebTransport receive_datagram not yet implemented")
+        match self.connection.receive_datagram().await {
+            Ok(datagram) => Ok(bytes::BytesMut::from(&datagram[..])),
+            Err(e) => {
+                tracing::error!("Failed to receive datagram: {:?}", e);
+                anyhow::bail!("Failed to receive datagram: {:?}", e)
+            }
+        }
     }
 }

--- a/moqt/src/modules/transport/webtransport/wt_connection.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 
-use crate::modules::transport::transport_connection::TransportConnection;
 use super::wt_receive_stream::WtReceiveStream;
 use super::wt_send_stream::WtSendStream;
+use crate::modules::transport::transport_connection::TransportConnection;
 
 #[derive(Debug)]
 pub struct WtConnection {

--- a/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
@@ -18,8 +18,40 @@ pub struct WtConnectionCreator {
 impl TransportConnectionCreator for WtConnectionCreator {
     type Connection = WtConnection;
 
-    fn client(_port_num: u16, _verify_certificate: bool) -> anyhow::Result<Self> {
-        todo!("WebTransport client not yet implemented")
+    fn client(port_num: u16, verify_certificate: bool) -> anyhow::Result<Self> {
+        use wtransport::tls::rustls;
+
+        let tls_config = if verify_certificate {
+            let mut roots = rustls::RootCertStore::empty();
+            for cert in rustls_native_certs::load_native_certs().unwrap() {
+                roots.add(cert).unwrap();
+            }
+            rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth()
+        } else {
+            // Currently quinn and wtransport share the same rustls version,
+            // so we reuse the QUIC SkipVerification to avoid duplication.
+            // If their rustls versions diverge, this may need a separate implementation.
+            rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(std::sync::Arc::new(
+                    crate::modules::transport::quic::skip_certd_validation::SkipVerification,
+                ))
+                .with_no_client_auth()
+        };
+
+        let config = wtransport::ClientConfig::builder()
+            .with_bind_default()
+            .with_custom_tls(tls_config)
+            .build();
+
+        let endpoint = wtransport::Endpoint::client(config)?;
+        tracing::info!("Client ready! for WebTransport port: {}", port_num);
+
+        Ok(WtConnectionCreator {
+            endpoint: WtEndpoint::Client(endpoint),
+        })
     }
 
     fn client_with_custom_cert(port_num: u16, custom_cert_path: &str) -> anyhow::Result<Self> {

--- a/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
@@ -2,10 +2,17 @@ use std::net::SocketAddr;
 
 use async_trait::async_trait;
 
-use crate::modules::transport::transport_connection_creator::TransportConnectionCreator;
 use super::wt_connection::WtConnection;
+use crate::modules::transport::transport_connection_creator::TransportConnectionCreator;
 
-pub struct WtConnectionCreator;
+enum WtEndpoint {
+    Server(wtransport::Endpoint<wtransport::endpoint::endpoint_side::Server>),
+    Client(wtransport::Endpoint<wtransport::endpoint::endpoint_side::Client>),
+}
+
+pub struct WtConnectionCreator {
+    endpoint: WtEndpoint,
+}
 
 #[async_trait]
 impl TransportConnectionCreator for WtConnectionCreator {
@@ -15,28 +22,133 @@ impl TransportConnectionCreator for WtConnectionCreator {
         todo!("WebTransport client not yet implemented")
     }
 
-    fn client_with_custom_cert(_port_num: u16, _custom_cert_path: &str) -> anyhow::Result<Self> {
-        todo!("WebTransport client_with_custom_cert not yet implemented")
+    fn client_with_custom_cert(port_num: u16, custom_cert_path: &str) -> anyhow::Result<Self> {
+        use std::fs::File;
+        use std::io::BufReader;
+        use wtransport::tls::rustls;
+
+        // 証明書を読み込む
+        let cert_file = File::open(custom_cert_path)
+            .inspect_err(|e| tracing::error!("Opening certificate file failed: {:?}", e))?;
+        let mut cert_reader = BufReader::new(cert_file);
+        let certs: Vec<_> = rustls_pemfile::certs(&mut cert_reader)
+            .collect::<Result<Vec<_>, _>>()
+            .inspect_err(|e| tracing::error!("Parsing certificate failed: {:?}", e))?;
+
+        // 自己署名証明書を信頼するrustls ClientConfigを作る
+        let mut roots = rustls::RootCertStore::empty();
+        for cert in certs {
+            roots
+                .add(cert)
+                .inspect_err(|e| tracing::error!("Adding certificate failed: {:?}", e))?;
+        }
+        let mut tls_config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        tls_config.alpn_protocols = vec![wtransport::tls::WEBTRANSPORT_ALPN.to_vec()];
+
+        // wtransportのクライアント設定を組み立てる
+        let config = wtransport::ClientConfig::builder()
+            .with_bind_default()
+            .with_custom_tls(tls_config)
+            .build();
+
+        // クライアントEndpointを作る
+        let endpoint = wtransport::Endpoint::client(config)?;
+        tracing::info!("Client ready! for WebTransport port: {}", port_num);
+
+        Ok(WtConnectionCreator {
+            endpoint: WtEndpoint::Client(endpoint),
+        })
     }
 
     fn server(
-        _cert_path: String,
-        _key_path: String,
-        _port_num: u16,
-        _keep_alive_sec: u64,
+        cert_path: &str,
+        key_path: &str,
+        port_num: u16,
+        keep_alive_sec: u64,
     ) -> anyhow::Result<Self> {
-        todo!("WebTransport server not yet implemented")
+        use std::fs::File;
+        use std::io::BufReader;
+
+        // 証明書を同期的に読み込む
+        let cert_file = File::open(cert_path)
+            .inspect_err(|e| tracing::error!("Opening certificate file failed: {:?}", e))?;
+        let mut cert_reader = BufReader::new(cert_file);
+        let certs: Vec<wtransport::tls::Certificate> = rustls_pemfile::certs(&mut cert_reader)
+            .filter_map(|c| c.ok())
+            .map(|der| wtransport::tls::Certificate::from_der(der.as_ref().to_vec()))
+            .collect::<Result<Vec<_>, _>>()
+            .inspect_err(|e| tracing::error!("Parsing certificates failed: {:?}", e))?;
+
+        // 秘密鍵を同期的に読み込む
+        let key_file = File::open(key_path)
+            .inspect_err(|e| tracing::error!("Opening key file failed: {:?}", e))?;
+        let mut key_reader = BufReader::new(key_file);
+        let key_der = rustls_pemfile::private_key(&mut key_reader)?
+            .ok_or_else(|| anyhow::anyhow!("No private key found"))?;
+        let private_key =
+            wtransport::tls::PrivateKey::from_der_pkcs8(key_der.secret_der().to_vec());
+
+        let identity =
+            wtransport::Identity::new(wtransport::tls::CertificateChain::new(certs), private_key);
+
+        let config = wtransport::ServerConfig::builder()
+            .with_bind_default(port_num)
+            .with_identity(identity)
+            .keep_alive_interval(Some(std::time::Duration::from_secs(keep_alive_sec)))
+            .build();
+
+        let endpoint = wtransport::Endpoint::server(config)?;
+        tracing::info!("Server ready! for WebTransport port: {}", port_num);
+
+        Ok(WtConnectionCreator {
+            endpoint: WtEndpoint::Server(endpoint),
+        })
     }
 
     async fn create_new_transport(
         &self,
-        _remote_address: SocketAddr,
-        _host: &str,
+        remote_address: SocketAddr,
+        host: &str,
     ) -> anyhow::Result<Self::Connection> {
-        todo!("WebTransport create_new_transport not yet implemented")
+        let ep = match &self.endpoint {
+            WtEndpoint::Client(ep) => ep,
+            WtEndpoint::Server(_) => {
+                anyhow::bail!("Cannot create_new_transport on a server endpoint")
+            }
+        };
+        let url = format!("https://{}:{}", host, remote_address.port());
+
+        let connection = ep
+            .connect(url)
+            .await
+            .inspect_err(|e| tracing::error!("failed to connect: {:?}", e))?;
+
+        Ok(WtConnection::new(connection))
     }
 
     async fn accept_new_transport(&mut self) -> anyhow::Result<Self::Connection> {
-        todo!("WebTransport accept_new_transport not yet implemented")
+        let ep = match &self.endpoint {
+            WtEndpoint::Server(ep) => ep,
+            WtEndpoint::Client(_) => {
+                anyhow::bail!("Cannot accept_new_transport on a client endpoint")
+            }
+        };
+        // クライアントの接続を待つ
+        let incoming_session = ep.accept().await;
+
+        // セッションリクエストを待つ
+        let session_request = incoming_session
+            .await
+            .inspect_err(|e| tracing::error!("failed to accept session: {:?}", e))?;
+
+        // リクエストを受け入れてセッションを確立する
+        let connection = session_request
+            .accept()
+            .await
+            .inspect_err(|e| tracing::error!("failed to establish connection: {:?}", e))?;
+
+        Ok(WtConnection::new(connection))
     }
 }

--- a/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
@@ -1,0 +1,42 @@
+use std::net::SocketAddr;
+
+use async_trait::async_trait;
+
+use crate::modules::transport::transport_connection_creator::TransportConnectionCreator;
+use super::wt_connection::WtConnection;
+
+pub struct WtConnectionCreator;
+
+#[async_trait]
+impl TransportConnectionCreator for WtConnectionCreator {
+    type Connection = WtConnection;
+
+    fn client(_port_num: u16, _verify_certificate: bool) -> anyhow::Result<Self> {
+        todo!("WebTransport client not yet implemented")
+    }
+
+    fn client_with_custom_cert(_port_num: u16, _custom_cert_path: &str) -> anyhow::Result<Self> {
+        todo!("WebTransport client_with_custom_cert not yet implemented")
+    }
+
+    fn server(
+        _cert_path: String,
+        _key_path: String,
+        _port_num: u16,
+        _keep_alive_sec: u64,
+    ) -> anyhow::Result<Self> {
+        todo!("WebTransport server not yet implemented")
+    }
+
+    async fn create_new_transport(
+        &self,
+        _remote_address: SocketAddr,
+        _host: &str,
+    ) -> anyhow::Result<Self::Connection> {
+        todo!("WebTransport create_new_transport not yet implemented")
+    }
+
+    async fn accept_new_transport(&mut self) -> anyhow::Result<Self::Connection> {
+        todo!("WebTransport accept_new_transport not yet implemented")
+    }
+}

--- a/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
@@ -1,14 +1,46 @@
+use std::{pin::Pin, task::Poll};
+
 use async_trait::async_trait;
 use bytes::BytesMut;
+use tokio::io::{AsyncRead, ReadBuf};
 
-use crate::modules::transport::transport_receive_stream::TransportReceiveStream;
+use crate::modules::transport::{
+    read_error::ReadError, transport_receive_stream::TransportReceiveStream,
+};
 
 #[derive(Debug)]
-pub struct WtReceiveStream;
+pub struct WtReceiveStream {
+    pub(crate) stable_id: usize,
+    pub(crate) stream_id: u64,
+    pub(crate) recv_stream: wtransport::RecvStream,
+}
 
 #[async_trait]
 impl TransportReceiveStream for WtReceiveStream {
-    async fn receive(&mut self, _buffer: &mut BytesMut) -> anyhow::Result<Option<usize>> {
-        todo!("WebTransport receive not yet implemented")
+    async fn receive(&mut self, buffer: &mut BytesMut) -> anyhow::Result<Option<usize>> {
+        let result = self.recv_stream.read(buffer).await?;
+        Ok(result)
+    }
+
+    fn poll_read(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut BytesMut,
+    ) -> Poll<Result<usize, ReadError>> {
+        let mut read_buf = ReadBuf::new(buf);
+        let filled_before = read_buf.filled().len();
+        match Pin::new(&mut self.recv_stream).poll_read(cx, &mut read_buf) {
+            Poll::Ready(Ok(())) => {
+                let size = read_buf.filled().len() - filled_before;
+                Poll::Ready(Ok(size))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(match e.kind() {
+                std::io::ErrorKind::ConnectionReset => ReadError::Reset,
+                std::io::ErrorKind::ConnectionAborted => ReadError::ConnectionLost,
+                std::io::ErrorKind::UnexpectedEof => ReadError::Closed,
+                _ => todo!("handle other wtransport read errors: {:?}", e),
+            })),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }

--- a/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
@@ -18,11 +18,6 @@ pub struct WtReceiveStream {
 
 #[async_trait]
 impl TransportReceiveStream for WtReceiveStream {
-    async fn receive(&mut self, buffer: &mut BytesMut) -> anyhow::Result<Option<usize>> {
-        let result = self.recv_stream.read(buffer).await?;
-        Ok(result)
-    }
-
     fn poll_read(
         &mut self,
         cx: &mut std::task::Context<'_>,

--- a/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
@@ -9,6 +9,7 @@ use crate::modules::transport::{
 };
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct WtReceiveStream {
     pub(crate) stable_id: usize,
     pub(crate) stream_id: u64,

--- a/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
@@ -1,0 +1,14 @@
+use async_trait::async_trait;
+use bytes::BytesMut;
+
+use crate::modules::transport::transport_receive_stream::TransportReceiveStream;
+
+#[derive(Debug)]
+pub struct WtReceiveStream;
+
+#[async_trait]
+impl TransportReceiveStream for WtReceiveStream {
+    async fn receive(&mut self, _buffer: &mut BytesMut) -> anyhow::Result<Option<usize>> {
+        todo!("WebTransport receive not yet implemented")
+    }
+}

--- a/moqt/src/modules/transport/webtransport/wt_send_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_send_stream.rs
@@ -4,11 +4,19 @@ use bytes::BytesMut;
 use crate::modules::transport::transport_send_stream::TransportSendStream;
 
 #[derive(Debug)]
-pub struct WtSendStream;
+pub struct WtSendStream {
+    pub(crate) stable_id: usize,
+    pub(crate) stream_id: u64,
+    pub(crate) send_stream: wtransport::SendStream,
+}
 
 #[async_trait]
 impl TransportSendStream for WtSendStream {
-    async fn send(&mut self, _buffer: &BytesMut) -> anyhow::Result<()> {
-        todo!("WebTransport send not yet implemented")
+    async fn send(&mut self, buffer: &BytesMut) -> anyhow::Result<()> {
+        Ok(self.send_stream.write_all(buffer).await?)
+    }
+
+    async fn close(&mut self) -> anyhow::Result<()> {
+        Ok(self.send_stream.finish().await?)
     }
 }

--- a/moqt/src/modules/transport/webtransport/wt_send_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_send_stream.rs
@@ -4,6 +4,7 @@ use bytes::BytesMut;
 use crate::modules::transport::transport_send_stream::TransportSendStream;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct WtSendStream {
     pub(crate) stable_id: usize,
     pub(crate) stream_id: u64,

--- a/moqt/src/modules/transport/webtransport/wt_send_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_send_stream.rs
@@ -1,0 +1,14 @@
+use async_trait::async_trait;
+use bytes::BytesMut;
+
+use crate::modules::transport::transport_send_stream::TransportSendStream;
+
+#[derive(Debug)]
+pub struct WtSendStream;
+
+#[async_trait]
+impl TransportSendStream for WtSendStream {
+    async fn send(&mut self, _buffer: &BytesMut) -> anyhow::Result<()> {
+        todo!("WebTransport send not yet implemented")
+    }
+}

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -51,7 +51,7 @@ pub fn init_logging(log_level: String) {
 
 use tokio::sync::oneshot::Receiver; // Receiver for shutdown signal
 
-pub fn run_relay_server(
+pub fn run_relay_server<T: moqt::TransportProtocol>(
     port: u16,
     shutdown_signal: Receiver<()>,
     key_path: &str,
@@ -77,7 +77,7 @@ pub fn run_relay_server(
                 keep_alive_interval_sec: 15,
             };
 
-            let _handler = SessionHandler::run(server_config, repo.clone(), sender); // SessionHandler::runのシグネチャも変更する
+            let _handler = SessionHandler::run::<T>(server_config, repo.clone(), sender);
             let _manager = EventHandler::run(repo, receiver);
             let _ = shutdown_signal.await.ok(); // 関数の引数として受け取ったshutdown_signalを使用
         })

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
     create_certs_for_test_if_needed()?;
 
     // run_relay_serverをバックグラウンドで実行
-    let relay_handle = run_relay_server(
+    let relay_handle = run_relay_server::<moqt::QUIC>(
         4434,
         rx,
         get_key_path().to_str().unwrap(),

--- a/relay/src/modules/session_handler.rs
+++ b/relay/src/modules/session_handler.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use moqt::{Endpoint, QUIC};
+use moqt::{Endpoint, TransportProtocol};
 
 use crate::modules::{
     enums::MOQTMessageReceived, session_repository::SessionRepository, types::generate_session_id,
@@ -11,27 +11,20 @@ pub struct SessionHandler {
 }
 
 impl SessionHandler {
-    pub fn run(
-        config: moqt::ServerConfig, // ここを変更
+    pub fn run<T: TransportProtocol>(
+        config: moqt::ServerConfig,
         repo: Arc<tokio::sync::Mutex<SessionRepository>>,
         session_event_sender: tokio::sync::mpsc::UnboundedSender<MOQTMessageReceived>,
     ) -> Self {
-        // let config = moqt::ServerConfig { // このブロックは削除
-        //     port: 4434,
-        //     cert_path,
-        //     key_path,
-        //     keep_alive_interval_sec: 15,
-        // };
-        let endpoint =
-            Endpoint::<QUIC>::create_server(&config) // 修正
-                .inspect_err(|e| tracing::error!("failed to create server: {}", e))
-                .unwrap();
-        let join_handle = Self::create_joinhandle(endpoint, repo, session_event_sender);
+        let endpoint = Endpoint::<T>::create_server(&config)
+            .inspect_err(|e| tracing::error!("failed to create server: {}", e))
+            .unwrap();
+        let join_handle = Self::create_joinhandle::<T>(endpoint, repo, session_event_sender);
         Self { join_handle }
     }
 
-    fn create_joinhandle(
-        mut endpoint: Endpoint<QUIC>,
+    fn create_joinhandle<T: TransportProtocol>(
+        mut endpoint: Endpoint<T>,
         repo: Arc<tokio::sync::Mutex<SessionRepository>>,
         session_event_sender: tokio::sync::mpsc::UnboundedSender<MOQTMessageReceived>,
     ) -> tokio::task::JoinHandle<()> {


### PR DESCRIPTION
## Summary
- WebTransport の WEBTRANSPORT stub を追加し、Client / Server をジェネリック化
- WebTransport の ConnectionCreator, Connection, SendStream, ReceiveStream を実装
- Client を TransportProtocol でジェネリックに切り替えられるように変更
- Extension Headers を draft-14 仕様に合わせて length-prefixed format に修正

## Test plan
- WebTransport 用のテストケースを追加済み
- [moqtail-ts](https://github.com/moqtail/moqtail/tree/main/libs/moqtail-ts) (draft14 ベース) を使用したアプリケーションで映像・音声の Pub/Sub が動作することを確認済み

## Note
lint-and-test の失敗は認識しています。
今回の PR では自分が変更したファイルのみに fmt / clippy 修正を適用しています。
（全ファイルに適用すると差分が大きくなりレビューしづらくなるため）
