### PR TITLE
feat: detect session disconnect from transport close

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@63eb9591781c46a70274cb3ebdf190fce92702e8
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
@@ -32,7 +32,7 @@ jobs:
         run: wasm-pack build moqt-client-wasm --target web --out-dir=js/pkg --features web_sys_unstable_apis
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
 
@@ -45,7 +45,7 @@ jobs:
         working-directory: js
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: js/dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: rust:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install Clippy and Rustfmt
         run: |
           rustup component add clippy
@@ -47,7 +47,7 @@ jobs:
     container:
       image: rust:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install cargo-audit
         run: cargo install --locked cargo-audit
       - name: Run cargo audit
@@ -60,7 +60,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install FFmpeg build dependencies
         run: |
           apt-get update
@@ -83,7 +83,7 @@ jobs:
         run: |
           RUSTFLAGS="--cfg=web_sys_unstable_apis --cfg=tokio_unstable" cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
@@ -92,7 +92,7 @@ jobs:
     container:
       image: cimg/node:21.6.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install Prettier
         run: npm install ./js
       - name: Check code formatting

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -123,6 +123,10 @@ impl<T: TransportProtocol> Client<T> {
                             Self::create_stream(label.clone(), &publisher, publication, &runner)
                                 .await;
                         }
+                        moqt::SessionEvent::Disconnected() => {
+                            tracing::info!("Received: {} Disconnected", label);
+                            break;
+                        }
                         moqt::SessionEvent::ProtocolViolation() => {
                             tracing::info!("Received: {} ProtocolViolation", label);
                         }

--- a/moqt/src/modules/moqt/control_plane/enums.rs
+++ b/moqt/src/modules/moqt/control_plane/enums.rs
@@ -22,6 +22,7 @@ pub enum SessionEvent<T: TransportProtocol> {
     SubscribeNameSpace(SubscribeNamespaceHandler<T>),
     Publish(PublishHandler<T>),
     Subscribe(SubscribeHandler<T>),
+    Disconnected(),
     ProtocolViolation(),
 }
 

--- a/moqt/src/modules/moqt/domains/session.rs
+++ b/moqt/src/modules/moqt/domains/session.rs
@@ -10,12 +10,14 @@ use crate::modules::moqt::control_plane::threads::datagram_receive_thread::Datag
 use crate::modules::moqt::data_plane::streams::stream::stream_receiver::BiStreamReceiver;
 use crate::modules::moqt::domains::session_context::SessionContext;
 use crate::modules::moqt::protocol::TransportProtocol;
+use crate::modules::transport::transport_connection::TransportConnection;
 
 pub struct Session<T: TransportProtocol> {
     inner: Arc<SessionContext<T>>,
     event_receiver: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<SessionEvent<T>>>,
     message_receive_join_handle: tokio::task::JoinHandle<()>,
     datagram_receive_thread: tokio::task::JoinHandle<()>,
+    close_watch_join_handle: tokio::task::JoinHandle<()>,
 }
 
 impl<T: TransportProtocol> Session<T> {
@@ -28,13 +30,33 @@ impl<T: TransportProtocol> Session<T> {
         let message_receive_join_handle =
             ControlMessageReceiveThread::run(receive_stream, Arc::downgrade(&inner));
         let datagram_receive_thread = DatagramReceiveThread::run(inner.clone());
+        let close_watch_join_handle = Self::spawn_disconnect_notifier(inner.clone());
 
         Self {
             inner,
             event_receiver: tokio::sync::Mutex::new(event_receiver),
             message_receive_join_handle,
             datagram_receive_thread,
+            close_watch_join_handle,
         }
+    }
+
+    fn spawn_disconnect_notifier(
+        session_context: Arc<SessionContext<T>>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::task::Builder::new()
+            .name("Connection Close Watcher")
+            .spawn(async move {
+                session_context.transport_connection.closed().await;
+
+                if let Err(err) = session_context
+                    .event_sender
+                    .send(SessionEvent::Disconnected())
+                {
+                    tracing::warn!("failed to send disconnect event: {:?}", err);
+                }
+            })
+            .unwrap()
     }
 
     pub fn publisher(&self) -> Publisher<T> {
@@ -66,5 +88,6 @@ impl<T: TransportProtocol> Drop for Session<T> {
         tracing::info!("Session dropped.");
         self.message_receive_join_handle.abort();
         self.datagram_receive_thread.abort();
+        self.close_watch_join_handle.abort();
     }
 }

--- a/moqt/src/modules/transport/quic/quic_connection.rs
+++ b/moqt/src/modules/transport/quic/quic_connection.rs
@@ -22,6 +22,11 @@ impl TransportConnection for QUICConnection {
     type SendStream = QUICSendStream;
     type ReceiveStream = QUICReceiveStream;
 
+    async fn closed(&self) {
+        let reason = self.connection.closed().await;
+        tracing::info!("QUIC connection closed: {:?}", reason);
+    }
+
     async fn open_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
         let (sender, receiver) = self.connection.open_bi().await?;
         let send_stream = QUICSendStream {

--- a/moqt/src/modules/transport/transport_connection.rs
+++ b/moqt/src/modules/transport/transport_connection.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 pub(crate) trait TransportConnection: Send + Sync + Debug {
     type SendStream: TransportSendStream;
     type ReceiveStream: TransportReceiveStream;
+    async fn closed(&self);
     async fn open_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)>;
     async fn accept_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)>;
     async fn open_uni(&self) -> anyhow::Result<Self::SendStream>;

--- a/moqt/src/modules/transport/webtransport/wt_connection.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection.rs
@@ -20,6 +20,11 @@ impl TransportConnection for WtConnection {
     type SendStream = WtSendStream;
     type ReceiveStream = WtReceiveStream;
 
+    async fn closed(&self) {
+        let reason = self.connection.closed().await;
+        tracing::info!("WebTransport connection closed: {:?}", reason);
+    }
+
     async fn open_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
         let (send, recv) = self.connection.open_bi().await?.await?;
         let send_stream = WtSendStream {

--- a/relay/src/modules/core/session.rs
+++ b/relay/src/modules/core/session.rs
@@ -36,6 +36,7 @@ impl<T: moqt::TransportProtocol> Session for moqt::Session<T> {
             moqt::SessionEvent::Subscribe(subscribe_handler) => {
                 SessionEvent::Subscribe(Box::new(subscribe_handler))
             }
+            moqt::SessionEvent::Disconnected() => SessionEvent::Disconnected(),
             moqt::SessionEvent::ProtocolViolation() => SessionEvent::ProtocolViolation(),
         };
         Ok(result)

--- a/relay/src/modules/core/session_event.rs
+++ b/relay/src/modules/core/session_event.rs
@@ -8,5 +8,6 @@ pub(crate) enum SessionEvent {
     SubscribeNamespace(Box<dyn SubscribeNamespaceHandler>),
     Publish(Box<dyn PublishHandler>),
     Subscribe(Box<dyn SubscribeHandler>),
+    Disconnected(),
     ProtocolViolation(),
 }

--- a/relay/src/modules/enums.rs
+++ b/relay/src/modules/enums.rs
@@ -126,5 +126,5 @@ pub(crate) enum MOQTMessageReceived {
     Publish(SessionId, Box<dyn PublishHandler>),
     Subscribe(SessionId, Box<dyn SubscribeHandler>),
     Disconnected(SessionId),
-    ProtocolViolation(),
+    ProtocolViolation(SessionId),
 }

--- a/relay/src/modules/enums.rs
+++ b/relay/src/modules/enums.rs
@@ -125,5 +125,6 @@ pub(crate) enum MOQTMessageReceived {
     SubscribeNameSpace(SessionId, Box<dyn SubscribeNamespaceHandler>),
     Publish(SessionId, Box<dyn PublishHandler>),
     Subscribe(SessionId, Box<dyn SubscribeHandler>),
+    Disconnected(SessionId),
     ProtocolViolation(),
 }

--- a/relay/src/modules/event_handler.rs
+++ b/relay/src/modules/event_handler.rs
@@ -72,6 +72,10 @@ impl EventHandler {
                                     )
                                     .await;
                             }
+                            MOQTMessageReceived::Disconnected(session_id) => {
+                                tracing::info!("Session disconnected: {}", session_id);
+                                notifier.repository.lock().await.remove(session_id);
+                            }
                             MOQTMessageReceived::ProtocolViolation() => todo!(),
                         }
                     } else {

--- a/relay/src/modules/event_handler.rs
+++ b/relay/src/modules/event_handler.rs
@@ -77,7 +77,11 @@ impl EventHandler {
                                 table.remove_session(session_id).await;
                                 notifier.repository.lock().await.remove(session_id);
                             }
-                            MOQTMessageReceived::ProtocolViolation() => todo!(),
+                            MOQTMessageReceived::ProtocolViolation(session_id) => {
+                                tracing::error!("Session protocol violation: {}", session_id);
+                                table.remove_session(session_id).await;
+                                notifier.repository.lock().await.remove(session_id);
+                            }
                         }
                     } else {
                         tracing::error!("Failed to receive session event");

--- a/relay/src/modules/event_handler.rs
+++ b/relay/src/modules/event_handler.rs
@@ -74,6 +74,7 @@ impl EventHandler {
                             }
                             MOQTMessageReceived::Disconnected(session_id) => {
                                 tracing::info!("Session disconnected: {}", session_id);
+                                table.remove_session(session_id).await;
                                 notifier.repository.lock().await.remove(session_id);
                             }
                             MOQTMessageReceived::ProtocolViolation() => todo!(),

--- a/relay/src/modules/event_resolver/moqt_session_event_resolver.rs
+++ b/relay/src/modules/event_resolver/moqt_session_event_resolver.rs
@@ -16,7 +16,7 @@ impl MOQTSessionEventResolver {
             SessionEvent::Publish(handler) => MOQTMessageReceived::Publish(session_id, handler),
             SessionEvent::Subscribe(handler) => MOQTMessageReceived::Subscribe(session_id, handler),
             SessionEvent::Disconnected() => MOQTMessageReceived::Disconnected(session_id),
-            SessionEvent::ProtocolViolation() => MOQTMessageReceived::ProtocolViolation(),
+            SessionEvent::ProtocolViolation() => MOQTMessageReceived::ProtocolViolation(session_id),
         }
     }
 }

--- a/relay/src/modules/event_resolver/moqt_session_event_resolver.rs
+++ b/relay/src/modules/event_resolver/moqt_session_event_resolver.rs
@@ -15,6 +15,7 @@ impl MOQTSessionEventResolver {
             }
             SessionEvent::Publish(handler) => MOQTMessageReceived::Publish(session_id, handler),
             SessionEvent::Subscribe(handler) => MOQTMessageReceived::Subscribe(session_id, handler),
+            SessionEvent::Disconnected() => MOQTMessageReceived::Disconnected(session_id),
             SessionEvent::ProtocolViolation() => MOQTMessageReceived::ProtocolViolation(),
         }
     }

--- a/relay/src/modules/sequences/tables/hashmap_table.rs
+++ b/relay/src/modules/sequences/tables/hashmap_table.rs
@@ -35,6 +35,54 @@ impl Table for HashMapTable {
         }
     }
 
+    async fn remove_session(&self, session_id: SessionId) {
+        let namespaces_to_remove: Vec<_> = self
+            .publisher_namespaces
+            .iter()
+            .filter_map(|entry| (*entry.value() == session_id).then(|| entry.key().clone()))
+            .collect();
+        for track_namespace in namespaces_to_remove {
+            self.publisher_namespaces.remove(&track_namespace);
+        }
+
+        let empty_prefixes: Vec<_> = self
+            .subscriber_namespaces
+            .iter()
+            .filter_map(|entry| {
+                entry.value().remove(&session_id);
+                entry.value().is_empty().then(|| entry.key().clone())
+            })
+            .collect();
+        for track_namespace_prefix in empty_prefixes {
+            self.subscriber_namespaces.remove(&track_namespace_prefix);
+        }
+
+        self.published_handlers
+            .write()
+            .await
+            .retain(|(registered_session_id, _)| *registered_session_id != session_id);
+
+        let aliases_to_remove: Vec<_> = self
+            .track_alias_links
+            .iter()
+            .filter_map(|entry| {
+                let (publisher_session_id, publisher_track_alias, subscriber_session_id) =
+                    *entry.key();
+                (publisher_session_id == session_id || subscriber_session_id == session_id)
+                    .then_some({
+                        (
+                            publisher_session_id,
+                            publisher_track_alias,
+                            subscriber_session_id,
+                        )
+                    })
+            })
+            .collect();
+        for key in aliases_to_remove {
+            self.track_alias_links.remove(&key);
+        }
+    }
+
     fn register_publish_namespace(&self, session_id: SessionId, track_namespace: String) -> bool {
         if self
             .publisher_namespaces
@@ -174,5 +222,122 @@ impl Table for HashMapTable {
                 subscriber_session_id,
             ))
             .map(|value| *value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::{
+        core::subscription::Subscription,
+        enums::{ContentExists, FilterType, GroupOrder},
+    };
+
+    #[derive(Debug)]
+    struct StubPublishHandler {
+        track_namespace: String,
+        track_name: String,
+        track_alias: u64,
+    }
+
+    #[async_trait::async_trait]
+    impl PublishHandler for StubPublishHandler {
+        fn track_namespace(&self) -> &str {
+            &self.track_namespace
+        }
+
+        fn track_name(&self) -> &str {
+            &self.track_name
+        }
+
+        fn track_alias(&self) -> u64 {
+            self.track_alias
+        }
+
+        fn _group_order(&self) -> GroupOrder {
+            GroupOrder::Ascending
+        }
+
+        fn _content_exists(&self) -> ContentExists {
+            ContentExists::False
+        }
+
+        fn _forward(&self) -> bool {
+            true
+        }
+
+        fn _authorization_token(&self) -> Option<String> {
+            None
+        }
+
+        fn _delivery_timeout(&self) -> Option<u64> {
+            None
+        }
+
+        fn _max_cache_duration(&self) -> Option<u64> {
+            None
+        }
+
+        async fn ok(
+            &self,
+            _subscriber_priority: u8,
+            _filter_type: FilterType,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn _error(&self, _code: u64, _reason_phrase: String) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn convert_into_subscription(&self, expires: u64) -> Subscription {
+            Subscription::from(moqt::Subscription {
+                track_alias: self.track_alias,
+                expires,
+                group_order: moqt::GroupOrder::Ascending,
+                content_exists: moqt::ContentExists::False,
+                delivery_timeout: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn remove_session_cleans_up_all_session_scoped_entries() {
+        let table = HashMapTable::new();
+
+        assert!(table.register_publish_namespace(1, "room/member".to_string()));
+        table.register_subscribe_namespace(1, "room/".to_string());
+        table.register_subscribe_namespace(2, "room/".to_string());
+        table.register_subscribe_namespace(1, "solo/".to_string());
+        table
+            .register_publish(
+                1,
+                Arc::new(StubPublishHandler {
+                    track_namespace: "room/member".to_string(),
+                    track_name: "video".to_string(),
+                    track_alias: 10,
+                }),
+            )
+            .await;
+        table.register_track_alias_link(1, 10, 2, 20);
+        table.register_track_alias_link(2, 30, 1, 40);
+
+        table.remove_session(1).await;
+
+        assert!(table.get_publish_namespace("room/member").is_none());
+        assert!(
+            table
+                .find_publish_handler_with("room/member", "video")
+                .await
+                .is_none()
+        );
+        assert!(table._find_subscriber_track_alias(1, 10, 2).is_none());
+        assert!(table._find_subscriber_track_alias(2, 30, 1).is_none());
+
+        let room_subscribers = table.get_namespace_subscribers("room/member");
+        assert!(room_subscribers.contains(&2));
+        assert!(!room_subscribers.contains(&1));
+
+        assert!(table.subscriber_namespaces.get("solo/").is_none());
     }
 }

--- a/relay/src/modules/sequences/tables/table.rs
+++ b/relay/src/modules/sequences/tables/table.rs
@@ -9,6 +9,7 @@ pub(crate) trait Table: Send + Sync + 'static + Debug {
     fn new() -> Self
     where
         Self: Sized;
+    async fn remove_session(&self, session_id: SessionId);
     fn register_publish_namespace(&self, session_id: SessionId, track_namespace: String) -> bool;
     fn register_subscribe_namespace(&self, session_id: SessionId, track_namespace_prefix: String);
     async fn register_publish(&self, session_id: SessionId, handler: Arc<dyn PublishHandler>);

--- a/relay/src/modules/session_repository.rs
+++ b/relay/src/modules/session_repository.rs
@@ -58,13 +58,16 @@ impl SessionRepository {
                             break;
                         }
                         let event = event.unwrap();
-                        let disconnected = matches!(event, SessionEvent::Disconnected());
+                        let should_stop = matches!(
+                            event,
+                            SessionEvent::Disconnected() | SessionEvent::ProtocolViolation()
+                        );
                         let session_event = MOQTSessionEventResolver::resolve(session_id, event);
                         if let Err(err) = event_sender.send(session_event) {
                             tracing::error!("Failed to forward session event: {}", err);
                             break;
                         }
-                        if disconnected {
+                        if should_stop {
                             break;
                         }
                     } else {

--- a/relay/src/modules/session_repository.rs
+++ b/relay/src/modules/session_repository.rs
@@ -52,12 +52,13 @@ impl SessionRepository {
             .spawn(async move {
                 loop {
                     if let Some(session) = session.upgrade() {
-                        let event = session.receive_session_event().await;
-                        if let Err(e) = event {
-                            tracing::error!("Failed to receive session event: {}", e);
-                            break;
-                        }
-                        let event = event.unwrap();
+                        let event = match session.receive_session_event().await {
+                            Ok(event) => event,
+                            Err(e) => {
+                                tracing::error!("Failed to receive session event: {}", e);
+                                break;
+                            }
+                        };
                         let should_stop = matches!(
                             event,
                             SessionEvent::Disconnected() | SessionEvent::ProtocolViolation()

--- a/relay/src/modules/session_repository.rs
+++ b/relay/src/modules/session_repository.rs
@@ -3,7 +3,9 @@ use std::sync::{Arc, Weak};
 use dashmap::DashMap;
 
 use crate::modules::{
-    core::{publisher::Publisher, session::Session, subscriber::Subscriber},
+    core::{
+        publisher::Publisher, session::Session, session_event::SessionEvent, subscriber::Subscriber,
+    },
     enums::MOQTMessageReceived,
     event_resolver::moqt_session_event_resolver::MOQTSessionEventResolver,
     thread_manager::ThreadManager,
@@ -34,6 +36,11 @@ impl SessionRepository {
         self.sessions.insert(session_id, arc_session);
     }
 
+    pub(crate) fn remove(&mut self, session_id: SessionId) {
+        self.sessions.remove(&session_id);
+        self.thread_manager.remove(&session_id);
+    }
+
     fn start_receive(
         &mut self,
         session_id: SessionId,
@@ -50,9 +57,16 @@ impl SessionRepository {
                             tracing::error!("Failed to receive session event: {}", e);
                             break;
                         }
-                        let session_event =
-                            MOQTSessionEventResolver::resolve(session_id, event.unwrap());
-                        event_sender.send(session_event).unwrap();
+                        let event = event.unwrap();
+                        let disconnected = matches!(event, SessionEvent::Disconnected());
+                        let session_event = MOQTSessionEventResolver::resolve(session_id, event);
+                        if let Err(err) = event_sender.send(session_event) {
+                            tracing::error!("Failed to forward session event: {}", err);
+                            break;
+                        }
+                        if disconnected {
+                            break;
+                        }
                     } else {
                         tracing::error!("Session dropped.");
                         break;

--- a/relay/src/modules/thread_manager.rs
+++ b/relay/src/modules/thread_manager.rs
@@ -17,8 +17,8 @@ impl ThreadManager {
     }
 
     pub(crate) fn remove(&mut self, session_id: &SessionId) {
-        if let Some(join_handle) = self.join_handles_map.remove(session_id) {
-            join_handle.1.abort();
+        if let Some((_removed_session_id, join_handle)) = self.join_handles_map.remove(session_id) {
+            join_handle.abort();
         }
     }
 }

--- a/relay/src/modules/thread_manager.rs
+++ b/relay/src/modules/thread_manager.rs
@@ -16,7 +16,7 @@ impl ThreadManager {
         self.join_handles_map.insert(session_id, join_handle);
     }
 
-    pub(crate) fn _remove(&mut self, session_id: &SessionId) {
+    pub(crate) fn remove(&mut self, session_id: &SessionId) {
         if let Some(join_handle) = self.join_handles_map.remove(session_id) {
             join_handle.1.abort();
         }


### PR DESCRIPTION
## Summary
- add transport-level closed() support to QUIC and WebTransport connections
- emit SessionEvent::Disconnected from moqt sessions and propagate it through relay
- remove disconnected sessions from the relay repository and stop the client loop on disconnect

## Validation
- ~/.cargo/bin/cargo fmt --all
- ~/.cargo/bin/cargo check -p relay -p client
- ~/.cargo/bin/cargo clippy -p moqt -p relay -p client