### PR TITLE
feat: support single-port relay with QUIC and WebTransport via ALPN

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: rust:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Clippy and Rustfmt
         run: |
           rustup component add clippy
@@ -47,7 +47,7 @@ jobs:
     container:
       image: rust:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install cargo-audit
         run: cargo install --locked cargo-audit
       - name: Run cargo audit
@@ -60,7 +60,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install FFmpeg build dependencies
         run: |
           apt-get update
@@ -83,7 +83,7 @@ jobs:
         run: |
           RUSTFLAGS="--cfg=web_sys_unstable_apis --cfg=tokio_unstable" cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
@@ -92,7 +92,7 @@ jobs:
     container:
       image: cimg/node:21.6.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Prettier
         run: npm install ./js
       - name: Check code formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,7 +3161,8 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "ttl_cache",
- "wtransport",
+ "url",
+ "web-transport-quinn",
 ]
 
 [[package]]
@@ -4257,6 +4258,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4475,6 +4496,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4711,6 +4733,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sfv"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d471eaefb14f4b30032525bdb124b36e55ba9cb1292080e06f1a236cd10fe87"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.13.0",
+ "ref-cast",
 ]
 
 [[package]]
@@ -6022,6 +6055,49 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-transport-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0225d295c8ac00a2e9a498aefeaf3f3c6186da12a251c938189b15b82ea22808"
+dependencies = [
+ "bytes",
+ "http",
+ "sfv",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "web-transport-quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e77c81fe4cf56c1049e07c6ed9c00862a967010fe9da4f5e02dc7f4d71fdac"
+dependencies = [
+ "bytes",
+ "futures",
+ "http",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "web-transport-proto",
+ "web-transport-trait",
+]
+
+[[package]]
+name = "web-transport-trait"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb67841c4a481ca3c1412ee4c9f463987401991e1ddc000903df2124f3dc85e9"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -29,7 +29,7 @@ pub struct Client<T: TransportProtocol> {
 impl<T: TransportProtocol> Client<T> {
     pub async fn new(cert_path: String, label: String) -> anyhow::Result<Self> {
         let endpoint = Endpoint::<T>::create_client_with_custom_cert(0, &cert_path)?;
-        let url = url::Url::from_str("moqt://localhost:4434")?; // ここも変更
+        let url = url::Url::from_str("moqt://localhost:4433")?;
         let host = url.host_str().unwrap();
         let remote_address = (host, url.port().unwrap_or(4433))
             .to_socket_addrs()?

--- a/examples/cross-protocol-test/publisher/src/moqt_sender.rs
+++ b/examples/cross-protocol-test/publisher/src/moqt_sender.rs
@@ -14,7 +14,7 @@ pub async fn connect_and_wait_for_subscriber(namespace: &str) -> Result<StreamDa
         verify_certificate: false,
     };
     let endpoint = Endpoint::<QUIC>::create_client(&config)?;
-    let url = url::Url::from_str("moqt://localhost:4434")?;
+    let url = url::Url::from_str("moqt://localhost:4433")?;
     let host = url.host_str().unwrap();
     let remote_address = (host, url.port().unwrap())
         .to_socket_addrs()?

--- a/examples/cross-protocol-test/quic-subscriber/src/moqt_receiver.rs
+++ b/examples/cross-protocol-test/quic-subscriber/src/moqt_receiver.rs
@@ -15,7 +15,7 @@ pub async fn subscribe_and_receive(namespace: &str, track_name: &str) -> Result<
         verify_certificate: false,
     };
     let endpoint = Endpoint::<QUIC>::create_client(&config)?;
-    let url = url::Url::from_str("moqt://localhost:4434")?;
+    let url = url::Url::from_str("moqt://localhost:4433")?;
     let host = url.host_str().unwrap();
     let remote_address = (host, url.port().unwrap())
         .to_socket_addrs()?

--- a/examples/interop-moqtail-shaka/publisher/src/connection.ts
+++ b/examples/interop-moqtail-shaka/publisher/src/connection.ts
@@ -17,7 +17,7 @@ export async function createClient(opts?: {
 	onMessageSent?: MessageCallback;
 	onMessageReceived?: MessageCallback;
 }): Promise<MOQtailClient> {
-	const url = "https://localhost:4434";
+	const url = "https://localhost:4433";
 	const certHash = decodeCertHash(__CERT_HASH_BASE64__);
 	console.log("Connecting via WebTransport to", url);
 	console.log("Cert hash:", __CERT_HASH_BASE64__);

--- a/moqt/Cargo.toml
+++ b/moqt/Cargo.toml
@@ -15,7 +15,7 @@ tracing = "0.1.37"
 once_cell = "1.21.3"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 quinn = "0.11.8"
-wtransport = { version = "0.6.1", features = ["quinn"] }
+web-transport-quinn = { version = "0.11", default-features = false, features = ["ring"] }
 bytes = "1"
 async-trait = "0.1.74"
 ttl_cache = "0.5.1"
@@ -26,6 +26,7 @@ mockall="0.13.1"
 rustls-native-certs="0.8.1"
 rustls-pemfile="2.2.0"
 thiserror = "2.0.16"
+url = "2"
 
 [dev-dependencies]
 rcgen = "0.14.3"

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -35,6 +35,7 @@ pub use modules::moqt::domains::session::Session;
 pub use modules::moqt::domains::subscriber::Subscriber;
 pub use modules::moqt::domains::subscription::DataReceiver;
 pub use modules::moqt::domains::subscription::Subscription;
+pub use modules::moqt::protocol::DUAL;
 pub use modules::moqt::protocol::QUIC;
 pub use modules::moqt::protocol::TransportProtocol;
 pub use modules::moqt::protocol::WEBTRANSPORT;

--- a/moqt/src/modules/moqt/protocol.rs
+++ b/moqt/src/modules/moqt/protocol.rs
@@ -1,6 +1,10 @@
 use std::fmt::Debug;
 
 use crate::modules::transport::{
+    dual::{
+        dual_connection::DualConnection, dual_connection_creator::DualProtocolCreator,
+        dual_receive_stream::DualReceiveStream, dual_send_stream::DualSendStream,
+    },
     quic::{
         quic_connection::QUICConnection, quic_connection_creator::QUICConnectionCreator,
         quic_receive_stream::QUICReceiveStream, quic_send_stream::QUICSendStream,
@@ -45,4 +49,15 @@ impl TransportProtocol for WEBTRANSPORT {
     type Connection = WtConnection;
     type SendStream = WtSendStream;
     type ReceiveStream = WtReceiveStream;
+}
+
+#[allow(warnings)]
+#[derive(Debug)]
+pub struct DUAL;
+
+impl TransportProtocol for DUAL {
+    type ConnectionCreator = DualProtocolCreator;
+    type Connection = DualConnection;
+    type SendStream = DualSendStream;
+    type ReceiveStream = DualReceiveStream;
 }

--- a/moqt/src/modules/transport.rs
+++ b/moqt/src/modules/transport.rs
@@ -1,3 +1,4 @@
+pub(crate) mod dual;
 pub(crate) mod quic;
 pub(crate) mod read_error;
 pub(crate) mod transport_connection;

--- a/moqt/src/modules/transport/dual.rs
+++ b/moqt/src/modules/transport/dual.rs
@@ -1,0 +1,4 @@
+pub(crate) mod dual_connection;
+pub(crate) mod dual_connection_creator;
+pub(crate) mod dual_receive_stream;
+pub(crate) mod dual_send_stream;

--- a/moqt/src/modules/transport/dual/dual_connection.rs
+++ b/moqt/src/modules/transport/dual/dual_connection.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+
+use super::dual_receive_stream::DualReceiveStream;
+use super::dual_send_stream::DualSendStream;
+use crate::modules::transport::{
+    quic::quic_connection::QUICConnection, transport_connection::TransportConnection,
+    webtransport::wt_connection::WtConnection,
+};
+
+#[derive(Debug)]
+pub enum DualConnection {
+    Quic(QUICConnection),
+    WebTransport(Box<WtConnection>),
+}
+
+#[async_trait]
+impl TransportConnection for DualConnection {
+    type SendStream = DualSendStream;
+    type ReceiveStream = DualReceiveStream;
+
+    async fn open_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
+        match self {
+            DualConnection::Quic(c) => {
+                let (send, recv) = c.open_bi().await?;
+                Ok((DualSendStream::Quic(send), DualReceiveStream::Quic(recv)))
+            }
+            DualConnection::WebTransport(c) => {
+                let (send, recv) = c.open_bi().await?;
+                Ok((
+                    DualSendStream::WebTransport(send),
+                    DualReceiveStream::WebTransport(recv),
+                ))
+            }
+        }
+    }
+
+    async fn accept_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
+        match self {
+            DualConnection::Quic(c) => {
+                let (send, recv) = c.accept_bi().await?;
+                Ok((DualSendStream::Quic(send), DualReceiveStream::Quic(recv)))
+            }
+            DualConnection::WebTransport(c) => {
+                let (send, recv) = c.accept_bi().await?;
+                Ok((
+                    DualSendStream::WebTransport(send),
+                    DualReceiveStream::WebTransport(recv),
+                ))
+            }
+        }
+    }
+
+    async fn open_uni(&self) -> anyhow::Result<Self::SendStream> {
+        match self {
+            DualConnection::Quic(c) => Ok(DualSendStream::Quic(c.open_uni().await?)),
+            DualConnection::WebTransport(c) => {
+                Ok(DualSendStream::WebTransport(c.open_uni().await?))
+            }
+        }
+    }
+
+    async fn accept_uni(&self) -> anyhow::Result<Self::ReceiveStream> {
+        match self {
+            DualConnection::Quic(c) => Ok(DualReceiveStream::Quic(c.accept_uni().await?)),
+            DualConnection::WebTransport(c) => {
+                Ok(DualReceiveStream::WebTransport(c.accept_uni().await?))
+            }
+        }
+    }
+
+    fn send_datagram(&self, bytes: bytes::BytesMut) -> anyhow::Result<()> {
+        match self {
+            DualConnection::Quic(c) => c.send_datagram(bytes),
+            DualConnection::WebTransport(c) => c.send_datagram(bytes),
+        }
+    }
+
+    async fn receive_datagram(&self) -> anyhow::Result<bytes::BytesMut> {
+        match self {
+            DualConnection::Quic(c) => c.receive_datagram().await,
+            DualConnection::WebTransport(c) => c.receive_datagram().await,
+        }
+    }
+}

--- a/moqt/src/modules/transport/dual/dual_connection_creator.rs
+++ b/moqt/src/modules/transport/dual/dual_connection_creator.rs
@@ -1,0 +1,132 @@
+use std::{
+    fs::File,
+    io::BufReader,
+    net::{Ipv6Addr, SocketAddr},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use quinn::rustls::{
+    self,
+    pki_types::{PrivateKeyDer, pem::PemObject},
+};
+
+use super::dual_connection::DualConnection;
+use crate::modules::transport::{
+    quic::quic_connection::QUICConnection,
+    transport_connection_creator::TransportConnectionCreator,
+    webtransport::wt_connection::WtConnection,
+};
+
+pub struct DualProtocolCreator {
+    endpoint: quinn::Endpoint,
+}
+
+#[async_trait]
+impl TransportConnectionCreator for DualProtocolCreator {
+    type Connection = DualConnection;
+
+    fn client(_port_num: u16, _verify_certificate: bool) -> anyhow::Result<Self> {
+        anyhow::bail!("DualProtocolCreator does not support client mode")
+    }
+
+    fn client_with_custom_cert(_port_num: u16, _custom_cert_path: &str) -> anyhow::Result<Self> {
+        anyhow::bail!("DualProtocolCreator does not support client mode")
+    }
+
+    fn server(
+        cert_path: &str,
+        key_path: &str,
+        port_num: u16,
+        keep_alive_sec: u64,
+    ) -> anyhow::Result<Self> {
+        // 証明書を同期的に読み込む
+        let cert = rustls_pemfile::certs(&mut BufReader::new(
+            File::open(cert_path)
+                .inspect_err(|e| tracing::error!("Opening certificate file failed: {:?}", e))?,
+        ))
+        .collect::<Result<Vec<_>, _>>()
+        .inspect_err(|e| tracing::error!("Parsing certificates failed: {:?}", e))?;
+
+        // 秘密鍵を同期的に読み込む
+        let key = PrivateKeyDer::from_pem_file(key_path)
+            .inspect_err(|e| tracing::error!("Creating private key failed: {:?}", e.to_string()))?;
+
+        let mut server_crypto = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(cert, key)
+            .inspect_err(|e| tracing::error!("server config failed: {:?}", e.to_string()))?;
+
+        // ALPN を2つ登録（WebTransport + QUIC）
+        server_crypto.alpn_protocols = vec![
+            web_transport_quinn::ALPN.as_bytes().to_vec(), // h3
+            b"moq-00".to_vec(),
+        ];
+        server_crypto.key_log = Arc::new(rustls::KeyLogFile::new());
+
+        let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(
+            quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto)?,
+        ));
+        let mut transport_config = quinn::TransportConfig::default();
+        let keep_alive_sec = std::time::Duration::from_secs(keep_alive_sec);
+        transport_config.keep_alive_interval(Some(keep_alive_sec));
+        transport_config.max_concurrent_uni_streams(100000u32.into());
+        transport_config.send_window(64 * 1024);
+        transport_config.packet_threshold(5);
+        transport_config.stream_receive_window(quinn::VarInt::from_u32(1024 * 1024));
+
+        let transport_arc = Arc::new(transport_config);
+        server_config.transport_config(transport_arc);
+
+        let address = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port_num));
+        let endpoint = quinn::Endpoint::server(server_config, address)?;
+        tracing::info!("Server ready! for Dual Protocol: {:?}", address);
+
+        Ok(DualProtocolCreator { endpoint })
+    }
+
+    async fn create_new_transport(
+        &self,
+        _remote_address: SocketAddr,
+        _host: &str,
+    ) -> anyhow::Result<Self::Connection> {
+        anyhow::bail!("DualProtocolCreator does not support client mode")
+    }
+
+    async fn accept_new_transport(&mut self) -> anyhow::Result<Self::Connection> {
+        let incoming = self
+            .endpoint
+            .accept()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Endpoint is closing"))?;
+
+        let connection = incoming
+            .await
+            .inspect_err(|e| tracing::error!("failed to create connection: {:?}", e.to_string()))?;
+
+        // ALPN で分岐
+        let alpn = connection
+            .handshake_data()
+            .and_then(|data| data.downcast::<quinn::crypto::rustls::HandshakeData>().ok())
+            .and_then(|data| data.protocol)
+            .ok_or_else(|| anyhow::anyhow!("No ALPN protocol negotiated"))?;
+
+        if alpn.as_slice() == web_transport_quinn::ALPN.as_bytes() {
+            // WebTransport: H3 ハンドシェイクを行いセッションを確立する
+            let request = web_transport_quinn::Request::accept(connection)
+                .await
+                .inspect_err(|e| {
+                    tracing::error!("failed to accept WebTransport request: {:?}", e)
+                })?;
+            let session = request.ok().await.inspect_err(|e| {
+                tracing::error!("failed to establish WebTransport session: {:?}", e)
+            })?;
+            Ok(DualConnection::WebTransport(Box::new(WtConnection::new(session))))
+        } else if alpn.as_slice() == b"moq-00" {
+            // Raw QUIC
+            Ok(DualConnection::Quic(QUICConnection::new(connection)))
+        } else {
+            anyhow::bail!("Unsupported ALPN: {:?}", String::from_utf8_lossy(&alpn))
+        }
+    }
+}

--- a/moqt/src/modules/transport/dual/dual_connection_creator.rs
+++ b/moqt/src/modules/transport/dual/dual_connection_creator.rs
@@ -121,7 +121,9 @@ impl TransportConnectionCreator for DualProtocolCreator {
             let session = request.ok().await.inspect_err(|e| {
                 tracing::error!("failed to establish WebTransport session: {:?}", e)
             })?;
-            Ok(DualConnection::WebTransport(Box::new(WtConnection::new(session))))
+            Ok(DualConnection::WebTransport(Box::new(WtConnection::new(
+                session,
+            ))))
         } else if alpn.as_slice() == b"moq-00" {
             // Raw QUIC
             Ok(DualConnection::Quic(QUICConnection::new(connection)))

--- a/moqt/src/modules/transport/dual/dual_receive_stream.rs
+++ b/moqt/src/modules/transport/dual/dual_receive_stream.rs
@@ -1,0 +1,30 @@
+use std::task::Poll;
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+
+use crate::modules::transport::{
+    quic::quic_receive_stream::QUICReceiveStream, read_error::ReadError,
+    transport_receive_stream::TransportReceiveStream,
+    webtransport::wt_receive_stream::WtReceiveStream,
+};
+
+#[derive(Debug)]
+pub enum DualReceiveStream {
+    Quic(QUICReceiveStream),
+    WebTransport(WtReceiveStream),
+}
+
+#[async_trait]
+impl TransportReceiveStream for DualReceiveStream {
+    fn poll_read(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut BytesMut,
+    ) -> Poll<Result<usize, ReadError>> {
+        match self {
+            DualReceiveStream::Quic(s) => s.poll_read(cx, buf),
+            DualReceiveStream::WebTransport(s) => s.poll_read(cx, buf),
+        }
+    }
+}

--- a/moqt/src/modules/transport/dual/dual_send_stream.rs
+++ b/moqt/src/modules/transport/dual/dual_send_stream.rs
@@ -1,0 +1,30 @@
+use async_trait::async_trait;
+use bytes::BytesMut;
+
+use crate::modules::transport::{
+    quic::quic_send_stream::QUICSendStream, transport_send_stream::TransportSendStream,
+    webtransport::wt_send_stream::WtSendStream,
+};
+
+#[derive(Debug)]
+pub enum DualSendStream {
+    Quic(QUICSendStream),
+    WebTransport(WtSendStream),
+}
+
+#[async_trait]
+impl TransportSendStream for DualSendStream {
+    async fn send(&mut self, buffer: &BytesMut) -> anyhow::Result<()> {
+        match self {
+            DualSendStream::Quic(s) => s.send(buffer).await,
+            DualSendStream::WebTransport(s) => s.send(buffer).await,
+        }
+    }
+
+    async fn close(&mut self) -> anyhow::Result<()> {
+        match self {
+            DualSendStream::Quic(s) => s.close().await,
+            DualSendStream::WebTransport(s) => s.close().await,
+        }
+    }
+}

--- a/moqt/src/modules/transport/webtransport/wt_connection.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection.rs
@@ -6,12 +6,12 @@ use crate::modules::transport::transport_connection::TransportConnection;
 
 #[derive(Debug)]
 pub struct WtConnection {
-    connection: wtransport::Connection,
+    session: web_transport_quinn::Session,
 }
 
 impl WtConnection {
-    pub(crate) fn new(connection: wtransport::Connection) -> Self {
-        Self { connection }
+    pub(crate) fn new(session: web_transport_quinn::Session) -> Self {
+        Self { session }
     }
 }
 
@@ -21,59 +21,67 @@ impl TransportConnection for WtConnection {
     type ReceiveStream = WtReceiveStream;
 
     async fn open_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
-        let (send, recv) = self.connection.open_bi().await?.await?;
+        let (send, recv) = self.session.open_bi().await?;
+        let stable_id = self.session.stable_id();
+        let stream_id = send.quic_id().index();
         let send_stream = WtSendStream {
-            stable_id: self.connection.stable_id(),
-            stream_id: recv.id().into_u64(),
+            stable_id,
+            stream_id,
             send_stream: send,
         };
         let receive_stream = WtReceiveStream {
-            stable_id: self.connection.stable_id(),
-            stream_id: recv.id().into_u64(),
+            stable_id,
+            stream_id,
             recv_stream: recv,
         };
         Ok((send_stream, receive_stream))
     }
 
     async fn accept_bi(&self) -> anyhow::Result<(Self::SendStream, Self::ReceiveStream)> {
-        let (send, recv) = self.connection.accept_bi().await?;
+        let (send, recv) = self.session.accept_bi().await?;
+        let stable_id = self.session.stable_id();
+        let stream_id = send.quic_id().index();
         let send_stream = WtSendStream {
-            stable_id: self.connection.stable_id(),
-            stream_id: recv.id().into_u64(),
+            stable_id,
+            stream_id,
             send_stream: send,
         };
         let receive_stream = WtReceiveStream {
-            stable_id: self.connection.stable_id(),
-            stream_id: recv.id().into_u64(),
+            stable_id,
+            stream_id,
             recv_stream: recv,
         };
         Ok((send_stream, receive_stream))
     }
 
     async fn open_uni(&self) -> anyhow::Result<Self::SendStream> {
-        let send = self.connection.open_uni().await?.await?;
+        let send = self.session.open_uni().await?;
+        let stable_id = self.session.stable_id();
+        let stream_id = send.quic_id().index();
         Ok(WtSendStream {
-            stable_id: self.connection.stable_id(),
-            stream_id: send.id().into_u64(),
+            stable_id,
+            stream_id,
             send_stream: send,
         })
     }
 
     async fn accept_uni(&self) -> anyhow::Result<Self::ReceiveStream> {
-        let recv = self.connection.accept_uni().await?;
+        let recv = self.session.accept_uni().await?;
+        let stable_id = self.session.stable_id();
+        let stream_id = recv.quic_id().index();
         Ok(WtReceiveStream {
-            stable_id: self.connection.stable_id(),
-            stream_id: recv.id().into_u64(),
+            stable_id,
+            stream_id,
             recv_stream: recv,
         })
     }
 
     fn send_datagram(&self, bytes: bytes::BytesMut) -> anyhow::Result<()> {
-        Ok(self.connection.send_datagram(bytes)?)
+        Ok(self.session.send_datagram(bytes.freeze())?)
     }
 
     async fn receive_datagram(&self) -> anyhow::Result<bytes::BytesMut> {
-        match self.connection.receive_datagram().await {
+        match self.session.read_datagram().await {
             Ok(datagram) => Ok(bytes::BytesMut::from(&datagram[..])),
             Err(e) => {
                 tracing::error!("Failed to receive datagram: {:?}", e);

--- a/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
@@ -6,8 +6,8 @@ use super::wt_connection::WtConnection;
 use crate::modules::transport::transport_connection_creator::TransportConnectionCreator;
 
 enum WtEndpoint {
-    Server(wtransport::Endpoint<wtransport::endpoint::endpoint_side::Server>),
-    Client(wtransport::Endpoint<wtransport::endpoint::endpoint_side::Client>),
+    Server(tokio::sync::Mutex<web_transport_quinn::Server>),
+    Client(web_transport_quinn::Client),
 }
 
 pub struct WtConnectionCreator {
@@ -19,47 +19,24 @@ impl TransportConnectionCreator for WtConnectionCreator {
     type Connection = WtConnection;
 
     fn client(port_num: u16, verify_certificate: bool) -> anyhow::Result<Self> {
-        use wtransport::tls::rustls;
-
-        let tls_config = if verify_certificate {
-            let mut roots = rustls::RootCertStore::empty();
-            for cert in rustls_native_certs::load_native_certs().unwrap() {
-                roots.add(cert).unwrap();
-            }
-            rustls::ClientConfig::builder()
-                .with_root_certificates(roots)
-                .with_no_client_auth()
+        let client = if verify_certificate {
+            web_transport_quinn::ClientBuilder::new().with_system_roots()?
         } else {
-            // Currently quinn and wtransport share the same rustls version,
-            // so we reuse the QUIC SkipVerification to avoid duplication.
-            // If their rustls versions diverge, this may need a separate implementation.
-            rustls::ClientConfig::builder()
+            web_transport_quinn::ClientBuilder::new()
                 .dangerous()
-                .with_custom_certificate_verifier(std::sync::Arc::new(
-                    crate::modules::transport::quic::skip_certd_validation::SkipVerification,
-                ))
-                .with_no_client_auth()
+                .with_no_certificate_verification()?
         };
-        let mut tls_config = tls_config;
-        tls_config.alpn_protocols = vec![wtransport::tls::WEBTRANSPORT_ALPN.to_vec()];
 
-        let config = wtransport::ClientConfig::builder()
-            .with_bind_default()
-            .with_custom_tls(tls_config)
-            .build();
-
-        let endpoint = wtransport::Endpoint::client(config)?;
         tracing::info!("Client ready! for WebTransport port: {}", port_num);
 
         Ok(WtConnectionCreator {
-            endpoint: WtEndpoint::Client(endpoint),
+            endpoint: WtEndpoint::Client(client),
         })
     }
 
     fn client_with_custom_cert(port_num: u16, custom_cert_path: &str) -> anyhow::Result<Self> {
         use std::fs::File;
         use std::io::BufReader;
-        use wtransport::tls::rustls;
 
         // 証明書を読み込む
         let cert_file = File::open(custom_cert_path)
@@ -69,30 +46,13 @@ impl TransportConnectionCreator for WtConnectionCreator {
             .collect::<Result<Vec<_>, _>>()
             .inspect_err(|e| tracing::error!("Parsing certificate failed: {:?}", e))?;
 
-        // 自己署名証明書を信頼するrustls ClientConfigを作る
-        let mut roots = rustls::RootCertStore::empty();
-        for cert in certs {
-            roots
-                .add(cert)
-                .inspect_err(|e| tracing::error!("Adding certificate failed: {:?}", e))?;
-        }
-        let mut tls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_no_client_auth();
-        tls_config.alpn_protocols = vec![wtransport::tls::WEBTRANSPORT_ALPN.to_vec()];
+        // 自己署名証明書を信頼するクライアントを作る
+        let client = web_transport_quinn::ClientBuilder::new().with_server_certificates(certs)?;
 
-        // wtransportのクライアント設定を組み立てる
-        let config = wtransport::ClientConfig::builder()
-            .with_bind_default()
-            .with_custom_tls(tls_config)
-            .build();
-
-        // クライアントEndpointを作る
-        let endpoint = wtransport::Endpoint::client(config)?;
         tracing::info!("Client ready! for WebTransport port: {}", port_num);
 
         Ok(WtConnectionCreator {
-            endpoint: WtEndpoint::Client(endpoint),
+            endpoint: WtEndpoint::Client(client),
         })
     }
 
@@ -100,7 +60,7 @@ impl TransportConnectionCreator for WtConnectionCreator {
         cert_path: &str,
         key_path: &str,
         port_num: u16,
-        keep_alive_sec: u64,
+        _keep_alive_sec: u64,
     ) -> anyhow::Result<Self> {
         use std::fs::File;
         use std::io::BufReader;
@@ -109,9 +69,7 @@ impl TransportConnectionCreator for WtConnectionCreator {
         let cert_file = File::open(cert_path)
             .inspect_err(|e| tracing::error!("Opening certificate file failed: {:?}", e))?;
         let mut cert_reader = BufReader::new(cert_file);
-        let certs: Vec<wtransport::tls::Certificate> = rustls_pemfile::certs(&mut cert_reader)
-            .filter_map(|c| c.ok())
-            .map(|der| wtransport::tls::Certificate::from_der(der.as_ref().to_vec()))
+        let certs: Vec<_> = rustls_pemfile::certs(&mut cert_reader)
             .collect::<Result<Vec<_>, _>>()
             .inspect_err(|e| tracing::error!("Parsing certificates failed: {:?}", e))?;
 
@@ -119,25 +77,18 @@ impl TransportConnectionCreator for WtConnectionCreator {
         let key_file = File::open(key_path)
             .inspect_err(|e| tracing::error!("Opening key file failed: {:?}", e))?;
         let mut key_reader = BufReader::new(key_file);
-        let key_der = rustls_pemfile::private_key(&mut key_reader)?
+        let key = rustls_pemfile::private_key(&mut key_reader)?
             .ok_or_else(|| anyhow::anyhow!("No private key found"))?;
-        let private_key =
-            wtransport::tls::PrivateKey::from_der_pkcs8(key_der.secret_der().to_vec());
 
-        let identity =
-            wtransport::Identity::new(wtransport::tls::CertificateChain::new(certs), private_key);
+        let addr: SocketAddr = format!("[::]:{}", port_num).parse()?;
+        let server = web_transport_quinn::ServerBuilder::new()
+            .with_addr(addr)
+            .with_certificate(certs, key)?;
 
-        let config = wtransport::ServerConfig::builder()
-            .with_bind_default(port_num)
-            .with_identity(identity)
-            .keep_alive_interval(Some(std::time::Duration::from_secs(keep_alive_sec)))
-            .build();
-
-        let endpoint = wtransport::Endpoint::server(config)?;
         tracing::info!("Server ready! for WebTransport port: {}", port_num);
 
         Ok(WtConnectionCreator {
-            endpoint: WtEndpoint::Server(endpoint),
+            endpoint: WtEndpoint::Server(tokio::sync::Mutex::new(server)),
         })
     }
 
@@ -146,43 +97,41 @@ impl TransportConnectionCreator for WtConnectionCreator {
         remote_address: SocketAddr,
         host: &str,
     ) -> anyhow::Result<Self::Connection> {
-        let ep = match &self.endpoint {
-            WtEndpoint::Client(ep) => ep,
+        let client = match &self.endpoint {
+            WtEndpoint::Client(c) => c,
             WtEndpoint::Server(_) => {
                 anyhow::bail!("Cannot create_new_transport on a server endpoint")
             }
         };
-        let url = format!("https://{}:{}", host, remote_address.port());
+        let url: url::Url = format!("https://{}:{}", host, remote_address.port()).parse()?;
 
-        let connection = ep
+        let session = client
             .connect(url)
             .await
             .inspect_err(|e| tracing::error!("failed to connect: {:?}", e))?;
 
-        Ok(WtConnection::new(connection))
+        Ok(WtConnection::new(session))
     }
 
     async fn accept_new_transport(&mut self) -> anyhow::Result<Self::Connection> {
-        let ep = match &self.endpoint {
-            WtEndpoint::Server(ep) => ep,
+        let server = match &self.endpoint {
+            WtEndpoint::Server(s) => s,
             WtEndpoint::Client(_) => {
                 anyhow::bail!("Cannot accept_new_transport on a client endpoint")
             }
         };
-        // クライアントの接続を待つ
-        let incoming_session = ep.accept().await;
 
-        // セッションリクエストを待つ
-        let session_request = incoming_session
-            .await
-            .inspect_err(|e| tracing::error!("failed to accept session: {:?}", e))?;
+        // クライアントの接続を待つ
+        let Some(request) = server.lock().await.accept().await else {
+            anyhow::bail!("Server endpoint closed");
+        };
 
         // リクエストを受け入れてセッションを確立する
-        let connection = session_request
-            .accept()
+        let session = request
+            .ok()
             .await
-            .inspect_err(|e| tracing::error!("failed to establish connection: {:?}", e))?;
+            .inspect_err(|e| tracing::error!("failed to establish session: {:?}", e))?;
 
-        Ok(WtConnection::new(connection))
+        Ok(WtConnection::new(session))
     }
 }

--- a/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_receive_stream.rs
@@ -13,7 +13,7 @@ use crate::modules::transport::{
 pub struct WtReceiveStream {
     pub(crate) stable_id: usize,
     pub(crate) stream_id: u64,
-    pub(crate) recv_stream: wtransport::RecvStream,
+    pub(crate) recv_stream: web_transport_quinn::RecvStream,
 }
 
 #[async_trait]
@@ -34,7 +34,7 @@ impl TransportReceiveStream for WtReceiveStream {
                 std::io::ErrorKind::ConnectionReset => ReadError::Reset,
                 std::io::ErrorKind::ConnectionAborted => ReadError::ConnectionLost,
                 std::io::ErrorKind::UnexpectedEof => ReadError::Closed,
-                _ => todo!("handle other wtransport read errors: {:?}", e),
+                _ => todo!("handle other web-transport-quinn read errors: {:?}", e),
             })),
             Poll::Pending => Poll::Pending,
         }

--- a/moqt/src/modules/transport/webtransport/wt_send_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_send_stream.rs
@@ -8,7 +8,7 @@ use crate::modules::transport::transport_send_stream::TransportSendStream;
 pub struct WtSendStream {
     pub(crate) stable_id: usize,
     pub(crate) stream_id: u64,
-    pub(crate) send_stream: wtransport::SendStream,
+    pub(crate) send_stream: web_transport_quinn::SendStream,
 }
 
 #[async_trait]
@@ -18,6 +18,6 @@ impl TransportSendStream for WtSendStream {
     }
 
     async fn close(&mut self) -> anyhow::Result<()> {
-        Ok(self.send_stream.finish().await?)
+        Ok(self.send_stream.finish()?)
     }
 }

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -60,13 +60,10 @@ async fn main() -> anyhow::Result<()> {
     // RelayServerインスタンスを作成（リポジトリとイベントハンドラが内部で初期化される）
     let server = relay::RelayServer::new(&key_path, &cert_path);
 
-    // QUICサーバーを起動 (Port: 4434)
-    let _quic_handler = server.spawn_transport::<moqt::QUIC>(4434);
+    // QUIC + WebTransport を1ポートで起動
+    let _handler = server.spawn_transport::<moqt::DUAL>(4433);
 
-    // WebTransportサーバーを起動 (Port: 4433)
-    let _wt_handler = server.spawn_transport::<moqt::WEBTRANSPORT>(4433);
-
-    tracing::info!("Relay server started with QUIC (4434) and WebTransport (4433)");
+    tracing::info!("Relay server started with QUIC + WebTransport (4433)");
     tracing::info!("Ctrl+C to shutdown");
 
     tokio::signal::ctrl_c().await?;


### PR DESCRIPTION
## Summary
- `wtransport` を `web-transport-quinn` に置き換え
- `DualProtocolCreator` を導入し、1ポートで QUIC (moq-00) と WebTransport (h3) を ALPN 分岐で受け付けるようにした
- relay のポートを 4433 に統一

## 設計
- 既存の `TransportProtocol` トレイトに `DUAL` 型を追加
- `DualProtocolCreator` は1つの `quinn::Endpoint` を持ち、accept 後に ALPN で分岐
  - `h3` → `web_transport_quinn::Request::accept()` → `WtConnection`
  - `moq-00` → `QUICConnection`
- 既存の `QUICConnectionCreator` / `WtConnectionCreator` はクライアント用に残した

## 動作確認
- QUIC Publisher → DUAL Relay → QUIC Subscriber: 映像再生 OK
- QUIC Publisher → DUAL Relay → WebTransport Subscriber (ブラウザ): 映像再生 OK