### PR TITLE
fix: draft-14 control message length and example fixes

### DIFF
--- a/examples/cross-protocol-test/quic-subscriber/src/moqt_receiver.rs
+++ b/examples/cross-protocol-test/quic-subscriber/src/moqt_receiver.rs
@@ -73,47 +73,49 @@ pub async fn subscribe_and_receive(namespace: &str, track_name: &str) -> Result<
 
     match receiver {
         moqt::DataReceiver::Stream(mut factory) => {
-            let mut stream = factory
-                .next()
-                .await
-                .context("failed to get initial stream")?;
             let stdout = std::io::stdout();
             let mut out = stdout.lock();
             let mut init_written = false;
-            let mut object_id: u64 = 0;
-            loop {
-                let result = match stream.receive().await {
-                    Ok(r) => r,
+            'outer: loop {
+                let mut stream = match factory.next().await {
+                    Ok(s) => s,
                     Err(e) => {
-                        tracing::error!("receive error: {}", e);
-                        break;
+                        tracing::error!("factory.next error: {}", e);
+                        break 'outer;
                     }
                 };
-                match result {
-                    Subgroup::Header(header) => {
-                        info!(group_id = header.group_id, "received subgroup header");
-                        object_id = 0;
-                    }
-                    Subgroup::Object(field) => {
-                        let current_object_id = object_id;
-                        object_id += 1;
-                        match field.subgroup_object {
-                            SubgroupObject::Payload { data, .. } => {
-                                // Object 0 は init segment。初回のみ書き出す
-                                if current_object_id == 0 {
-                                    if !init_written {
-                                        info!(size = data.len(), "writing init segment");
-                                        out.write_all(&data)?;
-                                        out.flush()?;
-                                        init_written = true;
+                let mut object_id: u64 = 0;
+                loop {
+                    let result = match stream.receive().await {
+                        Ok(r) => r,
+                        Err(_) => break,
+                    };
+                    match result {
+                        Subgroup::Header(header) => {
+                            info!(group_id = header.group_id, "received subgroup header");
+                            object_id = 0;
+                        }
+                        Subgroup::Object(field) => {
+                            let current_object_id = object_id;
+                            object_id += 1;
+                            match field.subgroup_object {
+                                SubgroupObject::Payload { data, .. } => {
+                                    // Object 0 は init segment。初回のみ書き出す
+                                    if current_object_id == 0 {
+                                        if !init_written {
+                                            info!(size = data.len(), "writing init segment");
+                                            out.write_all(&data)?;
+                                            out.flush()?;
+                                            init_written = true;
+                                        }
+                                        continue;
                                     }
-                                    continue;
+                                    out.write_all(&data)?;
+                                    out.flush()?;
                                 }
-                                out.write_all(&data)?;
-                                out.flush()?;
-                            }
-                            SubgroupObject::Status { code, .. } => {
-                                info!(code, "received status object");
+                                SubgroupObject::Status { code, .. } => {
+                                    info!(code, "received status object");
+                                }
                             }
                         }
                     }

--- a/examples/interop-moqtail-shaka/subscriber/index.html
+++ b/examples/interop-moqtail-shaka/subscriber/index.html
@@ -92,7 +92,7 @@
 
         log('Loading...');
         await player.load(
-          'https://127.0.0.1:4434',
+          'https://127.0.0.1:4433',
           /* startTime= */ undefined,
           'application/msf',
         );

--- a/moqt/src/wire.rs
+++ b/moqt/src/wire.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use bytes::{Buf, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use std::io::Cursor;
 
 pub use crate::modules::extensions::buf_get_ext::BufGetExt;
@@ -42,7 +42,8 @@ pub type SubscribeError = RequestError;
 pub fn encode_control_message(message_type: ControlMessageType, payload: BytesMut) -> BytesMut {
     let mut buf = BytesMut::new();
     buf.put_varint(u8::from(message_type) as u64);
-    buf.put_varint(payload.len() as u64);
+    // draft-14: Message Length is 16-bit fixed
+    buf.put_u16(payload.len() as u16);
     buf.unsplit(payload);
     buf
 }
@@ -55,7 +56,8 @@ pub fn take_control_message(
         Ok(value) => value,
         Err(_) => return Ok(None),
     };
-    let payload_length = match cursor.try_get_varint() {
+    // draft-14: Message Length is 16-bit fixed
+    let payload_length = match cursor.try_get_u16() {
         Ok(value) => value as usize,
         Err(_) => return Ok(None),
     };


### PR DESCRIPTION
## 概要

moqt の Control Message の wire format が draft-14 に追従しておらず、
moqtail (JS) や Shaka Player との CLIENT_SETUP で失敗する。これを
修正した。あわせて examples の軽微なバグも 2 件修正した。

## 1. `moqt`: Control Message Length を 16-bit 固定に

https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9

draft-14 では Control Message の Message Length は下記の通り 16-bit 固定。

```
MOQT Control Message {
  Message Type (i),
  Message Length (16),
  Message Payload (..),
}
```

moqt は varint で encode/decode していたので、修正した。

## 2. examples

- `cross-protocol-test/quic-subscriber`: 最初の uni stream しか accept できていなかったので、loop で全 group 受信するよう修正。
- `interop-moqtail-shaka/subscriber`: 4434 → 4433 (single-port relay 追従)

## 動作確認

`examples/cross-protocol-test`
- rust publisher (QUIC) → relay → rust quic-subscriber (QUIC): fMP4 を ffplay で再生できることを確認
- rust publisher (QUIC) → relay → moqtail browser-subscriber (WebTransport): ブラウザで再生できることを確認

`examples/interop-moqtail-shaka`
- moqtail browser publisher → relay → Shaka Player subscriber: ブラウザで再生できることを確認