### PR TITLE
feat: implement Standalone Fetch (draft-14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,6 +1808,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fetch-e2e"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "moqt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "ffmpeg-next"
 version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     'moqt',
     'relay',
     'examples/rust/manual-client',
+    'examples/rust/fetch-e2e',
     'examples/cross-protocol-test/publisher',
     'examples/cross-protocol-test/quic-subscriber',
     'bindings/wasm',

--- a/bridges/live-ingest/src/moqt.rs
+++ b/bridges/live-ingest/src/moqt.rs
@@ -381,6 +381,9 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                             handler.track_namespace, handler.track_name
                         );
                     }
+                    SessionEvent::Fetch(_) => {
+                        todo!()
+                    }
                 }
             }
         })

--- a/bridges/onvif/src/bin/moqt-onvif-client.rs
+++ b/bridges/onvif/src/bin/moqt-onvif-client.rs
@@ -466,6 +466,9 @@ async fn handle_session_event(
                 .await;
             Ok(None)
         }
+        SessionEvent::Fetch(_) => {
+            todo!()
+        }
     }
 }
 

--- a/examples/rust/fetch-e2e/Cargo.toml
+++ b/examples/rust/fetch-e2e/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fetch-e2e"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+moqt = { path = "../../../moqt" }
+tokio = { version = "1.45.0", features = ["full", "tracing"] }
+tracing = "0.1.37"
+anyhow = { version = "1.0.75", features = ["backtrace"] }
+url = "2.5.7"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/examples/rust/fetch-e2e/SCENARIO.md
+++ b/examples/rust/fetch-e2e/SCENARIO.md
@@ -1,0 +1,40 @@
+# Fetch E2E Scenario
+
+## Flow
+
+```
+alice: publish_namespace("room/alice")
+bob:   subscribe("room/alice", "data")
+alice: [Subscribe event] → subscribe_ok → publish group 0, 1, 2
+bob:   receive live stream, track group_id
+bob:   first object of group 2 received
+         → relay has cached group 0 and 1 for sure
+         → issue fetch A, B, C
+```
+
+## Published Data
+
+| Group | Objects       |
+|-------|---------------|
+| 0     | 0, 1, 2, 3, 4 |
+| 1     | 0, 1, 2, 3, 4 |
+| 2     | 0, 1, 2, 3, 4 |
+
+Payload: `"g{group}:o{object}"`
+
+## Fetch Cases
+
+### A: start to middle
+- start: `{group:0, obj:0}`
+- end:   `{group:1, obj:2}`
+- expected: g0/o0-4, g1/o0-2 (8 objects)
+
+### B: middle to middle
+- start: `{group:1, obj:2}`
+- end:   `{group:2, obj:3}`
+- expected: g1/o2-4, g2/o0-3 (7 objects)
+
+### C: entire group (end.obj=0 means no upper bound)
+- start: `{group:1, obj:0}`
+- end:   `{group:1, obj:0}`
+- expected: g1/o0-4 (5 objects)

--- a/examples/rust/fetch-e2e/src/main.rs
+++ b/examples/rust/fetch-e2e/src/main.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 
 use moqt::{
     ContentExists, DataReceiver, Endpoint, ExtensionHeaders, Fetch, FetchDataReceiver, FetchObject,
-    FetchOption, FilterType, GroupOrder, Location, Session, StreamDataReceiverFactory,
-    StreamDataSenderFactory, Subgroup, SubgroupId, SubgroupObject, SubscribeOption, QUIC,
+    FetchOption, FilterType, GroupOrder, Location, QUIC, Session, StreamDataReceiverFactory,
+    StreamDataSenderFactory, Subgroup, SubgroupId, SubgroupObject, SubscribeOption,
 };
 
 const RELAY_URL: &str = "moqt://localhost:4433";
@@ -23,7 +23,7 @@ async fn new_session(cert_path: &str) -> anyhow::Result<Session<QUIC>> {
         .unwrap();
     let endpoint = Endpoint::<QUIC>::create_client_with_custom_cert(0, cert_path)?;
     let connecting = endpoint.connect(remote, host).await?;
-    Ok(connecting.await?)
+    connecting.await
 }
 
 async fn send_group(factory: &StreamDataSenderFactory<QUIC>, group_id: u64) -> anyhow::Result<()> {
@@ -54,7 +54,10 @@ async fn run_fetch(
 ) -> anyhow::Result<()> {
     tracing::info!(
         "[bob] fetching g{}:o{}..g{}:o{}",
-        start.group_id, start.object_id, end.group_id, end.object_id
+        start.group_id,
+        start.object_id,
+        end.group_id,
+        end.object_id
     );
     let handle = subscriber
         .fetch(
@@ -79,14 +82,21 @@ async fn run_fetch(
             Ok(Fetch::End) => {
                 tracing::info!(
                     "[bob] fetch done g{}:o{}..g{}:o{}",
-                    start.group_id, start.object_id, end.group_id, end.object_id
+                    start.group_id,
+                    start.object_id,
+                    end.group_id,
+                    end.object_id
                 );
                 break;
             }
             Err(e) => {
                 tracing::info!(
                     "[bob] fetch done (error) g{}:o{}..g{}:o{}: {}",
-                    start.group_id, start.object_id, end.group_id, end.object_id, e
+                    start.group_id,
+                    start.object_id,
+                    end.group_id,
+                    end.object_id,
+                    e
                 );
                 break;
             }
@@ -144,7 +154,10 @@ async fn bob(cert_path: String) -> anyhow::Result<()> {
             },
         )
         .await?;
-    tracing::info!("[bob] subscribe ok, track_alias={}", subscription.track_alias);
+    tracing::info!(
+        "[bob] subscribe ok, track_alias={}",
+        subscription.track_alias
+    );
 
     let data_receiver = subscriber.accept_data_receiver(&subscription).await?;
     let mut factory: StreamDataReceiverFactory<QUIC> = match data_receiver {
@@ -172,11 +185,44 @@ async fn bob(cert_path: String) -> anyhow::Result<()> {
     tracing::info!("[bob] detect done, issuing fetches");
 
     // fetch A: g0/o0 .. g1/o2 (8 objects)
-    run_fetch(&mut subscriber, Location { group_id: 0, object_id: 0 }, Location { group_id: 1, object_id: 2 }).await?;
+    run_fetch(
+        &mut subscriber,
+        Location {
+            group_id: 0,
+            object_id: 0,
+        },
+        Location {
+            group_id: 1,
+            object_id: 2,
+        },
+    )
+    .await?;
     // fetch B: g1/o2 .. g2/o3 (7 objects)
-    run_fetch(&mut subscriber, Location { group_id: 1, object_id: 2 }, Location { group_id: 2, object_id: 3 }).await?;
+    run_fetch(
+        &mut subscriber,
+        Location {
+            group_id: 1,
+            object_id: 2,
+        },
+        Location {
+            group_id: 2,
+            object_id: 3,
+        },
+    )
+    .await?;
     // fetch C: g1/o0 .. g1/o0 = entire group 1 (5 objects)
-    run_fetch(&mut subscriber, Location { group_id: 1, object_id: 0 }, Location { group_id: 1, object_id: 0 }).await?;
+    run_fetch(
+        &mut subscriber,
+        Location {
+            group_id: 1,
+            object_id: 0,
+        },
+        Location {
+            group_id: 1,
+            object_id: 0,
+        },
+    )
+    .await?;
 
     tracing::info!("[bob] all done");
     Ok(())

--- a/examples/rust/fetch-e2e/src/main.rs
+++ b/examples/rust/fetch-e2e/src/main.rs
@@ -1,0 +1,208 @@
+use std::net::ToSocketAddrs;
+use std::str::FromStr;
+
+use moqt::{
+    ContentExists, DataReceiver, Endpoint, ExtensionHeaders, Fetch, FetchDataReceiver, FetchObject,
+    FetchOption, FilterType, GroupOrder, Location, Session, StreamDataReceiverFactory,
+    StreamDataSenderFactory, Subgroup, SubgroupId, SubgroupObject, SubscribeOption, QUIC,
+};
+
+const RELAY_URL: &str = "moqt://localhost:4433";
+const NAMESPACE: &str = "room/alice";
+const TRACK_NAME: &str = "data";
+const PUBLISHER_PRIORITY: u8 = 128;
+const GROUPS: u64 = 3;
+const OBJECTS_PER_GROUP: u64 = 5;
+
+async fn new_session(cert_path: &str) -> anyhow::Result<Session<QUIC>> {
+    let url = url::Url::from_str(RELAY_URL).unwrap();
+    let host = url.host_str().unwrap();
+    let remote = (host, url.port().unwrap_or(4433))
+        .to_socket_addrs()?
+        .next()
+        .unwrap();
+    let endpoint = Endpoint::<QUIC>::create_client_with_custom_cert(0, cert_path)?;
+    let connecting = endpoint.connect(remote, host).await?;
+    Ok(connecting.await?)
+}
+
+async fn send_group(factory: &StreamDataSenderFactory<QUIC>, group_id: u64) -> anyhow::Result<()> {
+    let sender = factory.next().await?;
+    let header = sender.create_header(group_id, SubgroupId::None, PUBLISHER_PRIORITY, false, false);
+    let mut stream = sender.send_header(header).await?;
+    for obj_id in 0..OBJECTS_PER_GROUP {
+        let payload = format!("g{}:o{}", group_id, obj_id);
+        let obj = stream.create_object_field(
+            0,
+            ExtensionHeaders {
+                prior_group_id_gap: vec![],
+                prior_object_id_gap: vec![],
+                immutable_extensions: vec![],
+            },
+            SubgroupObject::new_payload(payload.into()),
+        );
+        stream.send(obj).await?;
+        tracing::info!("[alice] sent g{}:o{}", group_id, obj_id);
+    }
+    stream.close().await
+}
+
+async fn run_fetch(
+    subscriber: &mut moqt::Subscriber<QUIC>,
+    start: Location,
+    end: Location,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        "[bob] fetching g{}:o{}..g{}:o{}",
+        start.group_id, start.object_id, end.group_id, end.object_id
+    );
+    let handle = subscriber
+        .fetch(
+            NAMESPACE.to_string(),
+            TRACK_NAME.to_string(),
+            start,
+            end,
+            FetchOption::default(),
+        )
+        .await?;
+    let mut receiver: FetchDataReceiver<QUIC> = subscriber.accept_fetch_receiver(&handle).await?;
+    loop {
+        match receiver.receive().await {
+            Ok(Fetch::Header(_)) => {}
+            Ok(Fetch::Object(obj)) => {
+                let payload = match &obj.fetch_object {
+                    FetchObject::Payload(b) => String::from_utf8_lossy(b).to_string(),
+                    FetchObject::Status(s) => format!("{:?}", s),
+                };
+                tracing::info!("[bob] g{}:o{} = {}", obj.group_id, obj.object_id, payload);
+            }
+            Ok(Fetch::End) => {
+                tracing::info!(
+                    "[bob] fetch done g{}:o{}..g{}:o{}",
+                    start.group_id, start.object_id, end.group_id, end.object_id
+                );
+                break;
+            }
+            Err(e) => {
+                tracing::info!(
+                    "[bob] fetch done (error) g{}:o{}..g{}:o{}: {}",
+                    start.group_id, start.object_id, end.group_id, end.object_id, e
+                );
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn alice(cert_path: String) -> anyhow::Result<()> {
+    let session = new_session(&cert_path).await?;
+    session
+        .publisher()
+        .publish_namespace(NAMESPACE.to_string())
+        .await?;
+    tracing::info!("[alice] publish_namespace ok");
+
+    loop {
+        match session.receive_event().await? {
+            moqt::SessionEvent::Subscribe(handler) => {
+                tracing::info!(
+                    "[alice] received Subscribe for {}/{}",
+                    handler.track_namespace,
+                    handler.track_name
+                );
+                let track_alias = handler.ok(0, ContentExists::False).await?;
+                let publication = handler.into_publication(track_alias);
+                let factory = session.publisher().create_stream(&publication);
+                for group_id in 0..GROUPS {
+                    send_group(&factory, group_id).await?;
+                }
+                tracing::info!("[alice] all groups published");
+            }
+            moqt::SessionEvent::Disconnected() => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+async fn bob(cert_path: String) -> anyhow::Result<()> {
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let session = new_session(&cert_path).await?;
+
+    let mut subscriber = session.subscriber();
+    let subscription = subscriber
+        .subscribe(
+            NAMESPACE.to_string(),
+            TRACK_NAME.to_string(),
+            SubscribeOption {
+                subscriber_priority: 128,
+                group_order: GroupOrder::Ascending,
+                forward: true,
+                filter_type: FilterType::LargestObject,
+            },
+        )
+        .await?;
+    tracing::info!("[bob] subscribe ok, track_alias={}", subscription.track_alias);
+
+    let data_receiver = subscriber.accept_data_receiver(&subscription).await?;
+    let mut factory: StreamDataReceiverFactory<QUIC> = match data_receiver {
+        DataReceiver::Stream(f) => f,
+        DataReceiver::Datagram(_) => anyhow::bail!("[bob] unexpected datagram"),
+    };
+
+    'detect: loop {
+        let mut stream = factory.next().await?;
+        loop {
+            match stream.receive().await {
+                Ok(Subgroup::Header(h)) => {
+                    tracing::info!("[bob] live group_id={}", h.group_id);
+                    if h.group_id >= 2 {
+                        tracing::info!("[bob] group 2 detected, relay cache ready");
+                        break 'detect;
+                    }
+                }
+                Ok(Subgroup::Object(_)) => {}
+                Err(_) => break, // stream ended, move to next group
+            }
+        }
+    }
+
+    tracing::info!("[bob] detect done, issuing fetches");
+
+    // fetch A: g0/o0 .. g1/o2 (8 objects)
+    run_fetch(&mut subscriber, Location { group_id: 0, object_id: 0 }, Location { group_id: 1, object_id: 2 }).await?;
+    // fetch B: g1/o2 .. g2/o3 (7 objects)
+    run_fetch(&mut subscriber, Location { group_id: 1, object_id: 2 }, Location { group_id: 2, object_id: 3 }).await?;
+    // fetch C: g1/o0 .. g1/o0 = entire group 1 (5 objects)
+    run_fetch(&mut subscriber, Location { group_id: 1, object_id: 0 }, Location { group_id: 1, object_id: 0 }).await?;
+
+    tracing::info!("[bob] all done");
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_line_number(true)
+        .try_init()
+        .ok();
+
+    let cert_path = format!(
+        "{}/relay/keys/cert.pem",
+        std::env::current_dir()?.to_str().unwrap()
+    );
+
+    let alice_handle = tokio::spawn(alice(cert_path.clone()));
+    let bob_handle = tokio::spawn(bob(cert_path));
+
+    tokio::select! {
+        r = alice_handle => { r??; }
+        r = bob_handle => { r??; }
+        _ = tokio::signal::ctrl_c() => {}
+    }
+
+    Ok(())
+}

--- a/examples/rust/manual-client/src/client.rs
+++ b/examples/rust/manual-client/src/client.rs
@@ -129,6 +129,9 @@ impl<T: TransportProtocol> Client<T> {
                         moqt::SessionEvent::ProtocolViolation() => {
                             tracing::info!("Received: {} ProtocolViolation", _label);
                         }
+                        moqt::SessionEvent::Fetch(_) => {
+                            todo!()
+                        }
                     };
                 }
             })

--- a/examples/rust/manual-client/src/client.rs
+++ b/examples/rust/manual-client/src/client.rs
@@ -130,7 +130,7 @@ impl<T: TransportProtocol> Client<T> {
                             tracing::info!("Received: {} ProtocolViolation", _label);
                         }
                         moqt::SessionEvent::Fetch(_) => {
-                            todo!()
+                            tracing::info!("Received: {} Fetch", _label);
                         }
                     };
                 }

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -18,6 +18,8 @@ pub use modules::moqt::control_plane::handler::subscribe_namespace_handler::Subs
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::control_plane::handler::unsubscribe_handler::UnsubscribeHandler;
 #[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::control_plane::options::FetchOption;
+#[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::control_plane::options::PublishOption;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::control_plane::options::SubscribeOption;
@@ -34,6 +36,10 @@ pub use modules::moqt::data_plane::object::subgroup::SubgroupHeaderType;
 pub use modules::moqt::data_plane::object::subgroup::SubgroupId;
 pub use modules::moqt::data_plane::object::subgroup::SubgroupObject;
 pub use modules::moqt::data_plane::object::subgroup::SubgroupObjectField;
+#[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::data_plane::stream::fetch_data_receiver::Fetch;
+#[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::data_plane::stream::fetch_data_receiver::FetchDataReceiver;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::data_plane::stream::stream_data_receiver::StreamDataReceiver;
 #[cfg(not(target_arch = "wasm32"))]
@@ -60,6 +66,8 @@ pub use modules::moqt::domains::endpoint::ClientConfig;
 pub use modules::moqt::domains::endpoint::Endpoint;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::endpoint::ServerConfig;
+#[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::domains::fetch_handle::FetchHandle;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::published_resource::PublishedResource;
 #[cfg(not(target_arch = "wasm32"))]

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -8,6 +8,8 @@ pub use modules::moqt::control_plane::control_messages::messages::parameters::lo
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::control_plane::enums::SessionEvent;
 #[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::control_plane::handler::fetch_handler::FetchHandler;
+#[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::control_plane::handler::publish_handler::PublishHandler;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::control_plane::handler::publish_namespace_handler::PublishNamespaceHandler;
@@ -30,7 +32,13 @@ pub use modules::moqt::data_plane::datagram::datagram_sender::DatagramSender;
 pub use modules::moqt::data_plane::object::datagram_field::DatagramField;
 pub use modules::moqt::data_plane::object::datagram_field::ObjectDatagramPayload;
 pub use modules::moqt::data_plane::object::extension_headers::ExtensionHeaders;
+#[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::data_plane::object::fetch::FetchObject;
+#[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::data_plane::object::fetch::FetchObjectField;
 pub use modules::moqt::data_plane::object::object_datagram::ObjectDatagram;
+#[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::data_plane::object::object_status::ObjectStatus;
 pub use modules::moqt::data_plane::object::subgroup::SubgroupHeader;
 pub use modules::moqt::data_plane::object::subgroup::SubgroupHeaderType;
 pub use modules::moqt::data_plane::object::subgroup::SubgroupId;
@@ -40,6 +48,8 @@ pub use modules::moqt::data_plane::object::subgroup::SubgroupObjectField;
 pub use modules::moqt::data_plane::stream::fetch_data_receiver::Fetch;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::data_plane::stream::fetch_data_receiver::FetchDataReceiver;
+#[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::data_plane::stream::fetch_data_sender::FetchDataSender;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::data_plane::stream::stream_data_receiver::StreamDataReceiver;
 #[cfg(not(target_arch = "wasm32"))]

--- a/moqt/src/modules/moqt/control_plane/control_messages/messages.rs
+++ b/moqt/src/modules/moqt/control_plane/control_messages/messages.rs
@@ -1,4 +1,6 @@
 pub mod client_setup;
+pub mod fetch;
+pub mod fetch_ok;
 pub mod go_away;
 pub mod namespace_ok;
 pub mod parameters;

--- a/moqt/src/modules/moqt/control_plane/control_messages/messages/fetch.rs
+++ b/moqt/src/modules/moqt/control_plane/control_messages/messages/fetch.rs
@@ -1,0 +1,465 @@
+use bytes::{Buf, BufMut, BytesMut};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use crate::modules::{
+    extensions::{buf_get_ext::BufGetExt, buf_put_ext::BufPutExt, result_ext::ResultExt},
+    moqt::control_plane::control_messages::{
+        key_value_pair::{KeyValuePair, VariantType},
+        messages::parameters::{
+            authorization_token::AuthorizationToken, group_order::GroupOrder, location::Location,
+        },
+    },
+};
+
+// https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.16
+//
+// Standalone Fetch {
+//   Track Namespace (tuple),
+//   Track Name Length (i),
+//   Track Name (..),
+//   Start Location (Location),
+//   End Location (Location)
+// }
+//
+// Joining Fetch {
+//   Joining Request ID (i),
+//   Joining Start (i)
+// }
+
+#[derive(Debug, Clone, TryFromPrimitive, IntoPrimitive)]
+#[repr(u64)]
+enum FetchTypeValue {
+    Standalone = 0x1,
+    RelativeJoining = 0x2,
+    AbsoluteJoining = 0x3,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FetchType {
+    Standalone {
+        track_namespace: Vec<String>,
+        track_name: String,
+        start_location: Location,
+        end_location: Location,
+    },
+    RelativeJoining {
+        joining_request_id: u64,
+        joining_start: u64,
+    },
+    AbsoluteJoining {
+        joining_request_id: u64,
+        joining_start: u64,
+    },
+}
+
+impl FetchType {
+    fn decode(buf: &mut std::io::Cursor<&[u8]>) -> Option<Self> {
+        let fetch_type_value = buf.try_get_varint().log_context("fetch type").ok()?;
+        let fetch_type = FetchTypeValue::try_from(fetch_type_value)
+            .log_context("fetch type value")
+            .ok()?;
+        match fetch_type {
+            FetchTypeValue::Standalone => {
+                let namespace_length = buf.try_get_varint().log_context("namespace length").ok()?;
+                let mut track_namespace = Vec::new();
+                for _ in 0..namespace_length {
+                    let ns = buf.try_get_string().log_context("namespace").ok()?;
+                    track_namespace.push(ns);
+                }
+                let track_name = buf.try_get_string().log_context("track name").ok()?;
+                let start_location = Location::decode(buf)?;
+                let end_location = Location::decode(buf)?;
+                Some(FetchType::Standalone {
+                    track_namespace,
+                    track_name,
+                    start_location,
+                    end_location,
+                })
+            }
+            FetchTypeValue::RelativeJoining => {
+                let joining_request_id = buf
+                    .try_get_varint()
+                    .log_context("joining request id")
+                    .ok()?;
+                let joining_start = buf.try_get_varint().log_context("joining start").ok()?;
+                Some(FetchType::RelativeJoining {
+                    joining_request_id,
+                    joining_start,
+                })
+            }
+            FetchTypeValue::AbsoluteJoining => {
+                let joining_request_id = buf
+                    .try_get_varint()
+                    .log_context("joining request id")
+                    .ok()?;
+                let joining_start = buf.try_get_varint().log_context("joining start").ok()?;
+                Some(FetchType::AbsoluteJoining {
+                    joining_request_id,
+                    joining_start,
+                })
+            }
+        }
+    }
+
+    fn encode(&self) -> BytesMut {
+        let mut payload = BytesMut::new();
+        match self {
+            FetchType::Standalone {
+                track_namespace,
+                track_name,
+                start_location,
+                end_location,
+            } => {
+                payload.put_varint(FetchTypeValue::Standalone as u64);
+                payload.put_varint(track_namespace.len() as u64);
+                for ns in track_namespace {
+                    payload.put_string(ns);
+                }
+                payload.put_string(track_name);
+                payload.unsplit(start_location.encode());
+                payload.unsplit(end_location.encode());
+            }
+            FetchType::RelativeJoining {
+                joining_request_id,
+                joining_start,
+            } => {
+                payload.put_varint(FetchTypeValue::RelativeJoining as u64);
+                payload.put_varint(*joining_request_id);
+                payload.put_varint(*joining_start);
+            }
+            FetchType::AbsoluteJoining {
+                joining_request_id,
+                joining_start,
+            } => {
+                payload.put_varint(FetchTypeValue::AbsoluteJoining as u64);
+                payload.put_varint(*joining_request_id);
+                payload.put_varint(*joining_start);
+            }
+        }
+        payload
+    }
+}
+
+// https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.16
+//
+// FETCH Message {
+//   Type (i) = 0x16,
+//   Length (16),
+//   Request ID (i),
+//   Subscriber Priority (8),
+//   Group Order (8),
+//   Fetch Type (i),
+//   [Standalone (Standalone Fetch)],
+//   [Joining (Joining Fetch)],
+//   Number of Parameters (i),
+//   Parameters (..) ...
+// }
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Fetch {
+    pub request_id: u64,
+    pub subscriber_priority: u8,
+    pub group_order: GroupOrder,
+    pub fetch_type: FetchType,
+    pub authorization_tokens: Vec<AuthorizationToken>,
+}
+
+impl Fetch {
+    pub fn decode(buf: &mut std::io::Cursor<&[u8]>) -> Option<Self> {
+        let request_id = buf.try_get_varint().log_context("request id").ok()?;
+        let subscriber_priority = buf.try_get_u8().log_context("subscriber priority").ok()?;
+        let group_order_u8 = buf.try_get_u8().log_context("group order u8").ok()?;
+        let group_order = GroupOrder::try_from(group_order_u8)
+            .log_context("group order")
+            .ok()?;
+        let fetch_type = FetchType::decode(buf)?;
+        let number_of_parameters = buf
+            .try_get_varint()
+            .log_context("number of parameters")
+            .ok()?;
+        let mut parameters = vec![];
+        for _ in 0..number_of_parameters {
+            let kv = KeyValuePair::decode(buf)?;
+            parameters.push(kv);
+        }
+        let authorization_tokens = parameters
+            .iter()
+            .filter(|kv| kv.key == 0x03)
+            .filter_map(|kv| match &kv.value {
+                VariantType::Odd(value) => {
+                    let mut cursor = std::io::Cursor::new(&value[..]);
+                    AuthorizationToken::decode(&mut cursor)
+                }
+                VariantType::Even(_) => unreachable!(),
+            })
+            .collect();
+        Some(Fetch {
+            request_id,
+            subscriber_priority,
+            group_order,
+            fetch_type,
+            authorization_tokens,
+        })
+    }
+
+    pub fn encode(&self) -> BytesMut {
+        let mut payload = BytesMut::new();
+        payload.put_varint(self.request_id);
+        payload.put_u8(self.subscriber_priority);
+        payload.put_u8(self.group_order as u8);
+        payload.unsplit(self.fetch_type.encode());
+        let mut number_of_parameters = 0;
+        let mut parameters_payload = BytesMut::new();
+        for token in &self.authorization_tokens {
+            let token_payload = KeyValuePair {
+                key: 0x03,
+                value: VariantType::Odd(token.encode().freeze()),
+            }
+            .encode();
+            parameters_payload.unsplit(token_payload);
+            number_of_parameters += 1;
+        }
+        payload.put_varint(number_of_parameters);
+        payload.unsplit(parameters_payload);
+        payload
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod success {
+        use super::super::*;
+
+        #[test]
+        fn standalone_round_trip() {
+            let fetch = Fetch {
+                request_id: 1,
+                subscriber_priority: 0,
+                group_order: GroupOrder::Ascending,
+                fetch_type: FetchType::Standalone {
+                    track_namespace: vec!["test".to_string(), "ns".to_string()],
+                    track_name: "track".to_string(),
+                    start_location: Location {
+                        group_id: 0,
+                        object_id: 0,
+                    },
+                    end_location: Location {
+                        group_id: 10,
+                        object_id: 0,
+                    },
+                },
+                authorization_tokens: vec![],
+            };
+            let buf = fetch.encode();
+            let mut cursor = std::io::Cursor::new(&buf[..]);
+            let result = Fetch::decode(&mut cursor).unwrap();
+            assert_eq!(result, fetch);
+        }
+
+        #[test]
+        fn standalone_packetize() {
+            let fetch = Fetch {
+                request_id: 1,
+                subscriber_priority: 128,
+                group_order: GroupOrder::Ascending,
+                fetch_type: FetchType::Standalone {
+                    track_namespace: vec!["a".to_string()],
+                    track_name: "b".to_string(),
+                    start_location: Location {
+                        group_id: 0,
+                        object_id: 0,
+                    },
+                    end_location: Location {
+                        group_id: 5,
+                        object_id: 0,
+                    },
+                },
+                authorization_tokens: vec![],
+            };
+            let result = fetch.encode();
+            let expected = [
+                1,   // Request ID
+                128, // Subscriber Priority
+                1,   // Group Order = Ascending
+                1,   // Fetch Type = Standalone
+                1,   // Track Namespace: number of elements
+                1, b'a', // Track Namespace[0]: length + "a"
+                1, b'b', // Track Name: length + "b"
+                0,    // Start Location: group_id
+                0,    // Start Location: object_id
+                5,    // End Location: group_id
+                0,    // End Location: object_id
+                0,    // Number of Parameters
+            ];
+            assert_eq!(result.as_ref(), expected.as_slice());
+        }
+
+        #[test]
+        fn standalone_depacketize() {
+            let bytes = [
+                1,   // Request ID
+                128, // Subscriber Priority
+                1,   // Group Order = Ascending
+                1,   // Fetch Type = Standalone
+                1,   // Track Namespace: number of elements
+                1, b'a', // Track Namespace[0]: length + "a"
+                1, b'b', // Track Name: length + "b"
+                0,    // Start Location: group_id
+                0,    // Start Location: object_id
+                5,    // End Location: group_id
+                0,    // End Location: object_id
+                0,    // Number of Parameters
+            ];
+            let mut cursor = std::io::Cursor::new(&bytes[..]);
+            let result = Fetch::decode(&mut cursor).unwrap();
+            let expected = Fetch {
+                request_id: 1,
+                subscriber_priority: 128,
+                group_order: GroupOrder::Ascending,
+                fetch_type: FetchType::Standalone {
+                    track_namespace: vec!["a".to_string()],
+                    track_name: "b".to_string(),
+                    start_location: Location {
+                        group_id: 0,
+                        object_id: 0,
+                    },
+                    end_location: Location {
+                        group_id: 5,
+                        object_id: 0,
+                    },
+                },
+                authorization_tokens: vec![],
+            };
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn relative_joining_packetize() {
+            let fetch = Fetch {
+                request_id: 5,
+                subscriber_priority: 0,
+                group_order: GroupOrder::Descending,
+                fetch_type: FetchType::RelativeJoining {
+                    joining_request_id: 3,
+                    joining_start: 2,
+                },
+                authorization_tokens: vec![],
+            };
+            let result = fetch.encode();
+            let expected = [
+                5, // Request ID
+                0, // Subscriber Priority
+                2, // Group Order = Descending
+                2, // Fetch Type = RelativeJoining
+                3, // Joining Request ID
+                2, // Joining Start
+                0, // Number of Parameters
+            ];
+            assert_eq!(result.as_ref(), expected.as_slice());
+        }
+
+        #[test]
+        fn relative_joining_depacketize() {
+            let bytes = [
+                5, // Request ID
+                0, // Subscriber Priority
+                2, // Group Order = Descending
+                2, // Fetch Type = RelativeJoining
+                3, // Joining Request ID
+                2, // Joining Start
+                0, // Number of Parameters
+            ];
+            let mut cursor = std::io::Cursor::new(&bytes[..]);
+            let result = Fetch::decode(&mut cursor).unwrap();
+            let expected = Fetch {
+                request_id: 5,
+                subscriber_priority: 0,
+                group_order: GroupOrder::Descending,
+                fetch_type: FetchType::RelativeJoining {
+                    joining_request_id: 3,
+                    joining_start: 2,
+                },
+                authorization_tokens: vec![],
+            };
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn absolute_joining_packetize() {
+            let fetch = Fetch {
+                request_id: 7,
+                subscriber_priority: 0,
+                group_order: GroupOrder::Ascending,
+                fetch_type: FetchType::AbsoluteJoining {
+                    joining_request_id: 4,
+                    joining_start: 100,
+                },
+                authorization_tokens: vec![],
+            };
+            let result = fetch.encode();
+            let expected = [
+                7, // Request ID
+                0, // Subscriber Priority
+                1, // Group Order = Ascending
+                3, // Fetch Type = AbsoluteJoining
+                4, // Joining Request ID
+                64, 100, // Joining Start (100 as 2-byte varint)
+                0,   // Number of Parameters
+            ];
+            assert_eq!(result.as_ref(), expected.as_slice());
+        }
+
+        #[test]
+        fn absolute_joining_depacketize() {
+            let bytes = [
+                7, // Request ID
+                0, // Subscriber Priority
+                1, // Group Order = Ascending
+                3, // Fetch Type = AbsoluteJoining
+                4, // Joining Request ID
+                64, 100, // Joining Start (100 as 2-byte varint)
+                0,   // Number of Parameters
+            ];
+            let mut cursor = std::io::Cursor::new(&bytes[..]);
+            let result = Fetch::decode(&mut cursor).unwrap();
+            let expected = Fetch {
+                request_id: 7,
+                subscriber_priority: 0,
+                group_order: GroupOrder::Ascending,
+                fetch_type: FetchType::AbsoluteJoining {
+                    joining_request_id: 4,
+                    joining_start: 100,
+                },
+                authorization_tokens: vec![],
+            };
+            assert_eq!(result, expected);
+        }
+    }
+
+    mod failure {
+        use super::super::*;
+
+        #[test]
+        fn invalid_fetch_type() {
+            let bytes = [
+                1, // Request ID
+                0, // Subscriber Priority
+                1, // Group Order = Ascending
+                4, // Fetch Type = 0x4 (invalid)
+            ];
+            let mut cursor = std::io::Cursor::new(&bytes[..]);
+            assert!(Fetch::decode(&mut cursor).is_none());
+        }
+
+        #[test]
+        fn invalid_group_order() {
+            let bytes = [
+                1, // Request ID
+                0, // Subscriber Priority
+                3, // Group Order = 0x3 (invalid)
+            ];
+            let mut cursor = std::io::Cursor::new(&bytes[..]);
+            assert!(Fetch::decode(&mut cursor).is_none());
+        }
+    }
+}

--- a/moqt/src/modules/moqt/control_plane/control_messages/messages/fetch_ok.rs
+++ b/moqt/src/modules/moqt/control_plane/control_messages/messages/fetch_ok.rs
@@ -1,0 +1,159 @@
+use bytes::{Buf, BufMut, BytesMut};
+
+use crate::modules::{
+    extensions::{buf_get_ext::BufGetExt, buf_put_ext::BufPutExt, result_ext::ResultExt},
+    moqt::control_plane::control_messages::{
+        key_value_pair::{KeyValuePair, VariantType},
+        messages::parameters::{group_order::GroupOrder, location::Location},
+        util,
+    },
+};
+
+// https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.17
+// FETCH_OK Message {
+//   Type (i) = 0x18,
+//   Length (16),
+//   Request ID (i),
+//   Group Order (8),
+//   End Of Track (8),
+//   End Location (Location),
+//   Number of Parameters (i),
+//   Parameters (..) ...
+// }
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FetchOk {
+    pub request_id: u64,
+    pub group_order: GroupOrder,
+    pub end_of_track: bool,
+    pub end_location: Location,
+    pub max_cache_duration: Option<u64>,
+}
+
+impl FetchOk {
+    pub fn decode(buf: &mut std::io::Cursor<&[u8]>) -> Option<Self> {
+        let request_id = buf.try_get_varint().log_context("request id").ok()?;
+        let group_order_u8 = buf.try_get_u8().log_context("group order u8").ok()?;
+        let group_order = GroupOrder::try_from(group_order_u8)
+            .log_context("group order")
+            .ok()?;
+        let end_of_track_u8 = buf.try_get_u8().log_context("end of track u8").ok()?;
+        let end_of_track = util::u8_to_bool(end_of_track_u8)
+            .log_context("end of track")
+            .ok()?;
+        let end_location = Location::decode(buf)?;
+        let number_of_parameters = buf
+            .try_get_varint()
+            .log_context("number of parameters")
+            .ok()?;
+        let mut parameters = vec![];
+        for _ in 0..number_of_parameters {
+            let kv = KeyValuePair::decode(buf)?;
+            parameters.push(kv);
+        }
+        let max_cache_duration =
+            parameters
+                .iter()
+                .find(|kv| kv.key == 0x04)
+                .map(|kv| match kv.value {
+                    VariantType::Odd(_) => unreachable!(),
+                    VariantType::Even(value) => value,
+                });
+        Some(FetchOk {
+            request_id,
+            group_order,
+            end_of_track,
+            end_location,
+            max_cache_duration,
+        })
+    }
+
+    pub fn encode(&self) -> BytesMut {
+        let mut payload = BytesMut::new();
+        payload.put_varint(self.request_id);
+        payload.put_u8(self.group_order as u8);
+        payload.put_u8(self.end_of_track as u8);
+        payload.unsplit(self.end_location.encode());
+        let mut number_of_parameters = 0u64;
+        let mut parameters_payload = BytesMut::new();
+        if let Some(max_cache_duration) = self.max_cache_duration {
+            let kv = KeyValuePair {
+                key: 0x04,
+                value: VariantType::Even(max_cache_duration),
+            }
+            .encode();
+            parameters_payload.unsplit(kv);
+            number_of_parameters += 1;
+        }
+        payload.put_varint(number_of_parameters);
+        payload.unsplit(parameters_payload);
+        payload
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod success {
+        use super::super::*;
+
+        #[test]
+        fn packetize() {
+            let fetch_ok = FetchOk {
+                request_id: 7,
+                group_order: GroupOrder::Ascending,
+                end_of_track: false,
+                end_location: Location {
+                    group_id: 10,
+                    object_id: 5,
+                },
+                max_cache_duration: None,
+            };
+            let result = fetch_ok.encode();
+            let expected = [
+                7,  // Request ID
+                1,  // Group Order = Ascending
+                0,  // End of Track = false
+                10, // End Location: group_id
+                5,  // End Location: object_id
+                0,  // Number of Parameters
+            ];
+            assert_eq!(result.as_ref(), expected.as_slice());
+        }
+
+        #[test]
+        fn depacketize() {
+            let bytes: [u8; 6] = [7, 1, 0, 10, 5, 0];
+            let mut cursor = std::io::Cursor::new(&bytes[..]);
+            let result = FetchOk::decode(&mut cursor).unwrap();
+            let expected = FetchOk {
+                request_id: 7,
+                group_order: GroupOrder::Ascending,
+                end_of_track: false,
+                end_location: Location {
+                    group_id: 10,
+                    object_id: 5,
+                },
+                max_cache_duration: None,
+            };
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn round_trip_end_of_track_true() {
+            let expected = FetchOk {
+                request_id: 3,
+                group_order: GroupOrder::Descending,
+                end_of_track: true,
+                end_location: Location {
+                    group_id: 100,
+                    object_id: 200,
+                },
+                max_cache_duration: Some(5000),
+            };
+            let buf = expected.encode();
+            let mut cursor = std::io::Cursor::new(&buf[..]);
+            let result = FetchOk::decode(&mut cursor).unwrap();
+            assert_eq!(result, expected);
+        }
+    }
+}

--- a/moqt/src/modules/moqt/control_plane/enums.rs
+++ b/moqt/src/modules/moqt/control_plane/enums.rs
@@ -5,7 +5,8 @@ use crate::{
             fetch_ok::FetchOk, publish_ok::PublishOk, subscribe_ok::SubscribeOk,
         },
         handler::{
-            publish_handler::PublishHandler, publish_namespace_handler::PublishNamespaceHandler,
+            fetch_handler::FetchHandler, publish_handler::PublishHandler,
+            publish_namespace_handler::PublishNamespaceHandler,
             subscribe_handler::SubscribeHandler,
             subscribe_namespace_handler::SubscribeNamespaceHandler,
             unsubscribe_handler::UnsubscribeHandler,
@@ -26,6 +27,7 @@ pub enum SessionEvent<T: TransportProtocol> {
     Publish(PublishHandler<T>),
     Subscribe(SubscribeHandler<T>),
     Unsubscribe(UnsubscribeHandler<T>),
+    Fetch(FetchHandler<T>),
     Disconnected(),
     ProtocolViolation(),
 }

--- a/moqt/src/modules/moqt/control_plane/enums.rs
+++ b/moqt/src/modules/moqt/control_plane/enums.rs
@@ -1,7 +1,9 @@
 use crate::{
     TransportProtocol,
     modules::moqt::control_plane::{
-        control_messages::messages::{publish_ok::PublishOk, subscribe_ok::SubscribeOk},
+        control_messages::messages::{
+            fetch_ok::FetchOk, publish_ok::PublishOk, subscribe_ok::SubscribeOk,
+        },
         handler::{
             publish_handler::PublishHandler, publish_namespace_handler::PublishNamespaceHandler,
             subscribe_handler::SubscribeHandler,
@@ -39,4 +41,6 @@ pub(crate) enum ResponseMessage {
     PublishError(RequestId, ErrorCode, ErrorPhrase),
     SubscribeOk(SubscribeOk),
     SubscribeError(RequestId, ErrorCode, ErrorPhrase),
+    FetchOk(FetchOk),
+    FetchError(RequestId, ErrorCode, ErrorPhrase),
 }

--- a/moqt/src/modules/moqt/control_plane/handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler.rs
@@ -1,3 +1,4 @@
+pub mod fetch_handler;
 pub mod publish_handler;
 pub mod publish_namespace_handler;
 pub mod subscribe_handler;

--- a/moqt/src/modules/moqt/control_plane/handler/fetch_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/fetch_handler.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use crate::{
+    GroupOrder, TransportProtocol,
+    modules::{
+        moqt::{
+            control_plane::control_messages::{
+                control_message_type::ControlMessageType,
+                messages::{
+                    fetch::Fetch, fetch_ok::FetchOk, parameters::location::Location,
+                    request_error::RequestError,
+                },
+            },
+            domains::session_context::SessionContext,
+        },
+        transport::transport_send_stream::TransportSendError,
+    },
+};
+
+#[derive(Debug, Clone)]
+pub struct FetchHandler<T: TransportProtocol> {
+    session_context: Arc<SessionContext<T>>,
+    pub request_id: u64,
+    pub group_order: GroupOrder,
+    pub fetch: Fetch,
+}
+
+impl<T: TransportProtocol> FetchHandler<T> {
+    pub(crate) fn new(session_context: Arc<SessionContext<T>>, fetch: Fetch) -> Self {
+        let request_id = fetch.request_id;
+        let group_order = fetch.group_order;
+        Self {
+            session_context,
+            request_id,
+            group_order,
+            fetch,
+        }
+    }
+
+    pub async fn ok(
+        &self,
+        end_of_track: bool,
+        end_location: Location,
+    ) -> Result<(), TransportSendError> {
+        let fetch_ok = FetchOk {
+            request_id: self.request_id,
+            group_order: self.group_order,
+            end_of_track,
+            end_location,
+            max_cache_duration: None,
+        };
+        self.session_context
+            .send_stream
+            .send(ControlMessageType::FetchOk, fetch_ok.encode())
+            .await
+    }
+
+    pub async fn error(
+        &self,
+        error_code: u64,
+        reason_phrase: String,
+    ) -> Result<(), TransportSendError> {
+        let err = RequestError {
+            request_id: self.request_id,
+            error_code,
+            reason_phrase,
+        };
+        self.session_context
+            .send_stream
+            .send(ControlMessageType::FetchError, err.encode())
+            .await
+    }
+}

--- a/moqt/src/modules/moqt/control_plane/options.rs
+++ b/moqt/src/modules/moqt/control_plane/options.rs
@@ -19,6 +19,20 @@ impl Default for PublishOption {
     }
 }
 
+pub struct FetchOption {
+    pub subscriber_priority: u8,
+    pub group_order: GroupOrder,
+}
+
+impl Default for FetchOption {
+    fn default() -> Self {
+        Self {
+            subscriber_priority: 128,
+            group_order: GroupOrder::Ascending,
+        }
+    }
+}
+
 pub struct SubscribeOption {
     pub subscriber_priority: u8,
     pub group_order: GroupOrder,

--- a/moqt/src/modules/moqt/data_plane/codec.rs
+++ b/moqt/src/modules/moqt/data_plane/codec.rs
@@ -1,3 +1,5 @@
 pub(crate) mod control_message_decoder;
-pub(crate) mod subgroup_decoder;
+mod fetch_decoder;
+mod subgroup_decoder;
 pub(crate) mod tokio_reader;
+pub(crate) mod uni_stream_decoder;

--- a/moqt/src/modules/moqt/data_plane/codec/control_message_decoder.rs
+++ b/moqt/src/modules/moqt/data_plane/codec/control_message_decoder.rs
@@ -7,7 +7,7 @@ use crate::modules::moqt::{
     control_plane::control_messages::{
         control_message_type::ControlMessageType,
         messages::{
-            client_setup::ClientSetup, fetch_ok::FetchOk, namespace_ok::NamespaceOk,
+            client_setup::ClientSetup, fetch::Fetch, fetch_ok::FetchOk, namespace_ok::NamespaceOk,
             publish::Publish, publish_namespace::PublishNamespace, publish_ok::PublishOk,
             request_error::RequestError, server_setup::ServerSetup, subscribe::Subscribe,
             subscribe_namespace::SubscribeNamespace, subscribe_ok::SubscribeOk,
@@ -145,7 +145,16 @@ impl ControlMessageDecoder {
                     }
                 }
             }
-            ControlMessageType::Fetch => todo!(),
+            ControlMessageType::Fetch => {
+                tracing::debug!("Event: Fetch");
+                match Fetch::decode(&mut cursor_buf) {
+                    Some(v) => ReceivedMessage::Fetch(v),
+                    None => {
+                        tracing::error!("Protocol violation is detected.");
+                        ReceivedMessage::FatalError()
+                    }
+                }
+            }
             ControlMessageType::FetchOk => {
                 tracing::debug!("Event: Fetch ok");
                 match FetchOk::decode(&mut cursor_buf) {

--- a/moqt/src/modules/moqt/data_plane/codec/control_message_decoder.rs
+++ b/moqt/src/modules/moqt/data_plane/codec/control_message_decoder.rs
@@ -7,8 +7,8 @@ use crate::modules::moqt::{
     control_plane::control_messages::{
         control_message_type::ControlMessageType,
         messages::{
-            client_setup::ClientSetup, namespace_ok::NamespaceOk, publish::Publish,
-            publish_namespace::PublishNamespace, publish_ok::PublishOk,
+            client_setup::ClientSetup, fetch_ok::FetchOk, namespace_ok::NamespaceOk,
+            publish::Publish, publish_namespace::PublishNamespace, publish_ok::PublishOk,
             request_error::RequestError, server_setup::ServerSetup, subscribe::Subscribe,
             subscribe_namespace::SubscribeNamespace, subscribe_ok::SubscribeOk,
             unsubscribe::Unsubscribe,
@@ -146,7 +146,16 @@ impl ControlMessageDecoder {
                 }
             }
             ControlMessageType::Fetch => todo!(),
-            ControlMessageType::FetchOk => todo!(),
+            ControlMessageType::FetchOk => {
+                tracing::debug!("Event: Fetch ok");
+                match FetchOk::decode(&mut cursor_buf) {
+                    Some(v) => ReceivedMessage::FetchOk(v),
+                    None => {
+                        tracing::error!("Protocol violation is detected.");
+                        ReceivedMessage::FatalError()
+                    }
+                }
+            }
             ControlMessageType::FetchError => todo!(),
             ControlMessageType::FetchCancel => todo!(),
             ControlMessageType::TrackStatusRequest => todo!(),

--- a/moqt/src/modules/moqt/data_plane/codec/fetch_decoder.rs
+++ b/moqt/src/modules/moqt/data_plane/codec/fetch_decoder.rs
@@ -1,0 +1,68 @@
+use bytes::BytesMut;
+use tokio_util::codec::Decoder;
+
+use crate::modules::moqt::data_plane::object::{
+    decode_error::DecodeError,
+    fetch::{FetchHeader, FetchObjectField},
+};
+use crate::modules::moqt::data_plane::stream::fetch_data_receiver::Fetch;
+
+#[derive(Debug)]
+pub(crate) struct FetchDecoder {
+    header_received: bool,
+}
+
+impl Decoder for FetchDecoder {
+    type Item = Fetch;
+    type Error = std::io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if !self.header_received {
+            self.decode_header(src)
+        } else {
+            self.decode_object(src)
+        }
+    }
+}
+
+impl FetchDecoder {
+    pub(crate) fn new() -> Self {
+        Self {
+            header_received: false,
+        }
+    }
+
+    fn decode_header(&mut self, src: &mut BytesMut) -> Result<Option<Fetch>, std::io::Error> {
+        let mut cursor = std::io::Cursor::new(&src[..]);
+        match FetchHeader::decode(&mut cursor) {
+            Ok(header) => {
+                let pos = cursor.position() as usize;
+                let _ = src.split_to(pos);
+                self.header_received = true;
+                Ok(Some(Fetch::Header(header)))
+            }
+            Err(DecodeError::NeedMoreData) => Ok(None),
+            Err(e) => {
+                tracing::error!("Failed to decode fetch header: {:?}", e);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Failed to decode fetch header: {:?}", e),
+                ))
+            }
+        }
+    }
+
+    fn decode_object(&self, src: &mut BytesMut) -> Result<Option<Fetch>, std::io::Error> {
+        match FetchObjectField::decode(src) {
+            Ok(fields) => Ok(Some(Fetch::Object(fields))),
+            Err(DecodeError::NeedMoreData) => Ok(None),
+            Err(e) => {
+                tracing::error!("Failed to decode fetch object fields: {:?}", e);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Failed to decode fetch object fields: {:?}", e),
+                ))
+            }
+        }
+    }
+}

--- a/moqt/src/modules/moqt/data_plane/codec/fetch_decoder.rs
+++ b/moqt/src/modules/moqt/data_plane/codec/fetch_decoder.rs
@@ -53,6 +53,9 @@ impl FetchDecoder {
     }
 
     fn decode_object(&self, src: &mut BytesMut) -> Result<Option<Fetch>, std::io::Error> {
+        if src.is_empty() {
+            return Ok(None);
+        }
         match FetchObjectField::decode(src) {
             Ok(fields) => Ok(Some(Fetch::Object(fields))),
             Err(DecodeError::NeedMoreData) => Ok(None),

--- a/moqt/src/modules/moqt/data_plane/codec/uni_stream_decoder.rs
+++ b/moqt/src/modules/moqt/data_plane/codec/uni_stream_decoder.rs
@@ -1,0 +1,76 @@
+use bytes::BytesMut;
+use tokio_util::codec::Decoder;
+
+use crate::modules::extensions::buf_get_ext::BufGetExt;
+
+use crate::Subgroup;
+use crate::modules::moqt::data_plane::{
+    codec::{fetch_decoder::FetchDecoder, subgroup_decoder::SubgroupDecoder},
+    object::fetch::FetchHeader,
+    stream::fetch_data_receiver::Fetch,
+};
+
+#[derive(Debug)]
+pub enum UniStreamData {
+    Subgroup(Subgroup),
+    Fetch(Fetch),
+}
+
+#[derive(Debug)]
+pub(crate) struct UniStreamDecoder {
+    inner: InnerDecoder,
+}
+
+#[derive(Debug)]
+enum InnerDecoder {
+    Unknown,
+    Subgroup(SubgroupDecoder),
+    Fetch(FetchDecoder),
+}
+
+impl Decoder for UniStreamDecoder {
+    type Item = UniStreamData;
+    type Error = std::io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        // Determine the decoder type from the first message type.
+        if let InnerDecoder::Unknown = self.inner {
+            let mut cursor = std::io::Cursor::new(&src[..]);
+            let message_type = match cursor.try_get_varint() {
+                Ok(b) => b,
+                Err(_) => return Ok(None),
+            };
+            if (0x10..=0x1d).contains(&message_type) {
+                // 0x10..=0x1d are valid SubgroupHeader message types.
+                self.inner = InnerDecoder::Subgroup(SubgroupDecoder::new());
+            } else if message_type == FetchHeader::TYPE {
+                self.inner = InnerDecoder::Fetch(FetchDecoder::new());
+            } else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Unknown message type: {message_type:#x}"),
+                ));
+            }
+        }
+        // Decode using the inner decoder chosen above.
+        match &mut self.inner {
+            InnerDecoder::Subgroup(dec) => match dec.decode(src)? {
+                Some(subgroup) => Ok(Some(UniStreamData::Subgroup(subgroup))),
+                None => Ok(None),
+            },
+            InnerDecoder::Fetch(dec) => match dec.decode(src)? {
+                Some(item) => Ok(Some(UniStreamData::Fetch(item))),
+                None => Ok(None),
+            },
+            InnerDecoder::Unknown => unreachable!(),
+        }
+    }
+}
+
+impl UniStreamDecoder {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: InnerDecoder::Unknown,
+        }
+    }
+}

--- a/moqt/src/modules/moqt/data_plane/object.rs
+++ b/moqt/src/modules/moqt/data_plane/object.rs
@@ -1,6 +1,7 @@
 pub mod datagram_field;
 pub mod decode_error;
 pub mod extension_headers;
+pub mod fetch;
 pub mod object_datagram;
 pub mod object_status;
 pub mod subgroup;

--- a/moqt/src/modules/moqt/data_plane/object/fetch.rs
+++ b/moqt/src/modules/moqt/data_plane/object/fetch.rs
@@ -1,0 +1,278 @@
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+use crate::modules::extensions::buf_get_ext::BufGetExt;
+use crate::modules::extensions::buf_put_ext::BufPutExt;
+use crate::modules::extensions::result_ext::ResultExt;
+use crate::modules::moqt::data_plane::object::decode_error::DecodeError;
+use crate::modules::moqt::data_plane::object::extension_headers::ExtensionHeaders;
+use crate::modules::moqt::data_plane::object::object_status::ObjectStatus;
+
+// FETCH_HEADER {
+//   Type (i) = 0x5,
+//   Request ID (i),
+// }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchHeader {
+    pub request_id: u64,
+}
+
+impl FetchHeader {
+    pub const TYPE: u64 = 0x5;
+
+    pub fn new(request_id: u64) -> Self {
+        Self { request_id }
+    }
+
+    pub fn decode(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self, DecodeError> {
+        let message_type = cursor
+            .try_get_varint()
+            .log_context("Fetch Header Message Type")
+            .map_err(|_| DecodeError::NeedMoreData)?;
+        if message_type != Self::TYPE {
+            return Err(DecodeError::Fatal(format!(
+                "Invalid message type for FetchHeader: {message_type:#x}"
+            )));
+        }
+        let request_id = cursor
+            .try_get_varint()
+            .log_context("Fetch Header Request ID")
+            .map_err(|_| DecodeError::NeedMoreData)?;
+        Ok(Self { request_id })
+    }
+
+    pub fn encode(&self) -> BytesMut {
+        let mut buf = BytesMut::new();
+        buf.put_varint(Self::TYPE);
+        buf.put_varint(self.request_id);
+        buf
+    }
+}
+
+// https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-10.4.4-3
+// {
+//   Group ID (i),
+//   Subgroup ID (i),
+//   Object ID (i),
+//   Publisher Priority (8),
+//   Extension Headers Length (i),
+//   [Extension headers (...)],
+//   Object Payload Length (i),
+//   [Object Status (i)],
+//   Object Payload (..),
+// }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FetchObject {
+    Payload(Bytes),
+    Status(ObjectStatus),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchObjectFields {
+    pub group_id: u64,
+    pub subgroup_id: u64,
+    pub object_id: u64,
+    pub publisher_priority: u8,
+    pub extension_headers: ExtensionHeaders,
+    pub fetch_object: FetchObject,
+}
+
+impl FetchObjectFields {
+    pub fn new(
+        group_id: u64,
+        subgroup_id: u64,
+        object_id: u64,
+        publisher_priority: u8,
+        extension_headers: ExtensionHeaders,
+        fetch_object: FetchObject,
+    ) -> Self {
+        Self {
+            group_id,
+            subgroup_id,
+            object_id,
+            publisher_priority,
+            extension_headers,
+            fetch_object,
+        }
+    }
+
+    pub fn decode(buf: &mut BytesMut) -> Result<Self, DecodeError> {
+        let mut cursor = std::io::Cursor::<&[u8]>::new(buf);
+        let group_id = cursor
+            .try_get_varint()
+            .log_context("Fetch Object Group ID")
+            .map_err(|_| DecodeError::NeedMoreData)?;
+        let subgroup_id = cursor
+            .try_get_varint()
+            .log_context("Fetch Object Subgroup ID")
+            .map_err(|_| DecodeError::NeedMoreData)?;
+        let object_id = cursor
+            .try_get_varint()
+            .log_context("Fetch Object Object ID")
+            .map_err(|_| DecodeError::NeedMoreData)?;
+        let publisher_priority = cursor
+            .try_get_u8()
+            .log_context("Fetch Object Publisher Priority")
+            .map_err(|_| DecodeError::NeedMoreData)?;
+        let extension_headers =
+            ExtensionHeaders::decode(&mut cursor).ok_or(DecodeError::NeedMoreData)?;
+        let payload_length = cursor
+            .try_get_varint()
+            .log_context("Fetch Object Payload Length")
+            .map_err(|_| DecodeError::NeedMoreData)?;
+        let fetch_object = if payload_length == 0 {
+            let status_value = cursor
+                .try_get_varint()
+                .log_context("Fetch Object Status")
+                .map_err(|_| DecodeError::NeedMoreData)?;
+            let status = ObjectStatus::try_from(status_value as u8).map_err(|_| {
+                DecodeError::Fatal(format!("Invalid Object Status: {status_value:#x}"))
+            })?;
+            let _ = buf.split_to(cursor.position() as usize);
+            FetchObject::Status(status)
+        } else {
+            if cursor.remaining() < payload_length as usize {
+                return Err(DecodeError::NeedMoreData);
+            }
+            let _ = buf.split_to(cursor.position() as usize);
+            let payload = buf.split_to(payload_length as usize).freeze();
+            FetchObject::Payload(payload)
+        };
+        Ok(Self {
+            group_id,
+            subgroup_id,
+            object_id,
+            publisher_priority,
+            extension_headers,
+            fetch_object,
+        })
+    }
+
+    pub fn encode(&self) -> BytesMut {
+        let mut buf = BytesMut::new();
+        buf.put_varint(self.group_id);
+        buf.put_varint(self.subgroup_id);
+        buf.put_varint(self.object_id);
+        buf.put_u8(self.publisher_priority);
+        let ext_headers_buf = self.extension_headers.encode();
+        buf.extend_from_slice(&ext_headers_buf);
+        match &self.fetch_object {
+            FetchObject::Payload(payload) => {
+                buf.put_varint(payload.len() as u64);
+                buf.put_slice(payload);
+            }
+            FetchObject::Status(status) => {
+                buf.put_varint(0);
+                buf.put_varint(u8::from(*status) as u64);
+            }
+        }
+        buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod success {
+        use super::super::*;
+        use bytes::Bytes;
+
+        #[test]
+        fn fetch_header_packetize() {
+            let header = FetchHeader::new(42);
+            let result = header.encode();
+            let expected = [
+                0x05, // Type
+                42,   // Request ID
+            ];
+            assert_eq!(result.as_ref(), expected.as_slice());
+        }
+
+        #[test]
+        fn fetch_header_depacketize() {
+            let bytes = [0x05u8, 42];
+            let mut cursor = std::io::Cursor::new(&bytes[..]);
+            let result = FetchHeader::decode(&mut cursor).unwrap();
+            let expected = FetchHeader::new(42);
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn fetch_header_round_trip() {
+            let expected = FetchHeader::new(12345);
+            let buf = expected.encode();
+            let mut cursor = std::io::Cursor::new(&buf[..]);
+            let result = FetchHeader::decode(&mut cursor).unwrap();
+            assert_eq!(result, expected);
+        }
+
+        fn sample_fields(object: FetchObject) -> FetchObjectFields {
+            FetchObjectFields::new(
+                1,   // group_id
+                2,   // subgroup_id
+                3,   // object_id
+                128, // publisher_priority
+                ExtensionHeaders {
+                    prior_group_id_gap: vec![],
+                    prior_object_id_gap: vec![],
+                    immutable_extensions: vec![],
+                },
+                object,
+            )
+        }
+
+        #[test]
+        fn packetize_with_payload() {
+            let fields = sample_fields(FetchObject::Payload(Bytes::from_static(b"abcd")));
+            let result = fields.encode();
+            let expected = vec![
+                1,   // Group ID
+                2,   // Subgroup ID
+                3,   // Object ID
+                128, // Publisher Priority
+                0,   // Extension Headers Length (= 0, 拡張なし)
+                4,   // Object Payload Length
+                b'a', b'b', b'c', b'd', // Payload
+            ];
+            assert_eq!(result.as_ref(), expected.as_slice());
+        }
+
+        #[test]
+        fn depacketize_with_payload() {
+            let bytes: [u8; 10] = [1, 2, 3, 128, 0, 4, b'a', b'b', b'c', b'd'];
+            let mut buf = bytes::BytesMut::with_capacity(bytes.len());
+            buf.extend_from_slice(&bytes);
+            let result = FetchObjectFields::decode(&mut buf).unwrap();
+            let expected = sample_fields(FetchObject::Payload(Bytes::from_static(b"abcd")));
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn round_trip_with_payload() {
+            let expected = sample_fields(FetchObject::Payload(Bytes::from_static(b"hello")));
+            let mut buf = expected.encode();
+            let result = FetchObjectFields::decode(&mut buf).unwrap();
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn round_trip_with_status() {
+            let expected = sample_fields(FetchObject::Status(ObjectStatus::DoesNotExist));
+            let mut buf = expected.encode();
+            let result = FetchObjectFields::decode(&mut buf).unwrap();
+            assert_eq!(result, expected);
+        }
+    }
+
+    mod failure {
+        use super::super::*;
+
+        #[test]
+        fn depacketize_invalid_type() {
+            let bytes = [0x10u8, 42];
+            let mut cursor = std::io::Cursor::new(&bytes[..]);
+            let result = FetchHeader::decode(&mut cursor);
+            assert!(matches!(result, Err(DecodeError::Fatal(_))));
+        }
+    }
+}

--- a/moqt/src/modules/moqt/data_plane/object/fetch.rs
+++ b/moqt/src/modules/moqt/data_plane/object/fetch.rs
@@ -69,7 +69,7 @@ pub enum FetchObject {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FetchObjectFields {
+pub struct FetchObjectField {
     pub group_id: u64,
     pub subgroup_id: u64,
     pub object_id: u64,
@@ -78,7 +78,7 @@ pub struct FetchObjectFields {
     pub fetch_object: FetchObject,
 }
 
-impl FetchObjectFields {
+impl FetchObjectField {
     pub fn new(
         group_id: u64,
         subgroup_id: u64,
@@ -206,8 +206,8 @@ mod tests {
             assert_eq!(result, expected);
         }
 
-        fn sample_fields(object: FetchObject) -> FetchObjectFields {
-            FetchObjectFields::new(
+        fn sample_fields(object: FetchObject) -> FetchObjectField {
+            FetchObjectField::new(
                 1,   // group_id
                 2,   // subgroup_id
                 3,   // object_id
@@ -242,7 +242,7 @@ mod tests {
             let bytes: [u8; 10] = [1, 2, 3, 128, 0, 4, b'a', b'b', b'c', b'd'];
             let mut buf = bytes::BytesMut::with_capacity(bytes.len());
             buf.extend_from_slice(&bytes);
-            let result = FetchObjectFields::decode(&mut buf).unwrap();
+            let result = FetchObjectField::decode(&mut buf).unwrap();
             let expected = sample_fields(FetchObject::Payload(Bytes::from_static(b"abcd")));
             assert_eq!(result, expected);
         }
@@ -251,7 +251,7 @@ mod tests {
         fn round_trip_with_payload() {
             let expected = sample_fields(FetchObject::Payload(Bytes::from_static(b"hello")));
             let mut buf = expected.encode();
-            let result = FetchObjectFields::decode(&mut buf).unwrap();
+            let result = FetchObjectField::decode(&mut buf).unwrap();
             assert_eq!(result, expected);
         }
 
@@ -259,7 +259,7 @@ mod tests {
         fn round_trip_with_status() {
             let expected = sample_fields(FetchObject::Status(ObjectStatus::DoesNotExist));
             let mut buf = expected.encode();
-            let result = FetchObjectFields::decode(&mut buf).unwrap();
+            let result = FetchObjectField::decode(&mut buf).unwrap();
             assert_eq!(result, expected);
         }
     }

--- a/moqt/src/modules/moqt/data_plane/object/object_status.rs
+++ b/moqt/src/modules/moqt/data_plane/object/object_status.rs
@@ -1,7 +1,7 @@
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::Serialize;
 
-#[derive(Debug, Serialize, Clone, PartialEq, TryFromPrimitive, IntoPrimitive, Copy)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, TryFromPrimitive, IntoPrimitive, Copy)]
 #[repr(u8)]
 pub enum ObjectStatus {
     Normal = 0x0,

--- a/moqt/src/modules/moqt/data_plane/object/subgroup.rs
+++ b/moqt/src/modules/moqt/data_plane/object/subgroup.rs
@@ -566,5 +566,51 @@ mod tests {
             let buf = h.encode();
             assert_eq!(buf[0], 0x1D);
         }
+
+        // --- resolve_object_id Tests ---
+
+        fn make_field(delta: u64) -> SubgroupObjectField {
+            SubgroupObjectField {
+                message_type: SubgroupHeaderType::new(0x10).unwrap(),
+                object_id_delta: delta,
+                extension_headers: ExtensionHeaders {
+                    prior_group_id_gap: vec![],
+                    prior_object_id_gap: vec![],
+                    immutable_extensions: vec![],
+                },
+                subgroup_object: SubgroupObject::new_payload(bytes::Bytes::new()),
+            }
+        }
+
+        // --- resolve_object_id Tests ---
+
+        #[test]
+        fn resolve_object_id_first_object() {
+            // First object: delta IS the object_id
+            assert_eq!(make_field(0).resolve_object_id(None), 0);
+            assert_eq!(make_field(5).resolve_object_id(None), 5);
+        }
+
+        #[test]
+        fn resolve_object_id_sequential() {
+            // Sequential 0,1,2,3: all deltas are 0
+            let mut prev = None;
+            for expected in 0..4 {
+                let id = make_field(0).resolve_object_id(prev);
+                assert_eq!(id, expected);
+                prev = Some(id);
+            }
+        }
+
+        #[test]
+        fn resolve_object_id_with_gap() {
+            // 0, 5, 10: deltas are 0, 4, 4
+            let id0 = make_field(0).resolve_object_id(None);
+            assert_eq!(id0, 0);
+            let id1 = make_field(4).resolve_object_id(Some(id0));
+            assert_eq!(id1, 5);
+            let id2 = make_field(4).resolve_object_id(Some(id1));
+            assert_eq!(id2, 10);
+        }
     }
 }

--- a/moqt/src/modules/moqt/data_plane/object/subgroup.rs
+++ b/moqt/src/modules/moqt/data_plane/object/subgroup.rs
@@ -47,6 +47,16 @@ pub enum SubgroupId {
     Value(u64),
 }
 
+impl SubgroupId {
+    // TODO: FirstObjectIdDelta should use the first object's object_id as subgroup_id
+    pub fn resolve(&self) -> u64 {
+        match self {
+            SubgroupId::None | SubgroupId::FirstObjectIdDelta => 0,
+            SubgroupId::Value(id) => *id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct SubgroupHeaderType(u64);
 
@@ -294,6 +304,13 @@ pub struct SubgroupObjectField {
 impl SubgroupObjectField {
     pub fn is_end_of_group(&self) -> bool {
         self.message_type.has_end_of_group()
+    }
+
+    pub fn resolve_object_id(&self, prev: Option<u64>) -> u64 {
+        match prev {
+            None => self.object_id_delta,
+            Some(prev) => prev + 1 + self.object_id_delta,
+        }
     }
 
     pub fn decode(

--- a/moqt/src/modules/moqt/data_plane/stream.rs
+++ b/moqt/src/modules/moqt/data_plane/stream.rs
@@ -1,5 +1,6 @@
 pub(crate) mod bi_stream_sender;
 pub(crate) mod fetch_data_receiver;
+pub(crate) mod fetch_data_sender;
 pub(crate) mod received_message;
 pub(crate) mod stream_data_receiver;
 pub(crate) mod stream_data_receiver_factory;

--- a/moqt/src/modules/moqt/data_plane/stream.rs
+++ b/moqt/src/modules/moqt/data_plane/stream.rs
@@ -1,4 +1,5 @@
 pub(crate) mod bi_stream_sender;
+pub(crate) mod fetch_data_receiver;
 pub(crate) mod received_message;
 pub(crate) mod stream_data_receiver;
 pub(crate) mod stream_data_receiver_factory;

--- a/moqt/src/modules/moqt/data_plane/stream/fetch_data_receiver.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/fetch_data_receiver.rs
@@ -1,0 +1,49 @@
+use crate::{
+    TransportProtocol,
+    modules::moqt::data_plane::{
+        codec::uni_stream_decoder::UniStreamData,
+        object::fetch::{FetchHeader, FetchObjectField},
+        stream::stream_receiver::UniStreamReceiver,
+    },
+};
+
+#[derive(Debug)]
+pub enum Fetch {
+    Header(FetchHeader),
+    Object(FetchObjectField),
+}
+
+#[derive(Debug)]
+pub struct FetchDataReceiver<T: TransportProtocol> {
+    stream_receiver: UniStreamReceiver<T>,
+    pub request_id: u64,
+    first_fetch_header: Option<FetchHeader>,
+}
+
+impl<T: TransportProtocol> FetchDataReceiver<T> {
+    pub(crate) fn new(stream: UniStreamReceiver<T>, fetch_header: FetchHeader) -> Self {
+        let request_id = fetch_header.request_id;
+        Self {
+            stream_receiver: stream,
+            request_id,
+            first_fetch_header: Some(fetch_header),
+        }
+    }
+
+    pub async fn receive(&mut self) -> anyhow::Result<Fetch> {
+        if let Some(fetch_header) = self.first_fetch_header.take() {
+            return Ok(Fetch::Header(fetch_header));
+        }
+
+        match self.stream_receiver.receive().await {
+            Ok(Some(UniStreamData::Fetch(fetch))) => Ok(fetch),
+            Ok(Some(UniStreamData::Subgroup(_))) => {
+                unreachable!("Unexpected subgroup data in fetch stream")
+            }
+            _ => {
+                tracing::error!("Failed to receive data from fetch stream");
+                anyhow::bail!("Failed to receive data from fetch stream")
+            }
+        }
+    }
+}

--- a/moqt/src/modules/moqt/data_plane/stream/fetch_data_receiver.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/fetch_data_receiver.rs
@@ -41,8 +41,8 @@ impl<T: TransportProtocol> FetchDataReceiver<T> {
             Ok(Some(UniStreamData::Subgroup(_))) => {
                 unreachable!("Unexpected subgroup data in fetch stream")
             }
-            None => Ok(Fetch::End),
-            Some(Err(e)) => {
+            Ok(None) => Ok(Fetch::End),
+            Err(e) => {
                 tracing::error!(?e, "Failed to receive data from fetch stream");
                 anyhow::bail!("Failed to receive data from fetch stream")
             }

--- a/moqt/src/modules/moqt/data_plane/stream/fetch_data_receiver.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/fetch_data_receiver.rs
@@ -11,6 +11,7 @@ use crate::{
 pub enum Fetch {
     Header(FetchHeader),
     Object(FetchObjectField),
+    End,
 }
 
 #[derive(Debug)]
@@ -40,8 +41,9 @@ impl<T: TransportProtocol> FetchDataReceiver<T> {
             Ok(Some(UniStreamData::Subgroup(_))) => {
                 unreachable!("Unexpected subgroup data in fetch stream")
             }
-            _ => {
-                tracing::error!("Failed to receive data from fetch stream");
+            None => Ok(Fetch::End),
+            Some(Err(e)) => {
+                tracing::error!(?e, "Failed to receive data from fetch stream");
                 anyhow::bail!("Failed to receive data from fetch stream")
             }
         }

--- a/moqt/src/modules/moqt/data_plane/stream/fetch_data_sender.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/fetch_data_sender.rs
@@ -1,0 +1,29 @@
+use crate::{
+    TransportProtocol,
+    modules::moqt::data_plane::{
+        object::fetch::{FetchHeader, FetchObjectField},
+        stream::stream_sender::StreamSender,
+    },
+};
+
+pub struct FetchDataSender<T: TransportProtocol> {
+    stream_sender: StreamSender<T>,
+}
+
+impl<T: TransportProtocol> FetchDataSender<T> {
+    pub async fn new(send_stream: T::SendStream, header: FetchHeader) -> anyhow::Result<Self> {
+        let stream_sender = StreamSender::new(send_stream);
+        let header_bytes = header.encode();
+        stream_sender.send(&header_bytes).await?;
+        Ok(Self { stream_sender })
+    }
+
+    pub async fn send(&self, object: FetchObjectField) -> anyhow::Result<()> {
+        let bytes = object.encode();
+        self.stream_sender.send(&bytes).await
+    }
+
+    pub async fn close(&self) -> anyhow::Result<()> {
+        self.stream_sender.close().await
+    }
+}

--- a/moqt/src/modules/moqt/data_plane/stream/received_message.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/received_message.rs
@@ -1,8 +1,8 @@
 use crate::modules::moqt::control_plane::control_messages::messages::{
-    client_setup::ClientSetup, fetch_ok::FetchOk, namespace_ok::NamespaceOk, publish::Publish,
-    publish_namespace::PublishNamespace, publish_ok::PublishOk, request_error::RequestError,
-    server_setup::ServerSetup, subscribe::Subscribe, subscribe_namespace::SubscribeNamespace,
-    subscribe_ok::SubscribeOk, unsubscribe::Unsubscribe,
+    client_setup::ClientSetup, fetch::Fetch, fetch_ok::FetchOk, namespace_ok::NamespaceOk,
+    publish::Publish, publish_namespace::PublishNamespace, publish_ok::PublishOk,
+    request_error::RequestError, server_setup::ServerSetup, subscribe::Subscribe,
+    subscribe_namespace::SubscribeNamespace, subscribe_ok::SubscribeOk, unsubscribe::Unsubscribe,
 };
 
 pub(crate) enum ReceivedMessage {
@@ -21,6 +21,7 @@ pub(crate) enum ReceivedMessage {
     SubscribeOk(SubscribeOk),
     SubscribeError(RequestError),
     Unsubscribe(Unsubscribe),
+    Fetch(Fetch),
     FetchOk(FetchOk),
     FatalError(),
 }
@@ -43,6 +44,7 @@ impl std::fmt::Debug for ReceivedMessage {
             ReceivedMessage::SubscribeOk(_) => "SubscribeOk",
             ReceivedMessage::SubscribeError(_) => "SubscribeError",
             ReceivedMessage::Unsubscribe(_) => "Unsubscribe",
+            ReceivedMessage::Fetch(_) => "Fetch",
             ReceivedMessage::FetchOk(_) => "FetchOk",
             ReceivedMessage::FatalError() => "FatalError",
         };

--- a/moqt/src/modules/moqt/data_plane/stream/received_message.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/received_message.rs
@@ -1,5 +1,5 @@
 use crate::modules::moqt::control_plane::control_messages::messages::{
-    client_setup::ClientSetup, namespace_ok::NamespaceOk, publish::Publish,
+    client_setup::ClientSetup, fetch_ok::FetchOk, namespace_ok::NamespaceOk, publish::Publish,
     publish_namespace::PublishNamespace, publish_ok::PublishOk, request_error::RequestError,
     server_setup::ServerSetup, subscribe::Subscribe, subscribe_namespace::SubscribeNamespace,
     subscribe_ok::SubscribeOk, unsubscribe::Unsubscribe,
@@ -21,6 +21,7 @@ pub(crate) enum ReceivedMessage {
     SubscribeOk(SubscribeOk),
     SubscribeError(RequestError),
     Unsubscribe(Unsubscribe),
+    FetchOk(FetchOk),
     FatalError(),
 }
 
@@ -42,6 +43,7 @@ impl std::fmt::Debug for ReceivedMessage {
             ReceivedMessage::SubscribeOk(_) => "SubscribeOk",
             ReceivedMessage::SubscribeError(_) => "SubscribeError",
             ReceivedMessage::Unsubscribe(_) => "Unsubscribe",
+            ReceivedMessage::FetchOk(_) => "FetchOk",
             ReceivedMessage::FatalError() => "FatalError",
         };
 

--- a/moqt/src/modules/moqt/data_plane/stream/stream_data_receiver.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/stream_data_receiver.rs
@@ -1,6 +1,7 @@
 use crate::{
     TransportProtocol,
     modules::moqt::data_plane::{
+        codec::uni_stream_decoder::UniStreamData,
         object::subgroup::{SubgroupHeader, SubgroupObjectField},
         stream::stream_receiver::{StreamReceiveError, UniStreamReceiver},
     },
@@ -38,7 +39,10 @@ impl<T: TransportProtocol> StreamDataReceiver<T> {
         }
 
         match self.stream_receiver.receive().await {
-            Ok(Some(subgroup)) => Ok(subgroup),
+            Ok(Some(UniStreamData::Subgroup(subgroup))) => Ok(subgroup),
+            Ok(Some(UniStreamData::Fetch(_))) => {
+                unreachable!("Unexpected fetch data in subgroup stream")
+            }
             Ok(None) => {
                 tracing::info!("Stream data ended");
                 anyhow::bail!("Stream data ended")

--- a/moqt/src/modules/moqt/data_plane/stream/stream_data_receiver_factory.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/stream_data_receiver_factory.rs
@@ -38,6 +38,9 @@ impl<T: TransportProtocol> StreamDataReceiverFactory<T> {
             Some(IncomingObject::Datagram(_)) => {
                 anyhow::bail!("Expected StreamHeader but got Datagram")
             }
+            Some(IncomingObject::Fetch { .. }) => {
+                anyhow::bail!("Expected StreamHeader but got Fetch")
+            }
             None => anyhow::bail!("Stream channel closed"),
         }
     }

--- a/moqt/src/modules/moqt/data_plane/stream/stream_receiver.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/stream_receiver.rs
@@ -3,14 +3,14 @@ use tokio_util::codec::{Decoder, FramedRead};
 
 use crate::modules::moqt::{
     data_plane::codec::{
-        control_message_decoder::ControlMessageDecoder, subgroup_decoder::SubgroupDecoder,
-        tokio_reader::Reader,
+        control_message_decoder::ControlMessageDecoder, tokio_reader::Reader,
+        uni_stream_decoder::UniStreamDecoder,
     },
     protocol::TransportProtocol,
 };
 
 pub(crate) type BiStreamReceiver<T> = StreamReceiver<T, 1024, ControlMessageDecoder>;
-pub(crate) type UniStreamReceiver<T> = StreamReceiver<T, { 64 * 1024 }, SubgroupDecoder>;
+pub(crate) type UniStreamReceiver<T> = StreamReceiver<T, { 64 * 1024 }, UniStreamDecoder>;
 
 #[derive(Debug)]
 pub(crate) enum StreamReceiveError {

--- a/moqt/src/modules/moqt/domains.rs
+++ b/moqt/src/modules/moqt/domains.rs
@@ -1,5 +1,6 @@
 pub(crate) mod connecting;
 pub(crate) mod endpoint;
+pub(crate) mod fetch_handle;
 pub(crate) mod published_resource;
 pub(crate) mod publisher;
 pub(crate) mod session;

--- a/moqt/src/modules/moqt/domains/fetch_handle.rs
+++ b/moqt/src/modules/moqt/domains/fetch_handle.rs
@@ -1,0 +1,23 @@
+use crate::{
+    GroupOrder, Location,
+    modules::moqt::control_plane::control_messages::messages::fetch_ok::FetchOk,
+};
+
+#[derive(Debug)]
+pub struct FetchHandle {
+    pub request_id: u64,
+    pub group_order: GroupOrder,
+    pub end_of_track: bool,
+    pub end_location: Location,
+}
+
+impl FetchHandle {
+    pub(crate) fn new(fetch_ok: FetchOk) -> Self {
+        Self {
+            request_id: fetch_ok.request_id,
+            group_order: fetch_ok.group_order,
+            end_of_track: fetch_ok.end_of_track,
+            end_location: fetch_ok.end_location,
+        }
+    }
+}

--- a/moqt/src/modules/moqt/domains/publisher.rs
+++ b/moqt/src/modules/moqt/domains/publisher.rs
@@ -5,18 +5,27 @@ use anyhow::bail;
 
 use crate::{
     DatagramSender,
-    modules::moqt::{
-        control_plane::{
-            control_messages::{
-                control_message_type::ControlMessageType,
-                messages::{publish::Publish, publish_namespace::PublishNamespace},
+    modules::{
+        moqt::{
+            control_plane::{
+                control_messages::{
+                    control_message_type::ControlMessageType,
+                    messages::{publish::Publish, publish_namespace::PublishNamespace},
+                },
+                enums::ResponseMessage,
+                options::PublishOption,
             },
-            enums::ResponseMessage,
-            options::PublishOption,
+            data_plane::{
+                object::fetch::FetchHeader,
+                stream::{
+                    fetch_data_sender::FetchDataSender,
+                    stream_data_sender_factory::StreamDataSenderFactory,
+                },
+            },
+            domains::{published_resource::PublishedResource, session_context::SessionContext},
+            protocol::TransportProtocol,
         },
-        data_plane::stream::stream_data_sender_factory::StreamDataSenderFactory,
-        domains::{published_resource::PublishedResource, session_context::SessionContext},
-        protocol::TransportProtocol,
+        transport::transport_connection::TransportConnection,
     },
 };
 
@@ -137,5 +146,10 @@ impl<T: TransportProtocol> Publisher<T> {
 
     pub fn create_datagram(&self, published_resource: &PublishedResource) -> DatagramSender<T> {
         DatagramSender::new(published_resource.track_alias, self.session.clone())
+    }
+
+    pub async fn create_fetch_stream(&self, request_id: u64) -> anyhow::Result<FetchDataSender<T>> {
+        let send_stream = self.session.transport_connection.open_uni().await?;
+        FetchDataSender::new(send_stream, FetchHeader::new(request_id)).await
     }
 }

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -25,6 +25,10 @@ pub(crate) struct SessionContext<T: TransportProtocol> {
         tokio::sync::RwLock<HashMap<u64, tokio::sync::mpsc::UnboundedSender<IncomingObject<T>>>>,
     pub(crate) receiver_map:
         tokio::sync::Mutex<HashMap<u64, tokio::sync::mpsc::UnboundedReceiver<IncomingObject<T>>>>,
+    pub(crate) fetch_notification_map:
+        tokio::sync::RwLock<HashMap<u64, tokio::sync::mpsc::UnboundedSender<IncomingObject<T>>>>,
+    pub(crate) fetch_receiver_map:
+        tokio::sync::Mutex<HashMap<u64, tokio::sync::mpsc::UnboundedReceiver<IncomingObject<T>>>>,
 }
 
 impl<T: TransportProtocol> SessionContext<T> {
@@ -43,6 +47,8 @@ impl<T: TransportProtocol> SessionContext<T> {
             sender_map: tokio::sync::Mutex::new(HashMap::new()),
             notification_map: tokio::sync::RwLock::new(HashMap::new()),
             receiver_map: tokio::sync::Mutex::new(HashMap::new()),
+            fetch_notification_map: tokio::sync::RwLock::new(HashMap::new()),
+            fetch_receiver_map: tokio::sync::Mutex::new(HashMap::new()),
         }
     }
 

--- a/moqt/src/modules/moqt/domains/subscriber.rs
+++ b/moqt/src/modules/moqt/domains/subscriber.rs
@@ -4,23 +4,23 @@ use anyhow::bail;
 use tracing::Instrument;
 
 use crate::{
-    DatagramReceiver, SubscribeOption, Subscription,
+    DatagramReceiver, FetchOption, Location, SubscribeOption, Subscription,
     modules::moqt::{
         control_plane::{
             control_messages::{
                 control_message_type::ControlMessageType,
                 messages::{
-                    subscribe::Subscribe, subscribe_namespace::SubscribeNamespace,
-                    unsubscribe::Unsubscribe,
+                    fetch::Fetch, fetch::FetchType, subscribe::Subscribe,
+                    subscribe_namespace::SubscribeNamespace, unsubscribe::Unsubscribe,
                 },
             },
             enums::ResponseMessage,
         },
         data_plane::stream::{
-            stream_data_receiver::StreamDataReceiver,
+            fetch_data_receiver::FetchDataReceiver, stream_data_receiver::StreamDataReceiver,
             stream_data_receiver_factory::StreamDataReceiverFactory,
         },
-        domains::session_context::SessionContext,
+        domains::{fetch_handle::FetchHandle, session_context::SessionContext},
         protocol::TransportProtocol,
         runtime::dispatch::incoming_object::IncomingObject,
     },
@@ -153,6 +153,83 @@ impl<T: TransportProtocol> Subscriber<T> {
 
     #[tracing::instrument(
         level = "info",
+        name = "moqt.subscriber.fetch",
+        skip_all,
+        fields(track_namespace = %track_namespace, track_name = %track_name)
+    )]
+    pub async fn fetch(
+        &mut self,
+        track_namespace: String,
+        track_name: String,
+        start_location: Location,
+        end_location: Location,
+        option: FetchOption,
+    ) -> anyhow::Result<FetchHandle> {
+        let vec_namespace = track_namespace.split('/').map(|s| s.to_string()).collect();
+        let request_id = self.session.get_request_id();
+
+        let (fetch_stream_tx, fetch_stream_rx) =
+            tokio::sync::mpsc::unbounded_channel::<IncomingObject<T>>();
+        self.session
+            .fetch_notification_map
+            .write()
+            .await
+            .insert(request_id, fetch_stream_tx);
+        self.session
+            .fetch_receiver_map
+            .lock()
+            .await
+            .insert(request_id, fetch_stream_rx);
+
+        let (fetch_message_tx, fetch_message_rx) =
+            tokio::sync::oneshot::channel::<ResponseMessage>();
+        self.session
+            .sender_map
+            .lock()
+            .await
+            .insert(request_id, fetch_message_tx);
+        let fetch = Fetch {
+            request_id,
+            subscriber_priority: option.subscriber_priority,
+            group_order: option.group_order,
+            fetch_type: FetchType::Standalone {
+                track_namespace: vec_namespace,
+                track_name,
+                start_location,
+                end_location,
+            },
+            authorization_tokens: vec![],
+        };
+        self.session
+            .send_stream
+            .send(ControlMessageType::Fetch, fetch.encode())
+            .await?;
+        let result = fetch_message_rx.await;
+        if let Err(e) = result {
+            bail!("Failed to receive message: {}", e)
+        }
+        let response = result.unwrap();
+        match response {
+            ResponseMessage::FetchOk(fetch_ok) => Ok(FetchHandle::new(fetch_ok)),
+            ResponseMessage::FetchError(_, _, _) => {
+                self.session
+                    .fetch_notification_map
+                    .write()
+                    .await
+                    .remove(&request_id);
+                self.session
+                    .fetch_receiver_map
+                    .lock()
+                    .await
+                    .remove(&request_id);
+                bail!("Fetch error")
+            }
+            _ => bail!("Protocol violation"),
+        }
+    }
+
+    #[tracing::instrument(
+        level = "info",
         name = "moqt.subscriber.unsubscribe",
         skip_all,
         fields(subscribe_id = %subscribe_id)
@@ -166,6 +243,39 @@ impl<T: TransportProtocol> Subscriber<T> {
             .send(ControlMessageType::UnSubscribe, unsubscribe.encode())
             .await?;
         Ok(())
+    }
+
+    #[tracing::instrument(
+        level = "info",
+        name = "moqt.subscriber.accept_fetch_receiver",
+        skip_all,
+        fields(request_id = fetch_handle.request_id)
+    )]
+    pub async fn accept_fetch_receiver(
+        &mut self,
+        fetch_handle: &FetchHandle,
+    ) -> anyhow::Result<FetchDataReceiver<T>> {
+        let request_id = fetch_handle.request_id;
+        let mut fetch_stream_rx = self
+            .session
+            .fetch_receiver_map
+            .lock()
+            .await
+            .remove(&request_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "fetch stream receiver already consumed for request_id: {}",
+                    request_id
+                )
+            })?;
+        let incoming_track_data = fetch_stream_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Failed to receive fetch stream"))?;
+        match incoming_track_data {
+            IncomingObject::Fetch { stream, header } => Ok(FetchDataReceiver::new(stream, header)),
+            _ => unreachable!("FetchReceiver can only receive IncomingObject::Fetch"),
+        }
     }
 
     #[tracing::instrument(
@@ -207,6 +317,9 @@ impl<T: TransportProtocol> Subscriber<T> {
                 IncomingObject::Datagram(_) => {
                     span.record("object_kind", "datagram");
                 }
+                IncomingObject::Fetch { .. } => {
+                    span.record("object_kind", "fetch");
+                }
             }
             stream_with_object
         };
@@ -220,6 +333,9 @@ impl<T: TransportProtocol> Subscriber<T> {
             IncomingObject::Datagram(object) => {
                 let data_receiver = DatagramReceiver::new(object, receiver).await;
                 Ok(DataReceiver::Datagram(data_receiver))
+            }
+            IncomingObject::Fetch { .. } => {
+                anyhow::bail!("Expected StreamHeader or Datagram but got Fetch")
             }
         }
     }

--- a/moqt/src/modules/moqt/runtime/dispatch.rs
+++ b/moqt/src/modules/moqt/runtime/dispatch.rs
@@ -1,2 +1,3 @@
+pub(crate) mod fetch_notifier;
 pub(crate) mod incoming_object;
 pub(crate) mod subscription_notifier;

--- a/moqt/src/modules/moqt/runtime/dispatch/fetch_notifier.rs
+++ b/moqt/src/modules/moqt/runtime/dispatch/fetch_notifier.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use crate::{
+    TransportProtocol,
+    modules::moqt::{
+        domains::session_context::SessionContext,
+        runtime::dispatch::incoming_object::IncomingObject,
+    },
+};
+
+pub(crate) struct FetchNotifier;
+
+impl FetchNotifier {
+    #[tracing::instrument(
+        level = "info",
+        name = "moqt.fetch_notifier.notify",
+        skip_all,
+        fields(request_id = request_id)
+    )]
+    pub(crate) async fn notify<T: TransportProtocol>(
+        context: &Arc<SessionContext<T>>,
+        request_id: u64,
+        incoming_object: IncomingObject<T>,
+    ) {
+        if let Some(sender) = context.fetch_notification_map.read().await.get(&request_id) {
+            if let Err(e) = sender.send(incoming_object) {
+                tracing::warn!("Failed to notify fetch stream: {}", e);
+            }
+        } else {
+            tracing::error!("No sender found for request_id: {}", request_id);
+        }
+    }
+}

--- a/moqt/src/modules/moqt/runtime/dispatch/incoming_object.rs
+++ b/moqt/src/modules/moqt/runtime/dispatch/incoming_object.rs
@@ -1,7 +1,7 @@
 use crate::{
     TransportProtocol,
     modules::moqt::data_plane::{
-        object::{object_datagram::ObjectDatagram, subgroup::SubgroupHeader},
+        object::{fetch::FetchHeader, object_datagram::ObjectDatagram, subgroup::SubgroupHeader},
         stream::stream_receiver::UniStreamReceiver,
     },
 };
@@ -12,4 +12,8 @@ pub(crate) enum IncomingObject<T: TransportProtocol> {
         header: SubgroupHeader,
     },
     Datagram(ObjectDatagram),
+    Fetch {
+        stream: UniStreamReceiver<T>,
+        header: FetchHeader,
+    },
 }

--- a/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
+++ b/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
@@ -8,7 +8,7 @@ use crate::{
         control_plane::{
             enums::ResponseMessage,
             handler::{
-                publish_handler::PublishHandler,
+                fetch_handler::FetchHandler, publish_handler::PublishHandler,
                 publish_namespace_handler::PublishNamespaceHandler,
                 subscribe_handler::SubscribeHandler,
                 subscribe_namespace_handler::SubscribeNamespaceHandler,
@@ -180,6 +180,11 @@ impl ControlMessageReceiveTask {
                 let response =
                     ResponseMessage::SubscribeNameSpaceError(request_id, error_code, reason_phrase);
                 DepacketizeResult::ResponseMessage(request_id, response)
+            }
+            ReceivedMessage::Fetch(fetch) => {
+                tracing::debug!("Event: Fetch");
+                let fetch_handler = FetchHandler::new(session.clone(), fetch);
+                DepacketizeResult::SessionEvent(SessionEvent::<T>::Fetch(fetch_handler))
             }
             ReceivedMessage::FetchOk(fetch_ok) => {
                 tracing::debug!("Event: Fetch ok");

--- a/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
+++ b/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
@@ -181,6 +181,12 @@ impl ControlMessageReceiveTask {
                     ResponseMessage::SubscribeNameSpaceError(request_id, error_code, reason_phrase);
                 DepacketizeResult::ResponseMessage(request_id, response)
             }
+            ReceivedMessage::FetchOk(fetch_ok) => {
+                tracing::debug!("Event: Fetch ok");
+                let request_id = fetch_ok.request_id;
+                let response = ResponseMessage::FetchOk(fetch_ok);
+                DepacketizeResult::ResponseMessage(request_id, response)
+            }
             _ => todo!(),
         }
     }

--- a/moqt/src/modules/moqt/runtime/tasks/uni_stream_receive_task.rs
+++ b/moqt/src/modules/moqt/runtime/tasks/uni_stream_receive_task.rs
@@ -7,12 +7,13 @@ use crate::{
     modules::{
         moqt::{
             data_plane::{
-                codec::subgroup_decoder::SubgroupDecoder,
-                stream::stream_receiver::UniStreamReceiver,
+                codec::uni_stream_decoder::{UniStreamData, UniStreamDecoder},
+                stream::{fetch_data_receiver::Fetch, stream_receiver::UniStreamReceiver},
             },
             domains::session_context::SessionContext,
             runtime::dispatch::{
-                incoming_object::IncomingObject, subscription_notifier::SubscriptionNotifier,
+                fetch_notifier::FetchNotifier, incoming_object::IncomingObject,
+                subscription_notifier::SubscriptionNotifier,
             },
         },
         transport::transport_connection::TransportConnection,
@@ -34,7 +35,8 @@ impl UniStreamReceiveTask {
                     loop {
                         match context.transport_connection.accept_uni().await {
                             Ok(stream) => {
-                                let stream = UniStreamReceiver::new(stream, SubgroupDecoder::new());
+                                let stream =
+                                    UniStreamReceiver::new(stream, UniStreamDecoder::new());
                                 Self::on_stream_received(&context, stream).await;
                             }
                             Err(_) => {
@@ -54,14 +56,11 @@ impl UniStreamReceiveTask {
         context: &Arc<SessionContext<T>>,
         mut stream: UniStreamReceiver<T>,
     ) -> bool {
-        let subgroup = match stream.receive().await {
-            Ok(subgroup) => {
-                if let Some(subgroup) = subgroup {
-                    subgroup
-                } else {
-                    tracing::info!("Stream closed before receiving data");
-                    return false;
-                }
+        let stream_data = match stream.receive().await {
+            Ok(Some(stream_data)) => stream_data,
+            Ok(None) => {
+                tracing::info!("Stream closed before receiving data");
+                return false;
             }
             Err(_) => {
                 tracing::error!("Stream closed before receiving data");
@@ -69,23 +68,28 @@ impl UniStreamReceiveTask {
             }
         };
 
-        let subgroup_header = match subgroup {
-            Subgroup::Header(header) => header,
+        match stream_data {
+            UniStreamData::Subgroup(Subgroup::Header(header)) => {
+                SubscriptionNotifier::notify(
+                    context,
+                    header.track_alias,
+                    IncomingObject::StreamHeader { stream, header },
+                )
+                .await;
+            }
+            UniStreamData::Fetch(Fetch::Header(header)) => {
+                FetchNotifier::notify(
+                    context,
+                    header.request_id,
+                    IncomingObject::Fetch { stream, header },
+                )
+                .await;
+            }
             _ => {
-                tracing::error!("First message in stream is not a subgroup header");
+                tracing::error!("First message in stream is not a header");
                 return false;
             }
-        };
-
-        SubscriptionNotifier::notify(
-            context,
-            subgroup_header.track_alias,
-            IncomingObject::StreamHeader {
-                stream,
-                header: subgroup_header,
-            },
-        )
-        .await;
+        }
         true
     }
 }

--- a/moqt/src/wire.rs
+++ b/moqt/src/wire.rs
@@ -14,6 +14,8 @@ pub use crate::modules::moqt::control_plane::control_messages::messages::paramet
 pub use crate::modules::moqt::control_plane::control_messages::messages::parameters::group_order::GroupOrder;
 pub use crate::modules::moqt::control_plane::control_messages::messages::parameters::location::Location;
 pub use crate::modules::moqt::control_plane::control_messages::messages::parameters::setup_parameters::SetupParameter;
+pub use crate::modules::moqt::control_plane::control_messages::messages::fetch::Fetch;
+pub use crate::modules::moqt::control_plane::control_messages::messages::fetch::FetchType;
 pub use crate::modules::moqt::control_plane::control_messages::messages::publish::Publish;
 pub use crate::modules::moqt::control_plane::control_messages::messages::publish_namespace::PublishNamespace;
 pub use crate::modules::moqt::control_plane::control_messages::messages::publish_ok::PublishOk;

--- a/moqt/src/wire.rs
+++ b/moqt/src/wire.rs
@@ -38,6 +38,7 @@ pub type PublishNamespaceError = RequestError;
 pub type SubscribeNamespaceError = RequestError;
 pub type PublishError = RequestError;
 pub type SubscribeError = RequestError;
+pub type FetchError = RequestError;
 
 pub fn encode_control_message(message_type: ControlMessageType, payload: BytesMut) -> BytesMut {
     let mut buf = BytesMut::new();

--- a/relay/src/modules/core/data_sender.rs
+++ b/relay/src/modules/core/data_sender.rs
@@ -1,4 +1,5 @@
 pub(crate) mod datagram_sender;
+pub(crate) mod fetch_sender;
 pub(crate) mod stream_sender;
 pub(crate) mod stream_sender_factory;
 

--- a/relay/src/modules/core/data_sender/fetch_sender.rs
+++ b/relay/src/modules/core/data_sender/fetch_sender.rs
@@ -1,0 +1,16 @@
+#[async_trait::async_trait]
+pub(crate) trait FetchSender: 'static + Send + Sync {
+    async fn send(&self, object: moqt::FetchObjectField) -> anyhow::Result<()>;
+    async fn close(&self) -> anyhow::Result<()>;
+}
+
+#[async_trait::async_trait]
+impl<T: moqt::TransportProtocol> FetchSender for moqt::FetchDataSender<T> {
+    async fn send(&self, object: moqt::FetchObjectField) -> anyhow::Result<()> {
+        self.send(object).await
+    }
+
+    async fn close(&self) -> anyhow::Result<()> {
+        self.close().await
+    }
+}

--- a/relay/src/modules/core/handler.rs
+++ b/relay/src/modules/core/handler.rs
@@ -1,3 +1,4 @@
+pub(crate) mod fetch;
 pub(crate) mod publish;
 pub(crate) mod publish_namespace;
 pub(crate) mod subscribe;

--- a/relay/src/modules/core/handler/fetch.rs
+++ b/relay/src/modules/core/handler/fetch.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub(crate) trait FetchHandler: 'static + Send + Sync {
+    fn request_id(&self) -> u64;
+    fn fetch_type(&self) -> moqt::wire::FetchType;
+    async fn ok(
+        &self,
+        end_of_track: bool,
+        end_location: moqt::Location,
+    ) -> Result<(), moqt::TransportSendError>;
+    async fn error(&self, code: u64, reason: String) -> Result<(), moqt::TransportSendError>;
+}
+
+#[async_trait]
+impl<T: moqt::TransportProtocol> FetchHandler for moqt::FetchHandler<T> {
+    fn request_id(&self) -> u64 {
+        self.request_id
+    }
+
+    fn fetch_type(&self) -> moqt::wire::FetchType {
+        self.fetch.fetch_type.clone()
+    }
+
+    async fn ok(
+        &self,
+        end_of_track: bool,
+        end_location: moqt::Location,
+    ) -> Result<(), moqt::TransportSendError> {
+        self.ok(end_of_track, end_location).await
+    }
+
+    async fn error(&self, code: u64, reason: String) -> Result<(), moqt::TransportSendError> {
+        self.error(code, reason).await
+    }
+}

--- a/relay/src/modules/core/publisher.rs
+++ b/relay/src/modules/core/publisher.rs
@@ -4,6 +4,7 @@ use crate::modules::core::{
     data_sender::{
         DataSender,
         datagram_sender::DatagramSender,
+        fetch_sender::FetchSender,
         stream_sender_factory::{ConcreteStreamSenderFactory, StreamSenderFactory},
     },
     published_resource::PublishedResource,
@@ -22,6 +23,7 @@ pub(crate) trait Publisher: 'static + Send + Sync {
         published_resource: &PublishedResource,
     ) -> Box<dyn StreamSenderFactory>;
     fn new_datagram(&self, published_resource: &PublishedResource) -> Box<dyn DataSender>;
+    async fn new_fetch_sender(&self, request_id: u64) -> anyhow::Result<Box<dyn FetchSender>>;
 }
 
 #[async_trait]
@@ -56,5 +58,10 @@ impl<T: moqt::TransportProtocol> Publisher for moqt::Publisher<T> {
         let sender = self.create_datagram(published_resource.as_moqt());
         let sender = DatagramSender::new(sender);
         Box::new(sender)
+    }
+
+    async fn new_fetch_sender(&self, request_id: u64) -> anyhow::Result<Box<dyn FetchSender>> {
+        let sender = self.create_fetch_stream(request_id).await?;
+        Ok(Box::new(sender))
     }
 }

--- a/relay/src/modules/core/session.rs
+++ b/relay/src/modules/core/session.rs
@@ -41,6 +41,9 @@ impl<T: moqt::TransportProtocol> Session for moqt::Session<T> {
             }
             moqt::SessionEvent::Disconnected() => MoqtSessionEvent::Disconnected(),
             moqt::SessionEvent::ProtocolViolation() => MoqtSessionEvent::ProtocolViolation(),
+            moqt::SessionEvent::Fetch(fetch_handler) => {
+                MoqtSessionEvent::Fetch(Box::new(fetch_handler))
+            }
         };
         Ok(result)
     }

--- a/relay/src/modules/core/session_event.rs
+++ b/relay/src/modules/core/session_event.rs
@@ -1,5 +1,5 @@
 use crate::modules::core::handler::{
-    publish::PublishHandler, publish_namespace::PublishNamespaceHandler,
+    fetch::FetchHandler, publish::PublishHandler, publish_namespace::PublishNamespaceHandler,
     subscribe::SubscribeHandler, subscribe_namespace::SubscribeNamespaceHandler,
     unsubscribe::UnsubscribeHandler,
 };
@@ -10,6 +10,7 @@ pub(crate) enum MoqtSessionEvent {
     Publish(Box<dyn PublishHandler>),
     Subscribe(Box<dyn SubscribeHandler>),
     Unsubscribe(Box<dyn UnsubscribeHandler>),
+    Fetch(Box<dyn FetchHandler>),
     Disconnected(),
     ProtocolViolation(),
 }
@@ -22,6 +23,7 @@ impl std::fmt::Debug for MoqtSessionEvent {
             MoqtSessionEvent::Publish(_) => "Publish",
             MoqtSessionEvent::Subscribe(_) => "Subscribe",
             MoqtSessionEvent::Unsubscribe(_) => "Unsubscribe",
+            MoqtSessionEvent::Fetch(_) => "Fetch",
             MoqtSessionEvent::Disconnected() => "Disconnected",
             MoqtSessionEvent::ProtocolViolation() => "ProtocolViolation",
         };

--- a/relay/src/modules/event_handler.rs
+++ b/relay/src/modules/event_handler.rs
@@ -4,6 +4,7 @@ use tokio::sync::mpsc;
 use crate::modules::{
     relay::{egress::coordinator::EgressCommand, ingress::ingress_coordinator::IngressCommand},
     sequences::{
+        fetch::Fetch,
         notifier::SessionSignalingDispatcher,
         publish::Publish,
         publish_namespace::PublishNamespace,
@@ -64,6 +65,7 @@ impl EventHandler {
                             | SessionEvent::Publish(session_id, _)
                             | SessionEvent::Subscribe(session_id, _)
                             | SessionEvent::Unsubscribe(session_id, _)
+                            | SessionEvent::Fetch(session_id, _)
                             | SessionEvent::Disconnected(session_id)
                             | SessionEvent::ProtocolViolation(session_id) => *session_id,
                         };
@@ -139,6 +141,18 @@ impl EventHandler {
                                         signaling_state_table.as_ref(),
                                         &session_signaling_dispatcher,
                                         &ingress_sender,
+                                        &egress_sender,
+                                        handler,
+                                    )
+                                    .await;
+                            }
+                            SessionEvent::Fetch(session_id, handler) => {
+                                let fetch = Fetch {};
+                                fetch
+                                    .handle(
+                                        session_id,
+                                        &session_span,
+                                        signaling_state_table.as_ref(),
                                         &egress_sender,
                                         handler,
                                     )
@@ -254,6 +268,13 @@ impl EventHandler {
                 "relay.session.event",
                 session_id = %session_id,
                 event = "Disconnected",
+            ),
+            SessionEvent::Fetch(session_id, handler) => tracing::info_span!(
+                parent: session_span,
+                "relay.session.event",
+                session_id = %session_id,
+                event = "Fetch",
+                request_id = handler.request_id(),
             ),
             SessionEvent::ProtocolViolation(session_id) => tracing::info_span!(
                 parent: session_span,

--- a/relay/src/modules/event_resolver/moqt_relay_event_resolver.rs
+++ b/relay/src/modules/event_resolver/moqt_relay_event_resolver.rs
@@ -18,6 +18,7 @@ impl RelaySessionEventResolver {
             MoqtSessionEvent::Unsubscribe(handler) => {
                 SessionEvent::Unsubscribe(session_id, handler)
             }
+            MoqtSessionEvent::Fetch(handler) => SessionEvent::Fetch(session_id, handler),
             MoqtSessionEvent::Disconnected() => SessionEvent::Disconnected(session_id),
             MoqtSessionEvent::ProtocolViolation() => SessionEvent::ProtocolViolation(session_id),
         }

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -58,4 +58,8 @@ impl GroupCache {
     pub(crate) async fn is_closed(&self) -> bool {
         *self.end_of_group.read().await
     }
+
+    pub(crate) async fn snapshot(&self) -> Vec<Arc<DataObject>> {
+        self.objects.read().await.clone()
+    }
 }

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -15,6 +15,11 @@ impl TrackCacheStore {
         }
     }
 
+    pub(crate) fn get(&self, track_key: TrackKey) -> Option<Arc<TrackCache>> {
+        // clone the Arc to drop the Ref and release the DashMap shard lock
+        self.caches.get(&track_key).map(|v| v.clone())
+    }
+
     pub(crate) fn get_or_create(&self, track_key: TrackKey) -> Arc<TrackCache> {
         self.caches
             .entry(track_key)

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -158,4 +158,95 @@ impl TrackCache {
             .map(|subgroups| subgroups.keys().cloned().collect())
             .unwrap_or_default()
     }
+
+    pub(crate) async fn get_fetch_objects(
+        &self,
+        start: moqt::Location,
+        end: moqt::Location,
+    ) -> Vec<moqt::FetchObjectField> {
+        // Collect all GroupCaches in the requested group range, tagged with their group_id.
+        // Example for start={group=1, object=3}, end={group=2, object=5}:
+        //   [(1, GroupCache),  // group=1, subgroup=0
+        //    (1, GroupCache),  // group=1, subgroup=1  <- group 1 has 2 subgroups
+        //    (2, GroupCache)]  // group=2, subgroup=0
+        let caches_in_range: Vec<(u64, Arc<GroupCache>)> = {
+            // NOTE: Datagram objects are not included.
+            let groups = self.stream_groups.read().await;
+            let mut caches_in_range = Vec::new();
+            for (&group_id, subgroup_map) in groups.range(start.group_id..=end.group_id) {
+                for cache in subgroup_map.values() {
+                    caches_in_range.push((group_id, cache.clone()));
+                }
+            }
+            caches_in_range
+        };
+
+        // Convert each GroupCache into FetchObjectFields.
+        // For the first and last group, filter objects by object_id.
+        // Example for start={group=1, object=3}, end={group=2, object=5}:
+        //   group=1: skip object_id 0,1,2 -> include 3,4,...
+        //   group=2: include object_id 0,1,2,3,4 -> stop before 5 (exclusive)
+        let mut fetch_objects = Vec::new();
+        for (group_id, cache) in caches_in_range {
+            let subgroup_objects = cache.snapshot().await;
+
+            let Some(header) = subgroup_objects.first() else {
+                tracing::error!("unexpected: GroupCache is empty");
+                continue;
+            };
+            let (publisher_priority, subgroup_id) = match header.as_ref() {
+                DataObject::SubgroupHeader(h) => (h.publisher_priority, h.subgroup_id.resolve()),
+                _ => {
+                    tracing::error!("unexpected: GroupCache does not start with SubgroupHeader");
+                    continue;
+                }
+            };
+
+            let mut prev_object_id: Option<u64> = None;
+            // skip index=0 which is SubgroupHeader
+            for obj in subgroup_objects.iter().skip(1) {
+                let field = match obj.as_ref() {
+                    DataObject::SubgroupObject(f) => f,
+                    _ => continue,
+                };
+                // Resolve absolute object_id from object_id_delta
+                let current_object_id = field.resolve_object_id(prev_object_id);
+                prev_object_id = Some(current_object_id);
+
+                // Apply range filter for first and last groups
+                if group_id == start.group_id && current_object_id < start.object_id {
+                    continue;
+                }
+                // end.object_id == 0 means entire group is requested
+                if group_id == end.group_id
+                    && end.object_id != 0
+                    && current_object_id > end.object_id
+                {
+                    break;
+                }
+
+                // Convert to FetchObjectField and append to fetch_objects
+                let fetch_object = match &field.subgroup_object {
+                    moqt::SubgroupObject::Payload { data, .. } => {
+                        moqt::FetchObject::Payload(data.clone())
+                    }
+                    moqt::SubgroupObject::Status { code, .. } => {
+                        let Ok(status) = moqt::ObjectStatus::try_from(*code as u8) else {
+                            continue;
+                        };
+                        moqt::FetchObject::Status(status)
+                    }
+                };
+                fetch_objects.push(moqt::FetchObjectField::new(
+                    group_id,
+                    subgroup_id,
+                    current_object_id,
+                    publisher_priority,
+                    field.extension_headers.clone(),
+                    fetch_object,
+                ));
+            }
+        }
+        fetch_objects
+    }
 }

--- a/relay/src/modules/relay/egress/coordinator.rs
+++ b/relay/src/modules/relay/egress/coordinator.rs
@@ -23,12 +23,21 @@ pub(crate) struct EgressStartRequest {
     pub(crate) parent_span: Span,
 }
 
+pub(crate) struct EgressFetchRequest {
+    pub(crate) subscriber_session_id: SessionId,
+    pub(crate) request_id: u64,
+    pub(crate) track_key: TrackKey,
+    pub(crate) start_location: moqt::Location,
+    pub(crate) end_location: moqt::Location,
+}
+
 pub(crate) enum EgressCommand {
     StartReader(Box<EgressStartRequest>),
     StopReader {
         subscriber_session_id: SessionId,
         downstream_subscribe_id: u64,
     },
+    StartFetch(EgressFetchRequest),
 }
 
 pub(crate) struct EgressCoordinator {
@@ -81,6 +90,14 @@ impl EgressCoordinator {
                             handle.abort();
                         }
                     }
+                    EgressCommand::StartFetch(request) => {
+                        Self::spawn_fetch_delivery(
+                            session_repo.clone(),
+                            cache_store.clone(),
+                            request,
+                        )
+                        .await;
+                    }
                 }
             }
 
@@ -97,6 +114,49 @@ impl EgressCoordinator {
 
     pub(crate) fn sender(&self) -> mpsc::Sender<EgressCommand> {
         self.command_sender.clone()
+    }
+
+    async fn spawn_fetch_delivery(
+        session_repo: Arc<tokio::sync::Mutex<SessionRepository>>,
+        cache_store: Arc<TrackCacheStore>,
+        request: EgressFetchRequest,
+    ) {
+        // publisher = relay's outbound handle to the session that issued FETCH
+        let publisher = session_repo
+            .lock()
+            .await
+            .publisher(request.subscriber_session_id);
+        let Some(publisher) = publisher else {
+            tracing::error!("session not found for fetch");
+            return;
+        };
+
+        let Some(cache) = cache_store.get(request.track_key) else {
+            tracing::error!("cache not found for fetch");
+            return;
+        };
+
+        tokio::spawn(async move {
+            let sender = match publisher.new_fetch_sender(request.request_id).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!(?e, "failed to create fetch sender");
+                    return;
+                }
+            };
+            let objects = cache
+                .get_fetch_objects(request.start_location, request.end_location)
+                .await;
+            for object in objects {
+                if let Err(e) = sender.send(object).await {
+                    tracing::error!(?e, "failed to send fetch object");
+                    return;
+                }
+            }
+            if let Err(e) = sender.close().await {
+                tracing::error!(?e, "failed to close fetch stream");
+            }
+        });
     }
 
     async fn spawn_runner(

--- a/relay/src/modules/sequences.rs
+++ b/relay/src/modules/sequences.rs
@@ -1,3 +1,4 @@
+pub(crate) mod fetch;
 pub(crate) mod notifier;
 pub(crate) mod publish;
 pub(crate) mod publish_namespace;

--- a/relay/src/modules/sequences/fetch.rs
+++ b/relay/src/modules/sequences/fetch.rs
@@ -1,0 +1,116 @@
+use tracing::Span;
+
+use crate::modules::{
+    core::handler::fetch::FetchHandler,
+    relay::egress::coordinator::{EgressCommand, EgressFetchRequest},
+    sequences::tables::table::SignalingStateTable,
+    types::SessionId,
+};
+
+pub(crate) struct Fetch;
+
+impl Fetch {
+    #[tracing::instrument(
+        level = "info",
+        name = "relay.sequence.fetch",
+        skip_all,
+        parent = session_span,
+        fields(session_id = %session_id)
+    )]
+    pub(crate) async fn handle(
+        &self,
+        session_id: SessionId,
+        session_span: &Span,
+        table: &dyn SignalingStateTable,
+        egress_sender: &tokio::sync::mpsc::Sender<EgressCommand>,
+        handler: Box<dyn FetchHandler>,
+    ) {
+        let (track_namespace, track_name, start_group, start_object, end_group, end_object) =
+            match handler.fetch_type() {
+                // TODO: implement relative/absolute joining fetch.
+                moqt::wire::FetchType::Standalone {
+                    track_namespace,
+                    track_name,
+                    start_location,
+                    end_location,
+                } => (
+                    track_namespace.join("/"),
+                    track_name,
+                    start_location.group_id,
+                    start_location.object_id,
+                    end_location.group_id,
+                    end_location.object_id,
+                ),
+                moqt::wire::FetchType::RelativeJoining { .. }
+                | moqt::wire::FetchType::AbsoluteJoining { .. } => {
+                    tracing::warn!("Joining fetch is not yet implemented");
+                    // 0 = Internal Error (TODO: use proper FetchErrorCode enum)
+                    let _ = handler
+                        .error(0, "Joining fetch is not yet implemented".to_string())
+                        .await;
+                    return;
+                }
+            };
+
+        // FIXME: Fetch fails if publisher has disconnected, even if cached data exists.
+        // Root cause: active_upstream_subscriptions are cleared on publisher disconnect,
+        // so track_key cannot be resolved after that.
+        let active_upstream_keys =
+            table.find_active_upstream_subscriptions(&track_namespace, &track_name);
+        let Some(key) = active_upstream_keys.into_iter().next() else {
+            tracing::warn!(
+                track_namespace,
+                track_name,
+                "No active upstream subscription found for fetch"
+            );
+            // TODO: use proper FetchErrorCode enum. 0x4 = TRACK_DOES_NOT_EXIST
+            let _ = handler.error(0x4, "Track not found".to_string()).await;
+            return;
+        };
+        let Some(active_upstream) = table.get_active_upstream_subscription(
+            key.publisher_session_id,
+            &track_namespace,
+            &track_name,
+        ) else {
+            tracing::warn!(
+                track_namespace,
+                track_name,
+                "Active upstream subscription data not found"
+            );
+            let _ = handler.error(0x4, "Track not found".to_string()).await;
+            return;
+        };
+        let track_key = active_upstream.track_key;
+
+        // Send FETCH_OK on the control stream.
+        // FIXME: end_location should reflect the last object actually available in cache,
+        // not the requested end.
+        let end_location = moqt::Location {
+            group_id: end_group,
+            object_id: end_object,
+        };
+
+        if let Err(e) = handler.ok(false, end_location).await {
+            tracing::error!(?e, "Failed to send FETCH_OK");
+            return;
+        }
+
+        // Delegate data delivery to egress.
+        let fetch_request = EgressFetchRequest {
+            subscriber_session_id: session_id,
+            request_id: handler.request_id(),
+            track_key,
+            start_location: moqt::Location {
+                group_id: start_group,
+                object_id: start_object,
+            },
+            end_location,
+        };
+        if let Err(e) = egress_sender
+            .send(EgressCommand::StartFetch(fetch_request))
+            .await
+        {
+            tracing::error!(?e, "Failed to send fetch request to egress");
+        }
+    }
+}

--- a/relay/src/modules/session_event.rs
+++ b/relay/src/modules/session_event.rs
@@ -1,5 +1,5 @@
 use crate::modules::core::handler::{
-    publish::PublishHandler, publish_namespace::PublishNamespaceHandler,
+    fetch::FetchHandler, publish::PublishHandler, publish_namespace::PublishNamespaceHandler,
     subscribe::SubscribeHandler, subscribe_namespace::SubscribeNamespaceHandler,
     unsubscribe::UnsubscribeHandler,
 };
@@ -11,6 +11,7 @@ pub(crate) enum SessionEvent {
     Publish(SessionId, Box<dyn PublishHandler>),
     Subscribe(SessionId, Box<dyn SubscribeHandler>),
     Unsubscribe(SessionId, Box<dyn UnsubscribeHandler>),
+    Fetch(SessionId, Box<dyn FetchHandler>),
     Disconnected(SessionId),
     ProtocolViolation(SessionId),
 }

--- a/relay/src/modules/session_repository.rs
+++ b/relay/src/modules/session_repository.rs
@@ -93,6 +93,14 @@ fn log_session_event(event: &MoqtSessionEvent) {
                 "Received session event"
             );
         }
+        MoqtSessionEvent::Fetch(handler) => {
+            tracing::info!(
+                event = "Fetch",
+                request_id = handler.request_id(),
+                fetch_type = ?handler.fetch_type(),
+                "Received session event"
+            );
+        }
         MoqtSessionEvent::Disconnected() => {
             tracing::info!(event = "Disconnected", "Received session event");
         }


### PR DESCRIPTION
## Summary

- Implement FETCH message wire format per MoQT draft-14
- Add client-side fetch API and relay-side fetch handling
- Add `Fetch::End` variant to distinguish clean stream termination from errors
- Add fetch-e2e example covering 3 fetch scenarios (A/B/C)

## Known Limitations

- Fetch fails if publisher has disconnected (even if cached data exists)
- `end_location` in FETCH_OK reflects requested end, not actual cache state
- Joining fetch not implemented (returns Internal Error)

## Test plan

- [x] Start the relay, then run `cargo run -p fetch-e2e`.
  Alice publishes 3 groups (g0–g2, 5 objects each).
  Bob subscribes live, waits until group 2 arrives (confirming groups 0–1 are cached),
  then issues 3 fetch requests against the relay cache.
  Confirm each fetch returns the expected objects without ERROR logs:
  - fetch A (`g0:o0..g1:o2`): 8 objects
  - fetch B (`g1:o2..g2:o3`): 7 objects
  - fetch C (`g1:o0..g1:o0`, entire group 1): 5 objects
- [x] `cargo clippy` / `cargo fmt --check` / `cargo test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)