### PR TITLE
fix: retrieve cached catalog via Standalone Fetch when content_exists

### DIFF
--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -17,10 +17,11 @@ use bytes::{Buf, Bytes, BytesMut};
 #[cfg(feature = "web_sys_unstable_apis")]
 use moqt::wire::{
     AuthorizationToken, BufGetExt, BufPutExt, ClientSetup, ContentExists, ControlMessageType,
-    DatagramField, ExtensionHeaders, FilterType, GroupOrder, Location, NamespaceOk, ObjectDatagram,
-    ObjectStatus, Publish, PublishNamespace, PublishOk, RequestError, ServerSetup, SetupParameter,
-    SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField, Subscribe, SubscribeNamespace,
-    SubscribeOk, encode_control_message, take_control_message,
+    DatagramField, ExtensionHeaders, Fetch, FetchHeader, FetchObjectField, FetchOk, FetchType,
+    FilterType, GroupOrder, Location, NamespaceOk, ObjectDatagram, ObjectStatus, Publish,
+    PublishNamespace, PublishOk, RequestError, ServerSetup, SetupParameter, SubgroupHeader,
+    SubgroupId, SubgroupObject, SubgroupObjectField, Subscribe, SubscribeNamespace, SubscribeOk,
+    encode_control_message, take_control_message,
 };
 #[cfg(feature = "web_sys_unstable_apis")]
 use std::{
@@ -399,6 +400,16 @@ impl MOQTClient {
         self.callbacks.borrow_mut().subgroup_object_callback = Some(callback);
     }
 
+    #[wasm_bindgen(js_name = onFetchResponse)]
+    pub fn set_fetch_response_callback(&mut self, callback: js_sys::Function) {
+        self.callbacks.borrow_mut().fetch_response_callback = Some(callback);
+    }
+
+    #[wasm_bindgen(js_name = onFetchObject)]
+    pub fn set_fetch_object_callback(&mut self, callback: js_sys::Function) {
+        self.callbacks.borrow_mut().fetch_object_callback = Some(callback);
+    }
+
     #[wasm_bindgen(js_name = onConnectionClosed)]
     pub fn set_connection_closed_callback(&mut self, callback: js_sys::Function) {
         self.callbacks.borrow_mut().connection_closed_callback = Some(callback);
@@ -628,6 +639,41 @@ impl MOQTClient {
             .borrow_mut()
             .start_outgoing_subscription(request_id, TrackKey::new(track_namespace, track_name));
         self.send_control_message(ControlMessageType::Subscribe, payload)
+            .await
+    }
+
+    #[wasm_bindgen(js_name = sendFetch)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn send_fetch(
+        &self,
+        request_id: u64,
+        track_namespace: Vec<String>,
+        track_name: String,
+        start_group: u64,
+        start_object: u64,
+        end_group: u64,
+        end_object: u64,
+    ) -> Result<(), JsValue> {
+        let payload = Fetch {
+            request_id,
+            subscriber_priority: 0,
+            group_order: GroupOrder::Ascending,
+            fetch_type: FetchType::Standalone {
+                track_namespace,
+                track_name,
+                start_location: Location {
+                    group_id: start_group,
+                    object_id: start_object,
+                },
+                end_location: Location {
+                    group_id: end_group,
+                    object_id: end_object,
+                },
+            },
+            authorization_tokens: vec![],
+        }
+        .encode();
+        self.send_control_message(ControlMessageType::Fetch, payload)
             .await
     }
 
@@ -1153,9 +1199,14 @@ async fn uni_directional_stream_read_thread(
     callbacks: Rc<RefCell<MOQTCallbacks>>,
     reader: &ReadableStreamDefaultReader,
 ) -> Result<(), JsValue> {
-    let mut header: Option<SubgroupHeader> = None;
     let mut buf = BytesMut::new();
     let mut stream_snapshot = Vec::new();
+    // fetch stream state
+    let mut fetch_request_id: Option<u64> = None;
+    // subgroup stream state
+    let mut subgroup_header: Option<SubgroupHeader> = None;
+    // None = undecided, Some(true) = fetch, Some(false) = subgroup
+    let mut is_fetch_stream: Option<bool> = None;
 
     while let Some(chunk) = read_byte_chunk(reader).await? {
         let new_bytes = normalize_stream_chunk(&mut stream_snapshot, chunk);
@@ -1164,33 +1215,73 @@ async fn uni_directional_stream_read_thread(
         }
         buf.extend_from_slice(&new_bytes);
 
-        loop {
-            if header.is_none() {
-                match take_subgroup_header(&mut buf) {
-                    Ok(Some(parsed_header)) => {
-                        emit_subgroup_header(callbacks.clone(), &parsed_header)?;
-                        header = Some(parsed_header);
-                        continue;
+        // Detect stream type from the first varint if not yet determined.
+        if is_fetch_stream.is_none() {
+            let first_varint = {
+                let mut cursor = Cursor::new(buf.as_ref());
+                cursor.try_get_varint().ok()
+            };
+            match first_varint {
+                Some(FetchHeader::TYPE) => is_fetch_stream = Some(true),
+                Some(_) => is_fetch_stream = Some(false),
+                None => continue,
+            }
+        }
+
+        if is_fetch_stream == Some(true) {
+            // Parse FetchHeader to obtain request_id if not yet done.
+            if fetch_request_id.is_none() {
+                let mut cursor = Cursor::new(buf.as_ref());
+                match FetchHeader::decode(&mut cursor) {
+                    Ok(header) => {
+                        let consumed = cursor.position() as usize;
+                        buf.advance(consumed);
+                        fetch_request_id = Some(header.request_id);
                     }
-                    Ok(None) => break,
-                    Err(error) => return Err(js_error(error.to_string())),
+                    Err(moqt::wire::DecodeError::NeedMoreData) => continue,
+                    Err(moqt::wire::DecodeError::Fatal(error)) => return Err(js_error(error)),
                 }
             }
-
-            let parsed_header = header.clone().expect("subgroup header");
-            match SubgroupObjectField::decode(parsed_header.message_type, &mut buf) {
-                Ok(field) => {
-                    let object_id_delta = field.object_id_delta;
-                    emit_subgroup_object(
-                        callbacks.clone(),
-                        &parsed_header,
-                        field,
-                        object_id_delta,
-                    )?;
-                    continue;
+            let request_id = fetch_request_id.expect("request_id");
+            loop {
+                match FetchObjectField::decode(&mut buf) {
+                    Ok(field) => {
+                        emit_fetch_object(callbacks.clone(), request_id, &field)?;
+                        continue;
+                    }
+                    Err(moqt::wire::DecodeError::NeedMoreData) => break,
+                    Err(moqt::wire::DecodeError::Fatal(error)) => return Err(js_error(error)),
                 }
-                Err(moqt::wire::DecodeError::NeedMoreData) => break,
-                Err(moqt::wire::DecodeError::Fatal(error)) => return Err(js_error(error)),
+            }
+        } else {
+            loop {
+                if subgroup_header.is_none() {
+                    match take_subgroup_header(&mut buf) {
+                        Ok(Some(parsed_header)) => {
+                            emit_subgroup_header(callbacks.clone(), &parsed_header)?;
+                            subgroup_header = Some(parsed_header);
+                            continue;
+                        }
+                        Ok(None) => break,
+                        Err(error) => return Err(js_error(error.to_string())),
+                    }
+                }
+
+                let parsed_header = subgroup_header.clone().expect("subgroup header");
+                match SubgroupObjectField::decode(parsed_header.message_type, &mut buf) {
+                    Ok(field) => {
+                        let object_id_delta = field.object_id_delta;
+                        emit_subgroup_object(
+                            callbacks.clone(),
+                            &parsed_header,
+                            field,
+                            object_id_delta,
+                        )?;
+                        continue;
+                    }
+                    Err(moqt::wire::DecodeError::NeedMoreData) => break,
+                    Err(moqt::wire::DecodeError::Fatal(error)) => return Err(js_error(error)),
+                }
             }
         }
     }
@@ -1368,6 +1459,22 @@ async fn handle_control_message(
                 );
             }
         }
+        ControlMessageType::FetchOk => {
+            let message = FetchOk::decode(&mut cursor)
+                .ok_or_else(|| js_error("failed to decode FETCH_OK"))?;
+            if let Some(callback) = callbacks.borrow().fetch_response_callback.clone() {
+                let wrapper = FetchOkMessage::from(&message);
+                let _ = callback.call1(&JsValue::NULL, &JsValue::from(wrapper));
+            }
+        }
+        ControlMessageType::FetchError => {
+            let message = RequestError::decode(&mut cursor)
+                .ok_or_else(|| js_error("failed to decode FETCH_ERROR"))?;
+            if let Some(callback) = callbacks.borrow().fetch_response_callback.clone() {
+                let wrapper = RequestErrorMessage::from(&message);
+                let _ = callback.call1(&JsValue::NULL, &JsValue::from(wrapper));
+            }
+        }
         _ => {
             console_log!("Unhandled control message: {:?}", message_type);
         }
@@ -1527,6 +1634,19 @@ fn emit_subgroup_header(
             subgroup_id,
             header.publisher_priority,
         );
+        let _ = callback.call1(&JsValue::NULL, &JsValue::from(wrapper));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "web_sys_unstable_apis")]
+fn emit_fetch_object(
+    callbacks: Rc<RefCell<MOQTCallbacks>>,
+    request_id: u64,
+    field: &FetchObjectField,
+) -> Result<(), JsValue> {
+    if let Some(callback) = callbacks.borrow().fetch_object_callback.clone() {
+        let wrapper = FetchObjectMessage::new(request_id, field);
         let _ = callback.call1(&JsValue::NULL, &JsValue::from(wrapper));
     }
     Ok(())
@@ -1752,6 +1872,8 @@ struct MOQTCallbacks {
     object_datagram_status_callback: Option<js_sys::Function>,
     subgroup_header_callback: Option<js_sys::Function>,
     subgroup_object_callback: Option<js_sys::Function>,
+    fetch_response_callback: Option<js_sys::Function>,
+    fetch_object_callback: Option<js_sys::Function>,
     connection_closed_callback: Option<js_sys::Function>,
 }
 

--- a/bindings/wasm/src/messages.rs
+++ b/bindings/wasm/src/messages.rs
@@ -1,8 +1,9 @@
 mod subgroup_state;
 
 use moqt::wire::{
-    ContentExists, FilterType, NamespaceOk, ObjectStatus, Publish, PublishNamespace, PublishOk,
-    RequestError, ServerSetup, Subscribe, SubscribeNamespace, SubscribeOk,
+    ContentExists, FetchObject, FetchObjectField, FetchOk, FilterType, NamespaceOk, ObjectStatus,
+    Publish, PublishNamespace, PublishOk, RequestError, ServerSetup, Subscribe, SubscribeNamespace,
+    SubscribeOk,
 };
 use packages::loc::LocHeader;
 pub use subgroup_state::SubgroupState;
@@ -758,6 +759,94 @@ impl SubgroupObjectMessage {
             object_payload_length: object_payload.len() as u32,
             object_payload,
             loc_header,
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub struct FetchOkMessage {
+    request_id: u64,
+    end_group_id: u64,
+    end_object_id: u64,
+    end_of_track: bool,
+}
+
+#[wasm_bindgen]
+impl FetchOkMessage {
+    #[wasm_bindgen(getter, js_name = requestId)]
+    pub fn request_id(&self) -> u64 {
+        self.request_id
+    }
+
+    #[wasm_bindgen(getter, js_name = endGroupId)]
+    pub fn end_group_id(&self) -> u64 {
+        self.end_group_id
+    }
+
+    #[wasm_bindgen(getter, js_name = endObjectId)]
+    pub fn end_object_id(&self) -> u64 {
+        self.end_object_id
+    }
+
+    #[wasm_bindgen(getter, js_name = endOfTrack)]
+    pub fn end_of_track(&self) -> bool {
+        self.end_of_track
+    }
+}
+
+impl From<&FetchOk> for FetchOkMessage {
+    fn from(message: &FetchOk) -> Self {
+        Self {
+            request_id: message.request_id,
+            end_group_id: message.end_location.group_id,
+            end_object_id: message.end_location.object_id,
+            end_of_track: message.end_of_track,
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub struct FetchObjectMessage {
+    request_id: u64,
+    group_id: u64,
+    object_id: u64,
+    object_payload: Vec<u8>,
+}
+
+#[wasm_bindgen]
+impl FetchObjectMessage {
+    #[wasm_bindgen(getter, js_name = requestId)]
+    pub fn request_id(&self) -> u64 {
+        self.request_id
+    }
+
+    #[wasm_bindgen(getter, js_name = groupId)]
+    pub fn group_id(&self) -> u64 {
+        self.group_id
+    }
+
+    #[wasm_bindgen(getter, js_name = objectId)]
+    pub fn object_id(&self) -> u64 {
+        self.object_id
+    }
+
+    #[wasm_bindgen(getter, js_name = objectPayload)]
+    pub fn object_payload(&self) -> Vec<u8> {
+        self.object_payload.clone()
+    }
+}
+
+impl FetchObjectMessage {
+    pub(crate) fn new(request_id: u64, field: &FetchObjectField) -> Self {
+        let payload = match &field.fetch_object {
+            FetchObject::Payload(data) => data.to_vec(),
+            FetchObject::Status(_) => Vec::new(),
+        };
+        Self {
+            request_id,
+            group_id: field.group_id,
+            object_id: field.object_id,
+            object_payload: payload,
         }
     }
 }

--- a/examples/browser/examples/call/src/components/JoinRoomForm.tsx
+++ b/examples/browser/examples/call/src/components/JoinRoomForm.tsx
@@ -21,9 +21,15 @@ const RELAY_OPTIONS = [
 ] as const
 
 export function JoinRoomForm({ onJoin }: JoinRoomFormProps) {
-  const [roomName, setRoomName] = useState('')
+  const [roomName, setRoomName] = useState(() => {
+    const now = new Date()
+    const MM = String(now.getMonth() + 1).padStart(2, '0')
+    const DD = String(now.getDate()).padStart(2, '0')
+    const mm = String(now.getMinutes()).padStart(2, '0')
+    return `test-${MM}${DD}${mm}`
+  })
   const [userName, setUserName] = useState('')
-  const [relayUrl, setRelayUrl] = useState<string>(RELAY_OPTIONS[0].value)
+  const [relayUrl, setRelayUrl] = useState<string>(RELAY_OPTIONS[1].value)
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()

--- a/examples/browser/examples/call/src/components/JoinRoomForm.tsx
+++ b/examples/browser/examples/call/src/components/JoinRoomForm.tsx
@@ -21,15 +21,9 @@ const RELAY_OPTIONS = [
 ] as const
 
 export function JoinRoomForm({ onJoin }: JoinRoomFormProps) {
-  const [roomName, setRoomName] = useState(() => {
-    const now = new Date()
-    const MM = String(now.getMonth() + 1).padStart(2, '0')
-    const DD = String(now.getDate()).padStart(2, '0')
-    const mm = String(now.getMinutes()).padStart(2, '0')
-    return `test-${MM}${DD}${mm}`
-  })
+  const [roomName, setRoomName] = useState('')
   const [userName, setUserName] = useState('')
-  const [relayUrl, setRelayUrl] = useState<string>(RELAY_OPTIONS[1].value)
+  const [relayUrl, setRelayUrl] = useState<string>(RELAY_OPTIONS[0].value)
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()

--- a/examples/browser/examples/call/src/session/localSession.ts
+++ b/examples/browser/examples/call/src/session/localSession.ts
@@ -97,7 +97,7 @@ export class LocalSession {
         console.info('[call][moqt] received SUBSCRIBE_OK', {
           contentExists: (response as any).contentExists ?? (response as any).content_exists,
           largestGroupId: response.largestGroupId?.toString(),
-          largestObjectId: response.largestObjectId?.toString(),
+          largestObjectId: response.largestObjectId?.toString()
         })
       } else {
         console.info('[call][moqt] received SUBSCRIBE response', response)
@@ -273,7 +273,7 @@ export class LocalSession {
             console.info('[call][catalog] content exists; fetching via Standalone Fetch', {
               trackNamespace,
               largestGroupId: largestGroupId.toString(),
-              largestObjectId: largestObjectId.toString(),
+              largestObjectId: largestObjectId.toString()
             })
             const fetchId = subscribeId + 1000000n
             this.client.setOnFetchObjectHandler(fetchId, (msg) => {
@@ -298,7 +298,7 @@ export class LocalSession {
           // Always set up stream handler for future catalog updates.
           this.client.setOnSubgroupObjectHandler(trackAlias, (groupId, subgroup) => {
             console.info('[call][catalog] payload received via subscribe stream', {
-              groupId: groupId.toString(),
+              groupId: groupId.toString()
             })
             handleCatalogPayload(new TextDecoder().decode(new Uint8Array(subgroup.objectPayload)))
           })

--- a/examples/browser/examples/call/src/session/localSession.ts
+++ b/examples/browser/examples/call/src/session/localSession.ts
@@ -93,7 +93,15 @@ export class LocalSession {
 
   setOnSubscribeResponseHandler(handler: (response: SubscribeOkMessage | RequestErrorMessage) => void): void {
     this.client.setOnSubscribeResponseHandler((response) => {
-      console.info('[call][moqt] received SUBSCRIBE response', response)
+      if (response instanceof SubscribeOkMessage) {
+        console.info('[call][moqt] received SUBSCRIBE_OK', {
+          contentExists: (response as any).contentExists ?? (response as any).content_exists,
+          largestGroupId: response.largestGroupId?.toString(),
+          largestObjectId: response.largestObjectId?.toString(),
+        })
+      } else {
+        console.info('[call][moqt] received SUBSCRIBE response', response)
+      }
       handler(response)
     })
   }
@@ -167,7 +175,8 @@ export class LocalSession {
     if (this.state !== LocalSessionState.Ready) {
       throw new Error(`Cannot subscribe when session state is "${this.state}"`)
     }
-    const trackAlias = await this.client.subscribe(subscribeId, trackNamespace, trackName, authInfo)
+    const subscribeOk = await this.client.subscribe(subscribeId, trackNamespace, trackName, authInfo)
+    const trackAlias = subscribeOk.trackAlias
     this.subscribeTrackAliases.set(subscribeId, trackAlias)
     const remoteUser = trackNamespace[1] ?? `alias-${trackAlias.toString()}`
 
@@ -228,44 +237,60 @@ export class LocalSession {
         reject(new Error('Catalog subscribe timed out'))
       }, timeoutMs)
 
+      const handleCatalogPayload = (payload: string) => {
+        try {
+          const tracks = parseCallCatalogTracks(payload)
+          onTracksUpdated?.(tracks)
+          if (settled) return
+          settled = true
+          window.clearTimeout(timeoutId)
+          resolve(tracks)
+        } catch (error) {
+          if (settled) {
+            console.error('Failed to parse updated catalog payload:', error)
+            return
+          }
+          settled = true
+          window.clearTimeout(timeoutId)
+          reject(error instanceof Error ? error : new Error('Failed to parse catalog payload'))
+        }
+      }
+
       this.client
         .subscribe(subscribeId, trackNamespace, 'catalog', authInfo)
-        .then((trackAlias) => {
+        .then(async (subscribeOk) => {
+          const trackAlias = subscribeOk.trackAlias
           this.subscribeTrackAliases.set(subscribeId, trackAlias)
-          this.client.setOnSubgroupObjectHandler(trackAlias, (_groupId, subgroup) => {
-            console.info('[call][moqt] received subgroup object', {
-              trackAlias: trackAlias.toString(),
-              groupId: _groupId.toString(),
-              subgroupId: subgroup.subgroupId?.toString() ?? '0',
-              objectIdDelta: subgroup.objectIdDelta.toString(),
-              objectPayloadLength: subgroup.objectPayloadLength,
-              objectStatus: subgroup.objectStatus
+
+          // If content exists, fetch the catalog directly instead of waiting for stream.
+          const contentExists = (subscribeOk as any).contentExists ?? (subscribeOk as any).content_exists
+          const largestGroupId: bigint | undefined = subscribeOk.largestGroupId
+          const largestObjectId: bigint | undefined = subscribeOk.largestObjectId
+          if (contentExists && largestGroupId !== undefined && largestObjectId !== undefined) {
+            const fetchId = subscribeId + 1000000n
+            this.client.setOnFetchObjectHandler(fetchId, (msg) => {
+              if (msg.objectPayload.length > 0) {
+                handleCatalogPayload(new TextDecoder().decode(new Uint8Array(msg.objectPayload)))
+              }
             })
-            try {
-              const payload = new TextDecoder().decode(new Uint8Array(subgroup.objectPayload))
-              const tracks = parseCallCatalogTracks(payload)
-              onTracksUpdated?.(tracks)
-              if (settled) {
-                return
-              }
-              settled = true
-              window.clearTimeout(timeoutId)
-              resolve(tracks)
-            } catch (error) {
-              if (settled) {
-                console.error('Failed to parse updated catalog payload:', error)
-                return
-              }
-              settled = true
-              window.clearTimeout(timeoutId)
-              reject(error instanceof Error ? error : new Error('Failed to parse catalog payload'))
-            }
+            await this.client.fetch(
+              fetchId,
+              trackNamespace,
+              'catalog',
+              largestGroupId,
+              largestObjectId,
+              largestGroupId,
+              largestObjectId
+            )
+          }
+
+          // Always set up stream handler for future catalog updates.
+          this.client.setOnSubgroupObjectHandler(trackAlias, (_groupId, subgroup) => {
+            handleCatalogPayload(new TextDecoder().decode(new Uint8Array(subgroup.objectPayload)))
           })
         })
         .catch((error) => {
-          if (settled) {
-            return
-          }
+          if (settled) return
           settled = true
           window.clearTimeout(timeoutId)
           reject(error instanceof Error ? error : new Error('Catalog subscribe failed'))

--- a/examples/browser/examples/call/src/session/localSession.ts
+++ b/examples/browser/examples/call/src/session/localSession.ts
@@ -257,7 +257,10 @@ export class LocalSession {
       }
 
       this.client
-        .subscribe(subscribeId, trackNamespace, 'catalog', authInfo)
+        // Largest Object (0x2) filter: receive catalog updates after the current
+        // largest object (fetched separately below). Prepares for a future move
+        // to Joining Fetch.
+        .subscribe(subscribeId, trackNamespace, 'catalog', authInfo, { filterType: 2 })
         .then(async (subscribeOk) => {
           const trackAlias = subscribeOk.trackAlias
           this.subscribeTrackAliases.set(subscribeId, trackAlias)
@@ -267,9 +270,15 @@ export class LocalSession {
           const largestGroupId: bigint | undefined = subscribeOk.largestGroupId
           const largestObjectId: bigint | undefined = subscribeOk.largestObjectId
           if (contentExists && largestGroupId !== undefined && largestObjectId !== undefined) {
+            console.info('[call][catalog] content exists; fetching via Standalone Fetch', {
+              trackNamespace,
+              largestGroupId: largestGroupId.toString(),
+              largestObjectId: largestObjectId.toString(),
+            })
             const fetchId = subscribeId + 1000000n
             this.client.setOnFetchObjectHandler(fetchId, (msg) => {
               if (msg.objectPayload.length > 0) {
+                console.info('[call][catalog] payload received via Standalone Fetch')
                 handleCatalogPayload(new TextDecoder().decode(new Uint8Array(msg.objectPayload)))
               }
             })
@@ -282,10 +291,15 @@ export class LocalSession {
               largestGroupId,
               largestObjectId
             )
+          } else {
+            console.info('[call][catalog] no content yet; waiting for subscribe stream', { trackNamespace })
           }
 
           // Always set up stream handler for future catalog updates.
-          this.client.setOnSubgroupObjectHandler(trackAlias, (_groupId, subgroup) => {
+          this.client.setOnSubgroupObjectHandler(trackAlias, (groupId, subgroup) => {
+            console.info('[call][catalog] payload received via subscribe stream', {
+              groupId: groupId.toString(),
+            })
             handleCatalogPayload(new TextDecoder().decode(new Uint8Array(subgroup.objectPayload)))
           })
         })

--- a/examples/browser/examples/media-cmaf/subscriber/main.ts
+++ b/examples/browser/examples/media-cmaf/subscriber/main.ts
@@ -765,12 +765,12 @@ const sendCatalogSubscribeButtonClickHandler = (): void => {
       setCatalogTrackStatus('Catalog track is required')
       return
     }
-    const catalogTrackAlias = await moqtClient.subscribe(
+    const catalogTrackAlias = (await moqtClient.subscribe(
       catalogSubscribeId,
       trackNamespace,
       catalogTrackName,
       AUTH_INFO
-    )
+    )).trackAlias
     form['catalog-track-alias'].value = catalogTrackAlias.toString()
     setupCatalogCallbacks(catalogTrackAlias)
     setCatalogTrackStatus(`Catalog subscribed: ${catalogTrackName}`)
@@ -800,11 +800,11 @@ const sendSubscribeButtonClickHandler = (): void => {
     }
 
     setupMediaSource(videoTrack.codec, audioTrack.codec)
-    const videoTrackAlias = await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)
+    const videoTrackAlias = (await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)).trackAlias
     form['video-track-alias'].value = videoTrackAlias.toString()
     setupVideoObjectCallbacks(videoTrackAlias)
 
-    const audioTrackAlias = await moqtClient.subscribe(audioSubscribeId, trackNamespace, audioTrack.name, AUTH_INFO)
+    const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, trackNamespace, audioTrack.name, AUTH_INFO)).trackAlias
     form['audio-track-alias'].value = audioTrackAlias.toString()
     setupAudioObjectCallbacks(audioTrackAlias)
     setCatalogTrackStatus(`Subscribed video=${selectedVideoTrack} audio=${audioTrack.name}`)

--- a/examples/browser/examples/media-cmaf/subscriber/main.ts
+++ b/examples/browser/examples/media-cmaf/subscriber/main.ts
@@ -765,12 +765,9 @@ const sendCatalogSubscribeButtonClickHandler = (): void => {
       setCatalogTrackStatus('Catalog track is required')
       return
     }
-    const catalogTrackAlias = (await moqtClient.subscribe(
-      catalogSubscribeId,
-      trackNamespace,
-      catalogTrackName,
-      AUTH_INFO
-    )).trackAlias
+    const catalogTrackAlias = (
+      await moqtClient.subscribe(catalogSubscribeId, trackNamespace, catalogTrackName, AUTH_INFO)
+    ).trackAlias
     form['catalog-track-alias'].value = catalogTrackAlias.toString()
     setupCatalogCallbacks(catalogTrackAlias)
     setCatalogTrackStatus(`Catalog subscribed: ${catalogTrackName}`)
@@ -800,11 +797,14 @@ const sendSubscribeButtonClickHandler = (): void => {
     }
 
     setupMediaSource(videoTrack.codec, audioTrack.codec)
-    const videoTrackAlias = (await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)).trackAlias
+    const videoTrackAlias = (
+      await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)
+    ).trackAlias
     form['video-track-alias'].value = videoTrackAlias.toString()
     setupVideoObjectCallbacks(videoTrackAlias)
 
-    const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, trackNamespace, audioTrack.name, AUTH_INFO)).trackAlias
+    const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, trackNamespace, audioTrack.name, AUTH_INFO))
+      .trackAlias
     form['audio-track-alias'].value = audioTrackAlias.toString()
     setupAudioObjectCallbacks(audioTrackAlias)
     setCatalogTrackStatus(`Subscribed video=${selectedVideoTrack} audio=${audioTrack.name}`)

--- a/examples/browser/examples/media/subscriber/main.ts
+++ b/examples/browser/examples/media/subscriber/main.ts
@@ -298,12 +298,12 @@ function sendCatalogSubscribeButtonClickHandler(): void {
       setCatalogTrackStatus('Catalog track is required')
       return
     }
-    const catalogTrackAlias = await moqtClient.subscribe(
+    const catalogTrackAlias = (await moqtClient.subscribe(
       catalogSubscribeId,
       trackNamespace,
       catalogTrackName,
       AUTH_INFO
-    )
+    )).trackAlias
     form['catalog-track-alias'].value = catalogTrackAlias.toString()
     setupCatalogCallbacks(catalogTrackAlias)
     setCatalogTrackStatus(`Catalog subscribe requested: ${catalogTrackName}`)
@@ -325,11 +325,11 @@ function sendSubscribeButtonClickHandler(): void {
       return
     }
 
-    const videoTrackAlias = await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)
+    const videoTrackAlias = (await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)).trackAlias
     form['video-track-alias'].value = videoTrackAlias.toString()
     setupClientObjectCallbacks('video', videoTrackAlias)
 
-    const audioTrackAlias = await moqtClient.subscribe(audioSubscribeId, trackNamespace, selectedAudioTrack, AUTH_INFO)
+    const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, trackNamespace, selectedAudioTrack, AUTH_INFO)).trackAlias
     form['audio-track-alias'].value = audioTrackAlias.toString()
     setupClientObjectCallbacks('audio', audioTrackAlias)
     setTrackSubscribeStatus(`Track subscribe requested: video=${selectedVideoTrack}, audio=${selectedAudioTrack}`)

--- a/examples/browser/examples/media/subscriber/main.ts
+++ b/examples/browser/examples/media/subscriber/main.ts
@@ -298,12 +298,9 @@ function sendCatalogSubscribeButtonClickHandler(): void {
       setCatalogTrackStatus('Catalog track is required')
       return
     }
-    const catalogTrackAlias = (await moqtClient.subscribe(
-      catalogSubscribeId,
-      trackNamespace,
-      catalogTrackName,
-      AUTH_INFO
-    )).trackAlias
+    const catalogTrackAlias = (
+      await moqtClient.subscribe(catalogSubscribeId, trackNamespace, catalogTrackName, AUTH_INFO)
+    ).trackAlias
     form['catalog-track-alias'].value = catalogTrackAlias.toString()
     setupCatalogCallbacks(catalogTrackAlias)
     setCatalogTrackStatus(`Catalog subscribe requested: ${catalogTrackName}`)
@@ -325,11 +322,15 @@ function sendSubscribeButtonClickHandler(): void {
       return
     }
 
-    const videoTrackAlias = (await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)).trackAlias
+    const videoTrackAlias = (
+      await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)
+    ).trackAlias
     form['video-track-alias'].value = videoTrackAlias.toString()
     setupClientObjectCallbacks('video', videoTrackAlias)
 
-    const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, trackNamespace, selectedAudioTrack, AUTH_INFO)).trackAlias
+    const audioTrackAlias = (
+      await moqtClient.subscribe(audioSubscribeId, trackNamespace, selectedAudioTrack, AUTH_INFO)
+    ).trackAlias
     form['audio-track-alias'].value = audioTrackAlias.toString()
     setupClientObjectCallbacks('audio', audioTrackAlias)
     setTrackSubscribeStatus(`Track subscribe requested: video=${selectedVideoTrack}, audio=${selectedAudioTrack}`)

--- a/examples/browser/examples/message/main.ts
+++ b/examples/browser/examples/message/main.ts
@@ -385,15 +385,17 @@ function setupActionButtons(): void {
       return
     }
 
-    const trackAlias = (await moqtClient.subscribe(requestId, trackNamespace, trackName, authInfo, {
-      subscriberPriority,
-      groupOrder,
-      filterType,
-      startGroup,
-      startObject,
-      endGroup,
-      forward
-    })).trackAlias
+    const trackAlias = (
+      await moqtClient.subscribe(requestId, trackNamespace, trackName, authInfo, {
+        subscriberPriority,
+        groupOrder,
+        filterType,
+        startGroup,
+        startObject,
+        endGroup,
+        forward
+      })
+    ).trackAlias
 
     registerTrackAlias(requestId, trackAlias, {
       trackNamespace: [...trackNamespace],

--- a/examples/browser/examples/message/main.ts
+++ b/examples/browser/examples/message/main.ts
@@ -385,7 +385,7 @@ function setupActionButtons(): void {
       return
     }
 
-    const trackAlias = await moqtClient.subscribe(requestId, trackNamespace, trackName, authInfo, {
+    const trackAlias = (await moqtClient.subscribe(requestId, trackNamespace, trackName, authInfo, {
       subscriberPriority,
       groupOrder,
       filterType,
@@ -393,7 +393,7 @@ function setupActionButtons(): void {
       startObject,
       endGroup,
       forward
-    })
+    })).trackAlias
 
     registerTrackAlias(requestId, trackAlias, {
       trackNamespace: [...trackNamespace],

--- a/examples/browser/examples/onvif/main.ts
+++ b/examples/browser/examples/onvif/main.ts
@@ -1189,7 +1189,7 @@ async function subscribeCatalog(): Promise<void> {
     return
   }
 
-  const catalogAlias = await moqtClient.subscribe(catalogSubscribeId, subscribeNamespace, catalogTrack, authInfo)
+  const catalogAlias = (await moqtClient.subscribe(catalogSubscribeId, subscribeNamespace, catalogTrack, authInfo)).trackAlias
   ;(document.getElementById('catalog-track-alias') as HTMLInputElement).value = catalogAlias.toString()
   setupCatalogCallbacks(catalogAlias)
   catalogTrackAlias = catalogAlias
@@ -1213,7 +1213,7 @@ async function subscribeSelectedVideo(): Promise<void> {
     return
   }
 
-  const videoTrackAlias = await moqtClient.subscribe(videoSubscribeId, subscribeNamespace, videoTrack, authInfo)
+  const videoTrackAlias = (await moqtClient.subscribe(videoSubscribeId, subscribeNamespace, videoTrack, authInfo)).trackAlias
   ;(document.getElementById('video-track-alias') as HTMLInputElement).value = videoTrackAlias.toString()
   setupVideoCallbacks(videoTrackAlias)
   videoSubscribed = true
@@ -1236,7 +1236,7 @@ async function subscribeSelectedAudio(): Promise<void> {
     return
   }
 
-  const audioTrackAlias = await moqtClient.subscribe(audioSubscribeId, subscribeNamespace, audioTrack, authInfo)
+  const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, subscribeNamespace, audioTrack, authInfo)).trackAlias
   ;(document.getElementById('audio-track-alias') as HTMLInputElement).value = audioTrackAlias.toString()
   setupAudioCallbacks(audioTrackAlias)
   audioSubscribed = true

--- a/examples/browser/examples/onvif/main.ts
+++ b/examples/browser/examples/onvif/main.ts
@@ -1189,7 +1189,8 @@ async function subscribeCatalog(): Promise<void> {
     return
   }
 
-  const catalogAlias = (await moqtClient.subscribe(catalogSubscribeId, subscribeNamespace, catalogTrack, authInfo)).trackAlias
+  const catalogAlias = (await moqtClient.subscribe(catalogSubscribeId, subscribeNamespace, catalogTrack, authInfo))
+    .trackAlias
   ;(document.getElementById('catalog-track-alias') as HTMLInputElement).value = catalogAlias.toString()
   setupCatalogCallbacks(catalogAlias)
   catalogTrackAlias = catalogAlias
@@ -1213,7 +1214,8 @@ async function subscribeSelectedVideo(): Promise<void> {
     return
   }
 
-  const videoTrackAlias = (await moqtClient.subscribe(videoSubscribeId, subscribeNamespace, videoTrack, authInfo)).trackAlias
+  const videoTrackAlias = (await moqtClient.subscribe(videoSubscribeId, subscribeNamespace, videoTrack, authInfo))
+    .trackAlias
   ;(document.getElementById('video-track-alias') as HTMLInputElement).value = videoTrackAlias.toString()
   setupVideoCallbacks(videoTrackAlias)
   videoSubscribed = true
@@ -1236,7 +1238,8 @@ async function subscribeSelectedAudio(): Promise<void> {
     return
   }
 
-  const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, subscribeNamespace, audioTrack, authInfo)).trackAlias
+  const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, subscribeNamespace, audioTrack, authInfo))
+    .trackAlias
   ;(document.getElementById('audio-track-alias') as HTMLInputElement).value = audioTrackAlias.toString()
   setupAudioCallbacks(audioTrackAlias)
   audioSubscribed = true

--- a/examples/browser/lib/moqt/moqtClient.ts
+++ b/examples/browser/lib/moqt/moqtClient.ts
@@ -1,4 +1,6 @@
 import init, {
+  FetchObjectMessage,
+  FetchOkMessage,
   MOQTClient,
   NamespaceOkMessage,
   ObjectDatagramMessage,
@@ -20,7 +22,9 @@ import {
 
 type SetupResolver = ((value: void) => void) | null
 type PendingVoidResolver = { resolve: () => void; reject: (error: Error) => void }
-type PendingSubscribeResolver = { resolve: (trackAlias: bigint) => void; reject: (error: Error) => void }
+type PendingSubscribeResolver = { resolve: (response: SubscribeOkMessage) => void; reject: (error: Error) => void }
+type FetchResponseHandler = ((response: FetchOkMessage | RequestErrorMessage) => void) | null
+type FetchObjectHandler = ((message: FetchObjectMessage) => void) | null
 type SubscribeResponseHandler = ((response: SubscribeOkMessage | RequestErrorMessage) => void) | null
 type NamespaceResponseHandler = ((response: NamespaceOkMessage | RequestErrorMessage) => void) | null
 type ConnectionClosedHandler = (() => void) | null
@@ -92,6 +96,8 @@ export class MoqtClientWrapper {
   private onObjectDatagramHandler: ObjectDatagramHandler = null
   private onObjectDatagramStatusHandler: ObjectDatagramStatusHandler = null
   private onSubgroupHeaderHandler: SubgroupHeaderHandler = null
+  private onFetchResponseHandler: FetchResponseHandler = null
+  private readonly fetchObjectHandlers = new Map<bigint, FetchObjectHandler>()
   private readonly subscriptionState: SubscriptionStateStore
   private readonly pendingPublishNamespace = new Map<bigint, PendingVoidResolver>()
   private readonly pendingSubscribeNamespace = new Map<bigint, PendingVoidResolver>()
@@ -268,14 +274,16 @@ export class MoqtClientWrapper {
     trackName: string,
     authInfo: string,
     options: SubscribeOptions = {}
-  ): Promise<bigint> {
+  ): Promise<SubscribeOkMessage> {
     const client = this.requireConnectedClient()
     const existingTrackAlias = this.subscriptionTrackAliases.get(requestId)
     if (existingTrackAlias !== undefined) {
-      return existingTrackAlias
+      // Reconstruct a minimal SubscribeOkMessage-like object is not possible here;
+      // callers that hit this branch only need trackAlias, so we throw to surface the issue.
+      throw new Error(`subscribe: requestId ${requestId} already has trackAlias ${existingTrackAlias}`)
     }
 
-    const response = new Promise<bigint>((resolve, reject) => {
+    const response = new Promise<SubscribeOkMessage>((resolve, reject) => {
       this.pendingSubscribe.set(requestId, { resolve, reject })
     })
 
@@ -295,6 +303,47 @@ export class MoqtClientWrapper {
     )
 
     return response
+  }
+
+  async fetch(
+    requestId: bigint,
+    trackNamespace: string[],
+    trackName: string,
+    startGroupId: bigint,
+    startObjectId: bigint,
+    endGroupId: bigint,
+    endObjectId: bigint
+  ): Promise<FetchOkMessage> {
+    const client = this.requireConnectedClient()
+    const response = new Promise<FetchOkMessage>((resolve, reject) => {
+      const handler: FetchResponseHandler = (msg) => {
+        this.onFetchResponseHandler = null
+        if (msg instanceof FetchOkMessage) {
+          resolve(msg)
+        } else {
+          reject(new Error(`FETCH_ERROR: ${(msg as RequestErrorMessage).reasonPhrase}`))
+        }
+      }
+      this.onFetchResponseHandler = handler
+    })
+    await client.sendFetch(
+      requestId,
+      trackNamespace,
+      trackName,
+      startGroupId,
+      startObjectId,
+      endGroupId,
+      endObjectId
+    )
+    return response
+  }
+
+  setOnFetchObjectHandler(requestId: bigint, handler: FetchObjectHandler): void {
+    this.fetchObjectHandlers.set(requestId, handler)
+  }
+
+  clearFetchObjectHandler(requestId: bigint): void {
+    this.fetchObjectHandlers.delete(requestId)
   }
 
   async unsubscribe(requestId: bigint): Promise<void> {
@@ -410,7 +459,7 @@ export class MoqtClientWrapper {
         const pending = this.pendingSubscribe.get(response.requestId)
         if (pending) {
           this.pendingSubscribe.delete(response.requestId)
-          pending.resolve(response.trackAlias)
+          pending.resolve(response)
         }
       }
       this.onSubscribeResponseHandler?.(response)
@@ -444,6 +493,13 @@ export class MoqtClientWrapper {
         return
       }
       this.subscriptionState.bufferSubgroupObject(trackAlias, groupId, subgroupObject)
+    })
+    this.client.onFetchResponse((response: FetchOkMessage | RequestErrorMessage) => {
+      this.onFetchResponseHandler?.(response)
+    })
+    this.client.onFetchObject((message: FetchObjectMessage) => {
+      const handler = this.fetchObjectHandlers.get(BigInt(message.requestId))
+      handler?.(message)
     })
     this.client.onConnectionClosed(() => this.handleConnectionClosed())
   }

--- a/examples/browser/lib/moqt/moqtClient.ts
+++ b/examples/browser/lib/moqt/moqtClient.ts
@@ -326,15 +326,7 @@ export class MoqtClientWrapper {
       }
       this.onFetchResponseHandler = handler
     })
-    await client.sendFetch(
-      requestId,
-      trackNamespace,
-      trackName,
-      startGroupId,
-      startObjectId,
-      endGroupId,
-      endObjectId
-    )
+    await client.sendFetch(requestId, trackNamespace, trackName, startGroupId, startObjectId, endGroupId, endObjectId)
     return response
   }
 

--- a/moqt/src/wire.rs
+++ b/moqt/src/wire.rs
@@ -16,6 +16,10 @@ pub use crate::modules::moqt::control_plane::control_messages::messages::paramet
 pub use crate::modules::moqt::control_plane::control_messages::messages::parameters::setup_parameters::SetupParameter;
 pub use crate::modules::moqt::control_plane::control_messages::messages::fetch::Fetch;
 pub use crate::modules::moqt::control_plane::control_messages::messages::fetch::FetchType;
+pub use crate::modules::moqt::control_plane::control_messages::messages::fetch_ok::FetchOk;
+pub use crate::modules::moqt::data_plane::object::fetch::FetchHeader;
+pub use crate::modules::moqt::data_plane::object::fetch::FetchObject;
+pub use crate::modules::moqt::data_plane::object::fetch::FetchObjectField;
 pub use crate::modules::moqt::control_plane::control_messages::messages::publish::Publish;
 pub use crate::modules::moqt::control_plane::control_messages::messages::publish_namespace::PublishNamespace;
 pub use crate::modules::moqt::control_plane::control_messages::messages::publish_ok::PublishOk;

--- a/relay/src/modules/event_handler.rs
+++ b/relay/src/modules/event_handler.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::modules::{
-    relay::{egress::coordinator::EgressCommand, ingress::ingress_coordinator::IngressCommand},
+    relay::{
+        cache::store::TrackCacheStore, egress::coordinator::EgressCommand,
+        ingress::ingress_coordinator::IngressCommand,
+    },
     sequences::{
         fetch::Fetch,
         notifier::SessionSignalingDispatcher,
@@ -32,12 +35,14 @@ impl EventHandler {
         relay_event_receiver: tokio::sync::mpsc::UnboundedReceiver<SessionEvent>,
         ingress_sender: mpsc::Sender<IngressCommand>,
         egress_sender: mpsc::Sender<EgressCommand>,
+        cache_store: Arc<TrackCacheStore>,
     ) -> Self {
         let relay_session_event_handler = Self::create_relay_session_event_handler(
             repo,
             relay_event_receiver,
             ingress_sender,
             egress_sender,
+            cache_store,
         );
         Self {
             relay_session_event_handler,
@@ -49,6 +54,7 @@ impl EventHandler {
         mut receiver: tokio::sync::mpsc::UnboundedReceiver<SessionEvent>,
         ingress_sender: mpsc::Sender<IngressCommand>,
         egress_sender: mpsc::Sender<EgressCommand>,
+        cache_store: Arc<TrackCacheStore>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::task::Builder::new()
             .name("Relay Session Event Handler")
@@ -128,6 +134,7 @@ impl EventHandler {
                                         &session_signaling_dispatcher,
                                         &ingress_sender,
                                         &egress_sender,
+                                        &cache_store,
                                         handler,
                                     )
                                     .await;

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -118,11 +118,12 @@ impl TrackCache {
     /// Ideally, the cache should track {group_id, object_id} directly at ingestion time
     /// to make this O(1). Deferred to a cache redesign task.
     pub(crate) async fn largest_location(&self) -> Option<moqt::Location> {
-        let groups = self.stream_groups.read().await;
-        let (&group_id, subgroups) = groups.iter().next_back()?;
-        let (_, cache) = subgroups.iter().next_back()?;
-        let cache = cache.clone();
-        drop(groups);
+        let (group_id, cache) = {
+            let groups = self.stream_groups.read().await;
+            let (&group_id, subgroups) = groups.iter().next_back()?;
+            let (_, cache) = subgroups.iter().next_back()?;
+            (group_id, cache.clone())
+        };
 
         let objects = cache.snapshot().await;
         let mut prev_object_id: Option<u64> = None;

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -101,8 +101,46 @@ impl TrackCache {
         group.mark_end_of_group().await;
     }
 
-    pub(crate) async fn latest_location(&self) -> Option<CacheLocation> {
+    /// Returns the cache position of the most recently appended object across all groups and subgroups.
+    ///
+    /// FIXME: When multiple subgroups are written concurrently, the ordering of writes to
+    /// `self.latest` is not guaranteed. The returned position may not correspond to the
+    /// MoQT-largest object if subgroups interleave. This is a known limitation to be
+    /// addressed in a cache redesign task.
+    pub(crate) async fn latest_cache_location(&self) -> Option<CacheLocation> {
         self.latest.read().await.clone()
+    }
+
+    /// Returns the Largest Location as defined in the MoQT spec.
+    ///
+    /// NOTE: This scans the latest subgroup to resolve object_id from the delta chain,
+    /// which is O(n) in the number of objects in the subgroup.
+    /// Ideally, the cache should track {group_id, object_id} directly at ingestion time
+    /// to make this O(1). Deferred to a cache redesign task.
+    pub(crate) async fn largest_location(&self) -> Option<moqt::Location> {
+        let groups = self.stream_groups.read().await;
+        let (&group_id, subgroups) = groups.iter().next_back()?;
+        let (_, cache) = subgroups.iter().next_back()?;
+        let cache = cache.clone();
+        drop(groups);
+
+        let objects = cache.snapshot().await;
+        let mut prev_object_id: Option<u64> = None;
+        let mut last_object_id: Option<u64> = None;
+
+        for obj in objects.iter().skip(1) {
+            let DataObject::SubgroupObject(field) = obj.as_ref() else {
+                continue;
+            };
+            let current_object_id = field.resolve_object_id(prev_object_id);
+            prev_object_id = Some(current_object_id);
+            last_object_id = Some(current_object_id);
+        }
+
+        Some(moqt::Location {
+            group_id,
+            object_id: last_object_id?,
+        })
     }
 
     pub(crate) async fn latest_group_id(&self) -> Option<u64> {
@@ -248,5 +286,145 @@ impl TrackCache {
             }
         }
         fetch_objects
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use moqt::{ExtensionHeaders, SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField};
+
+    fn make_header(group_id: u64) -> DataObject {
+        DataObject::SubgroupHeader(SubgroupHeader::new(
+            0,
+            group_id,
+            SubgroupId::Value(0),
+            0,
+            false,
+            false,
+        ))
+    }
+
+    fn make_object(delta: u64) -> DataObject {
+        let message_type =
+            SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false).message_type;
+        DataObject::SubgroupObject(SubgroupObjectField {
+            message_type,
+            object_id_delta: delta,
+            extension_headers: ExtensionHeaders {
+                prior_group_id_gap: vec![],
+                prior_object_id_gap: vec![],
+                immutable_extensions: vec![],
+            },
+            subgroup_object: SubgroupObject::new_payload(Bytes::from(vec![])),
+        })
+    }
+
+    #[tokio::test]
+    async fn largest_location_returns_none_when_empty() {
+        // Arrange: empty cache
+        let cache = TrackCache::new();
+        // Act / Assert: no objects exist, so None is returned
+        assert!(cache.largest_location().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn largest_location_returns_none_when_only_header() {
+        // Arrange: append a SubgroupHeader only, no SubgroupObject
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        cache
+            .append_stream_object(0, &subgroup, make_header(0))
+            .await;
+        // Act / Assert: a header is not an object, so None is returned
+        assert!(cache.largest_location().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn largest_location_returns_single_object() {
+        // Arrange: one SubgroupObject with delta=0 in group_id=0
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        cache
+            .append_stream_object(0, &subgroup, make_header(0))
+            .await;
+        cache
+            .append_stream_object(0, &subgroup, make_object(0))
+            .await;
+        // Act
+        let loc = cache.largest_location().await.unwrap();
+        // Assert: object_id resolves to 0 (delta=0, no previous)
+        assert_eq!(loc.group_id, 0);
+        assert_eq!(loc.object_id, 0);
+    }
+
+    #[tokio::test]
+    async fn largest_location_resolves_sequential_delta_chain() {
+        // Arrange: three objects with delta=0, yielding object_ids 0, 1, 2
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        cache
+            .append_stream_object(0, &subgroup, make_header(0))
+            .await;
+        cache
+            .append_stream_object(0, &subgroup, make_object(0))
+            .await; // object_id = 0
+        cache
+            .append_stream_object(0, &subgroup, make_object(0))
+            .await; // object_id = 1
+        cache
+            .append_stream_object(0, &subgroup, make_object(0))
+            .await; // object_id = 2
+        // Act
+        let loc = cache.largest_location().await.unwrap();
+        // Assert: largest object_id in the delta chain is returned
+        assert_eq!(loc.group_id, 0);
+        assert_eq!(loc.object_id, 2);
+    }
+
+    #[tokio::test]
+    async fn largest_location_resolves_delta_with_gap() {
+        // Arrange: first object has delta=5 (object_id=5), second has delta=2 (object_id=8)
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        cache
+            .append_stream_object(0, &subgroup, make_header(0))
+            .await;
+        cache
+            .append_stream_object(0, &subgroup, make_object(5))
+            .await; // object_id = 5
+        cache
+            .append_stream_object(0, &subgroup, make_object(2))
+            .await; // object_id = 5+1+2 = 8
+        // Act
+        let loc = cache.largest_location().await.unwrap();
+        // Assert: delta gaps are resolved correctly
+        assert_eq!(loc.group_id, 0);
+        assert_eq!(loc.object_id, 8);
+    }
+
+    #[tokio::test]
+    async fn largest_location_returns_latest_group() {
+        // Arrange: objects in group 0 and group 1
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        cache
+            .append_stream_object(0, &subgroup, make_header(0))
+            .await;
+        cache
+            .append_stream_object(0, &subgroup, make_object(0))
+            .await; // group=0, object_id=0
+        cache
+            .append_stream_object(1, &subgroup, make_header(1))
+            .await;
+        cache
+            .append_stream_object(1, &subgroup, make_object(0))
+            .await; // group=1, object_id=0
+        // Act
+        let loc = cache.largest_location().await.unwrap();
+        // Assert: the latest group's location is returned
+        assert_eq!(loc.group_id, 1);
+        assert_eq!(loc.object_id, 0);
     }
 }

--- a/relay/src/modules/relay/egress/scheduler.rs
+++ b/relay/src/modules/relay/egress/scheduler.rs
@@ -92,10 +92,13 @@ impl EgressScheduler {
         let absolute_group_id = absolute_start.map(|(group_id, _)| group_id);
         let mut start_offset_remaining = absolute_start.map(|(_, start_offset)| start_offset);
 
+        // Largest Object (0x2) filter: per draft-ietf-moq-transport §9.7 the
+        // Start Location is {Largest.Group, Largest.Object + 1}, so delivery
+        // starts just after the Largest Object rather than including it.
         if matches!(self.filter_type, FilterType::LargestObject)
             && let Some(location) = self.cache.latest_cache_location().await
         {
-            self.schedule_location(location, &mut scheduled).await;
+            self.schedule_after_location(location, &mut scheduled).await;
         }
 
         loop {
@@ -181,7 +184,11 @@ impl EgressScheduler {
         }
     }
 
-    async fn schedule_location(
+    /// Schedules delivery starting just after the given location.
+    ///
+    /// `index` is the cache position of that location, so delivery begins one
+    /// position later (the object at `index` itself is not sent).
+    async fn schedule_after_location(
         &self,
         location: CacheLocation,
         scheduled: &mut HashSet<GroupSendTaskKey>,
@@ -193,12 +200,12 @@ impl EgressScheduler {
                 index,
             } => {
                 let _ = self
-                    .schedule_stream_task(group_id, subgroup_id, index, scheduled)
+                    .schedule_stream_task(group_id, subgroup_id, index + 1, scheduled)
                     .await;
             }
             CacheLocation::Datagram { group_id, index } => {
                 let _ = self
-                    .schedule_datagram_task(group_id, index, scheduled)
+                    .schedule_datagram_task(group_id, index + 1, scheduled)
                     .await;
             }
         }
@@ -295,5 +302,80 @@ impl EgressScheduler {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::core::data_object::DataObject;
+    use bytes::Bytes;
+    use moqt::{ExtensionHeaders, SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField};
+
+    fn make_header() -> DataObject {
+        DataObject::SubgroupHeader(SubgroupHeader::new(
+            0,
+            0,
+            SubgroupId::Value(0),
+            0,
+            false,
+            false,
+        ))
+    }
+
+    fn make_object(delta: u64) -> DataObject {
+        let message_type =
+            SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false).message_type;
+        DataObject::SubgroupObject(SubgroupObjectField {
+            message_type,
+            object_id_delta: delta,
+            extension_headers: ExtensionHeaders {
+                prior_group_id_gap: vec![],
+                prior_object_id_gap: vec![],
+                immutable_extensions: vec![],
+            },
+            subgroup_object: SubgroupObject::new_payload(Bytes::from(vec![])),
+        })
+    }
+
+    // Largest Object (0x2) filter must start delivery just after the Largest
+    // Object (§9.7: Start = {Largest.Group, Largest.Object + 1}), not include it.
+    #[tokio::test]
+    async fn largest_object_filter_starts_after_largest_for_stream() {
+        let cache = Arc::new(TrackCache::new());
+        let subgroup = StreamSubgroupId::Value(0);
+        // index 0: subgroup header, index 1: the Largest Object
+        cache
+            .append_stream_object(0, &subgroup, make_header())
+            .await;
+        cache
+            .append_stream_object(0, &subgroup, make_object(0))
+            .await;
+
+        let (info_tx, _info_rx) = broadcast::channel(16);
+        let (task_tx, mut task_rx) = mpsc::channel(16);
+        let scheduler = EgressScheduler::new(
+            cache,
+            info_tx,
+            FilterType::LargestObject,
+            GroupOrder::Ascending,
+            task_tx,
+        );
+        let handle = tokio::spawn(scheduler.run());
+
+        let task = task_rx.recv().await.expect("a task should be scheduled");
+        match task {
+            GroupSendTask::Stream {
+                group_id,
+                start_offset,
+                ..
+            } => {
+                assert_eq!(group_id, 0);
+                // Largest Object is at cache index 1, so delivery starts at index 2.
+                assert_eq!(start_offset, 2);
+            }
+            _ => panic!("expected a Stream task"),
+        }
+        handle.abort();
     }
 }

--- a/relay/src/modules/relay/egress/scheduler.rs
+++ b/relay/src/modules/relay/egress/scheduler.rs
@@ -93,7 +93,7 @@ impl EgressScheduler {
         let mut start_offset_remaining = absolute_start.map(|(_, start_offset)| start_offset);
 
         if matches!(self.filter_type, FilterType::LargestObject)
-            && let Some(location) = self.cache.latest_location().await
+            && let Some(location) = self.cache.latest_cache_location().await
         {
             self.schedule_location(location, &mut scheduled).await;
         }

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -1,6 +1,10 @@
+use std::sync::Arc;
+
 use crate::modules::{
     core::handler::subscribe::SubscribeHandler,
+    enums::{ContentExists, Location},
     relay::{
+        cache::store::TrackCacheStore,
         egress::coordinator::{EgressCommand, EgressStartRequest},
         ingress::ingress_coordinator::{IngressCommand, IngressStartRequest},
     },
@@ -52,6 +56,7 @@ impl Subscribe {
         notifier: &SessionSignalingDispatcher,
         ingress_sender: &tokio::sync::mpsc::Sender<IngressCommand>,
         egress_sender: &tokio::sync::mpsc::Sender<EgressCommand>,
+        cache_store: &Arc<TrackCacheStore>,
         handler: Box<dyn SubscribeHandler>,
     ) {
         let track_namespace = handler.track_namespace();
@@ -104,6 +109,7 @@ impl Subscribe {
             active_upstream,
             table,
             egress_sender,
+            cache_store,
             handler.as_ref(),
         )
         .await;
@@ -289,14 +295,22 @@ impl Subscribe {
         active_upstream: ActiveUpstreamSubscription,
         table: &dyn SignalingStateTable,
         egress_sender: &tokio::sync::mpsc::Sender<EgressCommand>,
+        cache_store: &Arc<TrackCacheStore>,
         handler: &dyn SubscribeHandler,
     ) {
-        let Ok(subscriber_track_alias) = handler
-            .ok(
-                active_upstream.expires,
-                active_upstream.content_exists.clone(),
-            )
-            .await
+        let content_exists = match cache_store.get(active_upstream.track_key) {
+            Some(cache) => match cache.largest_location().await {
+                Some(loc) => ContentExists::True {
+                    location: Location {
+                        group_id: loc.group_id,
+                        object_id: loc.object_id,
+                    },
+                },
+                None => active_upstream.content_exists.clone(),
+            },
+            None => active_upstream.content_exists.clone(),
+        };
+        let Ok(subscriber_track_alias) = handler.ok(active_upstream.expires, content_exists).await
         else {
             tracing::error!("Failed to send `SUBSCRIBE_OK`. Session close.");
             // TODO: send_unsubscribe

--- a/relay/src/relay_server/runtime.rs
+++ b/relay/src/relay_server/runtime.rs
@@ -34,7 +34,13 @@ impl RelayRuntime {
             store.cache_store.clone(),
             store.object_notify_producer_map.clone(),
         );
-        let manager = EventHandler::run(repo, receiver, ingress.sender(), egress.sender());
+        let manager = EventHandler::run(
+            repo,
+            receiver,
+            ingress.sender(),
+            egress.sender(),
+            store.cache_store.clone(),
+        );
         (
             sender,
             Self {


### PR DESCRIPTION
## Summary

> ⚠️ This PR depends on #266 (feat: implement Standalone Fetch).
> Once #266 is merged, the diff will reduce to the 2 fix commits below.

- fix(relay): include `content_exists=true` and Largest Location from cache in SUBSCRIBE_OK
- fix(call): use Standalone Fetch to retrieve catalog immediately when `content_exists=true`

## Changes

### relay
- Add `TrackCache::largest_location()` that resolves group_id/object_id by walking the delta chain
- Attach largest location to SUBSCRIBE_OK when cache is non-empty
- Add unit tests for `largest_location()`

### call app (WASM bindings + TypeScript)
- When SUBSCRIBE_OK indicates `content_exists=true` with a valid largest location,
  fetch the cached catalog immediately via Standalone Fetch instead of waiting for stream delivery
- Always set `setOnSubgroupObjectHandler` after the fetch so subsequent catalog updates
  arriving via stream are still handled

## Test plan

Tested manually in the call app example:

- [x] A late joiner in a call session sees the catalog immediately upon joining
- [x] Catalog updates republished by the publisher are still received via stream