### PR TITLE
feat: implement Joining Fetch

### DIFF
--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -676,6 +676,28 @@ impl MOQTClient {
             .await
     }
 
+    #[wasm_bindgen(js_name = sendRelativeJoiningFetch)]
+    pub async fn send_relative_joining_fetch(
+        &self,
+        request_id: u64,
+        joining_request_id: u64,
+        joining_start: u64,
+    ) -> Result<(), JsValue> {
+        let payload = Fetch {
+            request_id,
+            subscriber_priority: 0,
+            group_order: GroupOrder::Ascending,
+            fetch_type: FetchType::RelativeJoining {
+                joining_request_id,
+                joining_start,
+            },
+            authorization_tokens: vec![],
+        }
+        .encode();
+        self.send_control_message(ControlMessageType::Fetch, payload)
+            .await
+    }
+
     #[wasm_bindgen(js_name = isSubscribed)]
     pub fn is_subscribed(&self, request_id: u64) -> bool {
         self.state

--- a/examples/browser/examples/call/src/components/CallRoom.tsx
+++ b/examples/browser/examples/call/src/components/CallRoom.tsx
@@ -76,7 +76,6 @@ export function CallRoom({ session, onLeave }: CallRoomProps) {
   const [catalogLoadingMemberIds, setCatalogLoadingMemberIds] = useState<Set<string>>(new Set())
   const [catalogSubscribedMemberIds, setCatalogSubscribedMemberIds] = useState<Set<string>>(new Set())
   const [catalogUnsubscribingTrackKeys, setCatalogUnsubscribingTrackKeys] = useState<Set<string>>(new Set())
-  const nextSubscribeIdRef = useRef<bigint>(0n)
   const {
     cameraEnabled,
     screenShareEnabled,
@@ -184,15 +183,7 @@ export function CallRoom({ session, onLeave }: CallRoomProps) {
     setCatalogUnsubscribingTrackKeys(new Set())
     setIsSidebarOpen(true)
     setStatsHistory(new Map())
-    nextSubscribeIdRef.current = 0n
   }, [session])
-
-  useEffect(() => {
-    const maxSubscribeId = getMaxSubscribeId(room.remoteMembers)
-    if (maxSubscribeId !== null && nextSubscribeIdRef.current <= maxSubscribeId) {
-      nextSubscribeIdRef.current = maxSubscribeId + 1n
-    }
-  }, [room.remoteMembers])
 
   useEffect(() => {
     const memberIds = new Set(room.remoteMembers.keys())
@@ -362,7 +353,6 @@ export function CallRoom({ session, onLeave }: CallRoomProps) {
     if (catalogLoadingMemberIds.has(memberId) || catalogSubscribedMemberIds.has(memberId)) {
       return
     }
-    const catalogSubscribeId = issueSubscribeId(nextSubscribeIdRef)
 
     setCatalogLoadingMemberIds((prev) => {
       const next = new Set(prev)
@@ -371,12 +361,8 @@ export function CallRoom({ session, onLeave }: CallRoomProps) {
     })
 
     try {
-      const tracks = await session.subscribeCatalog(
-        catalogSubscribeId,
-        trackNamespace,
-        undefined,
-        5000,
-        (updatedTracks) => applyRemoteCatalogTracks(memberId, updatedTracks)
+      const tracks = await session.subscribeCatalog(trackNamespace, undefined, 5000, (updatedTracks) =>
+        applyRemoteCatalogTracks(memberId, updatedTracks)
       )
       applyRemoteCatalogTracks(memberId, tracks)
       setCatalogSubscribedMemberIds((prev) => {
@@ -453,30 +439,34 @@ export function CallRoom({ session, onLeave }: CallRoomProps) {
     if (trackState.isSubscribed || trackState.isSubscribing || catalogUnsubscribingTrackKeys.has(trackKey)) {
       return
     }
-    const subscribeId = issueSubscribeId(nextSubscribeIdRef)
+    // Optimistically mark as subscribing; the request id is unknown until
+    // subscribe() returns it (issued internally by moqtClient).
     setRoom((currentRoom) =>
       updateMemberSubscriptionStateByRole(currentRoom, memberId, role, () => ({
         ...trackState,
         isSubscribing: true,
         isSubscribed: false,
-        subscribeId
+        subscribeId: undefined
       }))
     )
 
     try {
-      await session.subscribe(subscribeId, trackNamespace, trackName, undefined, role, trackCodec)
+      const requestId = await session.subscribe(trackNamespace, trackName, undefined, role, trackCodec)
+      setRoom((currentRoom) =>
+        updateMemberSubscriptionStateByRole(currentRoom, memberId, role, (track) => ({
+          ...track,
+          subscribeId: requestId,
+          isSubscribing: false,
+          isSubscribed: true
+        }))
+      )
     } catch (error) {
       console.error(`Failed to subscribe ${role} track for ${memberId}:`, error)
       setRoom((currentRoom) =>
-        updateMemberSubscriptionStateByRole(currentRoom, memberId, role, (track) => {
-          if (track.subscribeId !== subscribeId) {
-            return track
-          }
-          return {
-            ...track,
-            isSubscribing: false
-          }
-        })
+        updateMemberSubscriptionStateByRole(currentRoom, memberId, role, (track) => ({
+          ...track,
+          isSubscribing: false
+        }))
       )
     }
   }
@@ -545,12 +535,7 @@ export function CallRoom({ session, onLeave }: CallRoomProps) {
     for (const member of room.remoteMembers.values()) {
       const chatState = member.subscribedTracks.chat
       const chatTrackKey = buildTrackActionKey(member.id, 'chat')
-      if (
-        chatState.isSubscribed ||
-        chatState.isSubscribing ||
-        catalogUnsubscribingTrackKeys.has(chatTrackKey) ||
-        typeof chatState.subscribeId !== 'bigint'
-      ) {
+      if (chatState.isSubscribed || chatState.isSubscribing || catalogUnsubscribingTrackKeys.has(chatTrackKey)) {
         continue
       }
       const trackNamespace = getTrackNamespace(member)
@@ -728,33 +713,6 @@ function getTracksForRole(tracks: CallCatalogTrack[], role: CatalogSubscribeRole
       ? track.role === 'video' && track.name.trim().toLowerCase().startsWith('screenshare')
       : track.role === 'video' && !track.name.trim().toLowerCase().startsWith('screenshare')
   )
-}
-
-function issueSubscribeId(nextSubscribeIdRef: { current: bigint }): bigint {
-  const subscribeId = nextSubscribeIdRef.current
-  nextSubscribeIdRef.current = subscribeId + 1n
-  return subscribeId
-}
-
-function getMaxSubscribeId(remoteMembers: Map<string, RemoteMember>): bigint | null {
-  let maxSubscribeId: bigint | null = null
-  for (const member of remoteMembers.values()) {
-    const states = [
-      member.subscribedTracks.chat,
-      member.subscribedTracks.audio,
-      member.subscribedTracks.video,
-      member.subscribedTracks.screenshare
-    ]
-    for (const state of states) {
-      if (typeof state.subscribeId !== 'bigint') {
-        continue
-      }
-      if (maxSubscribeId === null || state.subscribeId > maxSubscribeId) {
-        maxSubscribeId = state.subscribeId
-      }
-    }
-  }
-  return maxSubscribeId
 }
 
 function updateMemberSubscriptionStateByRole(

--- a/examples/browser/examples/call/src/hooks/useSessionEventHandlers.ts
+++ b/examples/browser/examples/call/src/hooks/useSessionEventHandlers.ts
@@ -3,7 +3,7 @@ import { PublishNamespaceMessage, RequestErrorMessage, SubscribeOkMessage } from
 import { LocalSession, LocalSessionState } from '../session/localSession'
 import { Room } from '../types/room'
 import { ChatMessage } from '../types/chat'
-import { addOrUpdateRemoteMember, updateSubscriptionState } from '../utils/state/roomState'
+import { addOrUpdateRemoteMember } from '../utils/state/roomState'
 
 interface EventHandlerParams {
   session: LocalSession
@@ -39,7 +39,7 @@ export function useSessionEventHandlers({ session, roomName, userName, setRoom, 
   }, [roomName, session, setRoom, userName])
 
   useEffect(() => {
-    const handleSubscribeResponse = createSubscribeResponseHandler(session, setRoom)
+    const handleSubscribeResponse = createSubscribeResponseHandler(session)
     session.setOnSubscribeResponseHandler(handleSubscribeResponse)
     return () => {
       session.setOnSubscribeResponseHandler(() => {})
@@ -77,37 +77,21 @@ function createPublishNamespaceHandler({ session, roomName, userName, setRoom }:
       return
     }
 
-    setRoom((currentRoom) => {
-      const update = addOrUpdateRemoteMember(currentRoom, announcedUser, trackNamespace)
-      return update.room
-    })
+    setRoom((currentRoom) => addOrUpdateRemoteMember(currentRoom, announcedUser, trackNamespace))
   }
 }
 
-function createSubscribeResponseHandler(session: LocalSession, setRoom: Dispatch<SetStateAction<Room>>) {
+// Subscription state (isSubscribing/isSubscribed/subscribeId) is now driven by
+// the awaited result of session.subscribe() in CallRoom, so this handler only
+// surfaces errors for diagnostics.
+function createSubscribeResponseHandler(session: LocalSession) {
   return (response: SubscribeOkMessage | RequestErrorMessage) => {
     if (session.status !== LocalSessionState.Ready) {
       return
     }
     if ('errorCode' in response) {
       console.error('SUBSCRIBE_ERROR:', response.requestId, response.errorCode, response.reasonPhrase)
-      setRoom((currentRoom) =>
-        updateSubscriptionState(currentRoom, response.requestId, (track) => ({
-          ...track,
-          isSubscribing: false,
-          isSubscribed: false
-        }))
-      )
-      return
     }
-
-    setRoom((currentRoom) =>
-      updateSubscriptionState(currentRoom, response.requestId, (track) => ({
-        ...track,
-        isSubscribed: true,
-        isSubscribing: false
-      }))
-    )
   }
 }
 

--- a/examples/browser/examples/call/src/session/localSession.ts
+++ b/examples/browser/examples/call/src/session/localSession.ts
@@ -257,34 +257,26 @@ export class LocalSession {
       }
 
       this.client
-        // Largest Object (0x2) filter: receive catalog updates after the current
-        // largest object (fetched separately below). Prepares for a future move
-        // to Joining Fetch.
+        // Largest Object (0x2) filter: receive catalog updates after largest_at_subscribe.
+        // The current catalog is backfilled via Joining Fetch below.
         .subscribe(subscribeId, trackNamespace, 'catalog', authInfo, { filterType: 2 })
         .then(async (subscribeOk) => {
           const trackAlias = subscribeOk.trackAlias
           this.subscribeTrackAliases.set(subscribeId, trackAlias)
 
-          // If content exists, fetch the catalog directly instead of waiting for stream.
+          // If content exists, fetch the latest catalog via Joining Fetch.
+          // joining_start=0 means "the group at largest_at_subscribe" (0 groups back).
           const contentExists = (subscribeOk as any).contentExists ?? (subscribeOk as any).content_exists
-          const largestGroupId: bigint | undefined = subscribeOk.largestGroupId
-          const largestObjectId: bigint | undefined = subscribeOk.largestObjectId
-          if (contentExists && largestGroupId !== undefined && largestObjectId !== undefined) {
-            console.info('[call][catalog] content exists; fetching via Standalone Fetch', {
-              trackNamespace,
-              largestGroupId: largestGroupId.toString(),
-              largestObjectId: largestObjectId.toString()
-            })
+          if (contentExists) {
+            console.info('[call][catalog] content exists; fetching via Joining Fetch', { trackNamespace })
             const fetchId = subscribeId + 1000000n
             this.client.setOnFetchObjectHandler(fetchId, (msg) => {
               if (msg.objectPayload.length > 0) {
-                console.info('[call][catalog] payload received via Standalone Fetch')
+                console.info('[call][catalog] payload received via Joining Fetch')
                 handleCatalogPayload(new TextDecoder().decode(new Uint8Array(msg.objectPayload)))
               }
             })
-            // Catalog = one object per group (object_id always 0). End is exclusive, but
-            // object_id==0 means "whole group", so this fetches exactly the latest catalog.
-            await this.client.fetch(fetchId, trackNamespace, 'catalog', largestGroupId, 0n, largestGroupId, 0n)
+            await this.client.relativeJoiningFetch(fetchId, subscribeId, 0n)
           } else {
             console.info('[call][catalog] no content yet; waiting for subscribe stream', { trackNamespace })
           }

--- a/examples/browser/examples/call/src/session/localSession.ts
+++ b/examples/browser/examples/call/src/session/localSession.ts
@@ -165,7 +165,6 @@ export class LocalSession {
   }
 
   async subscribe(
-    subscribeId: bigint,
     trackNamespace: string[],
     trackName: string,
     authInfo: string = this.defaultAuthInfo,
@@ -175,9 +174,9 @@ export class LocalSession {
     if (this.state !== LocalSessionState.Ready) {
       throw new Error(`Cannot subscribe when session state is "${this.state}"`)
     }
-    const subscribeOk = await this.client.subscribe(subscribeId, trackNamespace, trackName, authInfo)
+    const { requestId, subscribeOk } = await this.client.subscribe(trackNamespace, trackName, authInfo)
     const trackAlias = subscribeOk.trackAlias
-    this.subscribeTrackAliases.set(subscribeId, trackAlias)
+    this.subscribeTrackAliases.set(requestId, trackAlias)
     const remoteUser = trackNamespace[1] ?? `alias-${trackAlias.toString()}`
 
     const resolvedRole = role ?? this.resolveTrackRole(trackName)
@@ -214,11 +213,10 @@ export class LocalSession {
       this.mediaController.registerRemoteTrack(remoteUser, trackName, trackAlias, resolvedRole, codec)
     }
 
-    return trackAlias
+    return requestId
   }
 
   async subscribeCatalog(
-    subscribeId: bigint,
     trackNamespace: string[],
     authInfo: string = this.defaultAuthInfo,
     timeoutMs: number = 5000,
@@ -259,24 +257,26 @@ export class LocalSession {
       this.client
         // Largest Object (0x2) filter: receive catalog updates after largest_at_subscribe.
         // The current catalog is backfilled via Joining Fetch below.
-        .subscribe(subscribeId, trackNamespace, 'catalog', authInfo, { filterType: 2 })
-        .then(async (subscribeOk) => {
+        .subscribe(trackNamespace, 'catalog', authInfo, { filterType: 2 })
+        .then(async ({ requestId: catalogRequestId, subscribeOk }) => {
           const trackAlias = subscribeOk.trackAlias
-          this.subscribeTrackAliases.set(subscribeId, trackAlias)
+          this.subscribeTrackAliases.set(catalogRequestId, trackAlias)
 
           // If content exists, fetch the latest catalog via Joining Fetch.
           // joining_start=0 means "the group at largest_at_subscribe" (0 groups back).
+          // The fetch id is issued internally by moqtClient; joiningRequestId is the
+          // catalog subscribe's request id we just received.
           const contentExists = (subscribeOk as any).contentExists ?? (subscribeOk as any).content_exists
           if (contentExists) {
             console.info('[call][catalog] content exists; fetching via Joining Fetch', { trackNamespace })
-            const fetchId = subscribeId + 1000000n
-            this.client.setOnFetchObjectHandler(fetchId, (msg) => {
-              if (msg.objectPayload.length > 0) {
-                console.info('[call][catalog] payload received via Joining Fetch')
-                handleCatalogPayload(new TextDecoder().decode(new Uint8Array(msg.objectPayload)))
+            await this.client.relativeJoiningFetch(catalogRequestId, 0n, {
+              onObject: (msg) => {
+                if (msg.objectPayload.length > 0) {
+                  console.info('[call][catalog] payload received via Joining Fetch')
+                  handleCatalogPayload(new TextDecoder().decode(new Uint8Array(msg.objectPayload)))
+                }
               }
             })
-            await this.client.relativeJoiningFetch(fetchId, subscribeId, 0n)
           } else {
             console.info('[call][catalog] no content yet; waiting for subscribe stream', { trackNamespace })
           }

--- a/examples/browser/examples/call/src/utils/state/roomState.ts
+++ b/examples/browser/examples/call/src/utils/state/roomState.ts
@@ -1,47 +1,14 @@
 import { RemoteMember, SubscriptionState } from '../../types/member'
 import { Room } from '../../types/room'
 
-export interface RemoteMemberUpdateResult {
-  room: Room
-  chatSubscribeId: bigint
-  catalogSubscribeId: bigint
-  audioSubscribeId: bigint
-  videoSubscribeId: bigint
-  screenshareSubscribeId: bigint
-  targetMember: RemoteMember
-}
-
-export function addOrUpdateRemoteMember(
-  room: Room,
-  announcedUser: string,
-  trackNamespace: string[]
-): RemoteMemberUpdateResult {
+export function addOrUpdateRemoteMember(room: Room, announcedUser: string, trackNamespace: string[]): Room {
   const existingMember = room.remoteMembers.get(announcedUser)
-  const { chatSubscribeId, catalogSubscribeId, audioSubscribeId, videoSubscribeId, screenshareSubscribeId } =
-    computeSubscribeIds(room, announcedUser, existingMember)
-
-  const updatedMember = buildRemoteMember({
-    existingMember,
-    announcedUser,
-    trackNamespace,
-    chatSubscribeId,
-    audioSubscribeId,
-    videoSubscribeId,
-    screenshareSubscribeId
-  })
+  const updatedMember = buildRemoteMember({ existingMember, announcedUser, trackNamespace })
 
   const updatedMembers = new Map(room.remoteMembers)
   updatedMembers.set(announcedUser, updatedMember)
 
-  return {
-    room: { ...room, remoteMembers: updatedMembers },
-    chatSubscribeId,
-    catalogSubscribeId,
-    audioSubscribeId,
-    videoSubscribeId,
-    screenshareSubscribeId,
-    targetMember: updatedMember
-  }
+  return { ...room, remoteMembers: updatedMembers }
 }
 
 export function resetSubscriptionsOnError(room: Room, userId: string): Room {
@@ -111,38 +78,16 @@ export function alreadySubscribing(existingMember?: RemoteMember): boolean {
   )
 }
 
-export function computeSubscribeIds(room: Room, announcedUser: string, existingMember?: RemoteMember) {
-  const memberIndex = existingMember
-    ? Array.from(room.remoteMembers.keys()).indexOf(announcedUser)
-    : room.remoteMembers.size
-  const baseSubscribeId = memberIndex * 5
-  return {
-    chatSubscribeId: BigInt(baseSubscribeId),
-    catalogSubscribeId: BigInt(baseSubscribeId + 1),
-    audioSubscribeId: BigInt(baseSubscribeId + 2),
-    videoSubscribeId: BigInt(baseSubscribeId + 3),
-    screenshareSubscribeId: BigInt(baseSubscribeId + 4)
-  }
-}
-
 interface BuildRemoteMemberOptions {
   existingMember?: RemoteMember
   announcedUser: string
   trackNamespace: string[]
-  chatSubscribeId: bigint
-  audioSubscribeId: bigint
-  videoSubscribeId: bigint
-  screenshareSubscribeId: bigint
 }
 
 export function buildRemoteMember({
   existingMember,
   announcedUser,
-  trackNamespace,
-  chatSubscribeId,
-  audioSubscribeId,
-  videoSubscribeId,
-  screenshareSubscribeId
+  trackNamespace
 }: BuildRemoteMemberOptions): RemoteMember {
   if (existingMember) {
     return {
@@ -187,11 +132,13 @@ export function buildRemoteMember({
       screenshare: { isAnnounced: true, trackNamespace },
       audio: { isAnnounced: true, trackNamespace }
     },
+    // subscribeId is left undefined until the track is actually subscribed; the
+    // id is then taken from subscribe()'s return value (issued by moqtClient).
     subscribedTracks: {
-      chat: { isSubscribing: false, isSubscribed: false, subscribeId: chatSubscribeId },
-      audio: { isSubscribing: false, isSubscribed: false, subscribeId: audioSubscribeId },
-      video: { isSubscribing: false, isSubscribed: false, subscribeId: videoSubscribeId },
-      screenshare: { isSubscribing: false, isSubscribed: false, subscribeId: screenshareSubscribeId }
+      chat: { isSubscribing: false, isSubscribed: false },
+      audio: { isSubscribing: false, isSubscribed: false },
+      video: { isSubscribing: false, isSubscribed: false },
+      screenshare: { isSubscribing: false, isSubscribed: false }
     }
   }
 }

--- a/examples/browser/examples/media-cmaf/subscriber/main.ts
+++ b/examples/browser/examples/media-cmaf/subscriber/main.ts
@@ -766,8 +766,8 @@ const sendCatalogSubscribeButtonClickHandler = (): void => {
       return
     }
     const catalogTrackAlias = (
-      await moqtClient.subscribe(catalogSubscribeId, trackNamespace, catalogTrackName, AUTH_INFO)
-    ).trackAlias
+      await moqtClient.subscribe(trackNamespace, catalogTrackName, AUTH_INFO, { requestId: catalogSubscribeId })
+    ).subscribeOk.trackAlias
     form['catalog-track-alias'].value = catalogTrackAlias.toString()
     setupCatalogCallbacks(catalogTrackAlias)
     setCatalogTrackStatus(`Catalog subscribed: ${catalogTrackName}`)
@@ -798,13 +798,14 @@ const sendSubscribeButtonClickHandler = (): void => {
 
     setupMediaSource(videoTrack.codec, audioTrack.codec)
     const videoTrackAlias = (
-      await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)
-    ).trackAlias
+      await moqtClient.subscribe(trackNamespace, selectedVideoTrack, AUTH_INFO, { requestId: videoSubscribeId })
+    ).subscribeOk.trackAlias
     form['video-track-alias'].value = videoTrackAlias.toString()
     setupVideoObjectCallbacks(videoTrackAlias)
 
-    const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, trackNamespace, audioTrack.name, AUTH_INFO))
-      .trackAlias
+    const audioTrackAlias = (
+      await moqtClient.subscribe(trackNamespace, audioTrack.name, AUTH_INFO, { requestId: audioSubscribeId })
+    ).subscribeOk.trackAlias
     form['audio-track-alias'].value = audioTrackAlias.toString()
     setupAudioObjectCallbacks(audioTrackAlias)
     setCatalogTrackStatus(`Subscribed video=${selectedVideoTrack} audio=${audioTrack.name}`)

--- a/examples/browser/examples/media/subscriber/main.ts
+++ b/examples/browser/examples/media/subscriber/main.ts
@@ -299,8 +299,8 @@ function sendCatalogSubscribeButtonClickHandler(): void {
       return
     }
     const catalogTrackAlias = (
-      await moqtClient.subscribe(catalogSubscribeId, trackNamespace, catalogTrackName, AUTH_INFO)
-    ).trackAlias
+      await moqtClient.subscribe(trackNamespace, catalogTrackName, AUTH_INFO, { requestId: catalogSubscribeId })
+    ).subscribeOk.trackAlias
     form['catalog-track-alias'].value = catalogTrackAlias.toString()
     setupCatalogCallbacks(catalogTrackAlias)
     setCatalogTrackStatus(`Catalog subscribe requested: ${catalogTrackName}`)
@@ -323,14 +323,14 @@ function sendSubscribeButtonClickHandler(): void {
     }
 
     const videoTrackAlias = (
-      await moqtClient.subscribe(videoSubscribeId, trackNamespace, selectedVideoTrack, AUTH_INFO)
-    ).trackAlias
+      await moqtClient.subscribe(trackNamespace, selectedVideoTrack, AUTH_INFO, { requestId: videoSubscribeId })
+    ).subscribeOk.trackAlias
     form['video-track-alias'].value = videoTrackAlias.toString()
     setupClientObjectCallbacks('video', videoTrackAlias)
 
     const audioTrackAlias = (
-      await moqtClient.subscribe(audioSubscribeId, trackNamespace, selectedAudioTrack, AUTH_INFO)
-    ).trackAlias
+      await moqtClient.subscribe(trackNamespace, selectedAudioTrack, AUTH_INFO, { requestId: audioSubscribeId })
+    ).subscribeOk.trackAlias
     form['audio-track-alias'].value = audioTrackAlias.toString()
     setupClientObjectCallbacks('audio', audioTrackAlias)
     setTrackSubscribeStatus(`Track subscribe requested: video=${selectedVideoTrack}, audio=${selectedAudioTrack}`)

--- a/examples/browser/examples/message/main.ts
+++ b/examples/browser/examples/message/main.ts
@@ -386,7 +386,8 @@ function setupActionButtons(): void {
     }
 
     const trackAlias = (
-      await moqtClient.subscribe(requestId, trackNamespace, trackName, authInfo, {
+      await moqtClient.subscribe(trackNamespace, trackName, authInfo, {
+        requestId,
         subscriberPriority,
         groupOrder,
         filterType,
@@ -395,7 +396,7 @@ function setupActionButtons(): void {
         endGroup,
         forward
       })
-    ).trackAlias
+    ).subscribeOk.trackAlias
 
     registerTrackAlias(requestId, trackAlias, {
       trackNamespace: [...trackNamespace],

--- a/examples/browser/examples/onvif/main.ts
+++ b/examples/browser/examples/onvif/main.ts
@@ -1189,8 +1189,9 @@ async function subscribeCatalog(): Promise<void> {
     return
   }
 
-  const catalogAlias = (await moqtClient.subscribe(catalogSubscribeId, subscribeNamespace, catalogTrack, authInfo))
-    .trackAlias
+  const catalogAlias = (
+    await moqtClient.subscribe(subscribeNamespace, catalogTrack, authInfo, { requestId: catalogSubscribeId })
+  ).subscribeOk.trackAlias
   ;(document.getElementById('catalog-track-alias') as HTMLInputElement).value = catalogAlias.toString()
   setupCatalogCallbacks(catalogAlias)
   catalogTrackAlias = catalogAlias
@@ -1214,8 +1215,9 @@ async function subscribeSelectedVideo(): Promise<void> {
     return
   }
 
-  const videoTrackAlias = (await moqtClient.subscribe(videoSubscribeId, subscribeNamespace, videoTrack, authInfo))
-    .trackAlias
+  const videoTrackAlias = (
+    await moqtClient.subscribe(subscribeNamespace, videoTrack, authInfo, { requestId: videoSubscribeId })
+  ).subscribeOk.trackAlias
   ;(document.getElementById('video-track-alias') as HTMLInputElement).value = videoTrackAlias.toString()
   setupVideoCallbacks(videoTrackAlias)
   videoSubscribed = true
@@ -1238,8 +1240,9 @@ async function subscribeSelectedAudio(): Promise<void> {
     return
   }
 
-  const audioTrackAlias = (await moqtClient.subscribe(audioSubscribeId, subscribeNamespace, audioTrack, authInfo))
-    .trackAlias
+  const audioTrackAlias = (
+    await moqtClient.subscribe(subscribeNamespace, audioTrack, authInfo, { requestId: audioSubscribeId })
+  ).subscribeOk.trackAlias
   ;(document.getElementById('audio-track-alias') as HTMLInputElement).value = audioTrackAlias.toString()
   setupAudioCallbacks(audioTrackAlias)
   audioSubscribed = true

--- a/examples/browser/lib/moqt/moqtClient.ts
+++ b/examples/browser/lib/moqt/moqtClient.ts
@@ -330,6 +330,27 @@ export class MoqtClientWrapper {
     return response
   }
 
+  async relativeJoiningFetch(
+    requestId: bigint,
+    joiningRequestId: bigint,
+    joiningStart: bigint
+  ): Promise<FetchOkMessage> {
+    const client = this.requireConnectedClient()
+    const response = new Promise<FetchOkMessage>((resolve, reject) => {
+      const handler: FetchResponseHandler = (msg) => {
+        this.onFetchResponseHandler = null
+        if (msg instanceof FetchOkMessage) {
+          resolve(msg)
+        } else {
+          reject(new Error(`FETCH_ERROR: ${(msg as RequestErrorMessage).reasonPhrase}`))
+        }
+      }
+      this.onFetchResponseHandler = handler
+    })
+    await client.sendRelativeJoiningFetch(requestId, joiningRequestId, joiningStart)
+    return response
+  }
+
   setOnFetchObjectHandler(requestId: bigint, handler: FetchObjectHandler): void {
     this.fetchObjectHandlers.set(requestId, handler)
   }

--- a/examples/browser/lib/moqt/moqtClient.ts
+++ b/examples/browser/lib/moqt/moqtClient.ts
@@ -48,6 +48,13 @@ export interface SubscribeNamespaceOptions {
 }
 
 export interface SubscribeOptions {
+  /**
+   * Override the request id. When omitted, a session-unique id is issued
+   * internally via issueRequestId(). Production code should let it be issued
+   * automatically; only manual/test tools that need to control the exact id on
+   * the wire should pass this.
+   */
+  requestId?: bigint
   subscriberPriority?: number
   groupOrder?: number
   filterType?: number
@@ -56,6 +63,25 @@ export interface SubscribeOptions {
   endGroup?: bigint
   forward?: boolean
   deliveryTimeout?: bigint
+}
+
+export interface FetchOptions {
+  /** Override the request id; issued internally when omitted. */
+  requestId?: bigint
+  /** Handler for FETCH objects, registered before the request is sent. */
+  onObject?: FetchObjectHandler
+}
+
+/** Result of subscribe(): the id we issued plus the SUBSCRIBE_OK response. */
+export interface SubscribeResult {
+  requestId: bigint
+  subscribeOk: SubscribeOkMessage
+}
+
+/** Result of fetch()/relativeJoiningFetch(): the id we issued plus FETCH_OK. */
+export interface FetchResult {
+  requestId: bigint
+  fetchOk: FetchOkMessage
 }
 
 export interface IncomingPublishNamespaceContext {
@@ -269,17 +295,17 @@ export class MoqtClientWrapper {
   }
 
   async subscribe(
-    requestId: bigint,
     trackNamespace: string[],
     trackName: string,
     authInfo: string,
     options: SubscribeOptions = {}
-  ): Promise<SubscribeOkMessage> {
+  ): Promise<SubscribeResult> {
     const client = this.requireConnectedClient()
+    const requestId = options.requestId ?? this.issueRequestId()
     const existingTrackAlias = this.subscriptionTrackAliases.get(requestId)
     if (existingTrackAlias !== undefined) {
-      // Reconstruct a minimal SubscribeOkMessage-like object is not possible here;
-      // callers that hit this branch only need trackAlias, so we throw to surface the issue.
+      // Only reachable when a caller passes an explicit options.requestId that
+      // collides with an in-flight subscription; internally issued ids never do.
       throw new Error(`subscribe: requestId ${requestId} already has trackAlias ${existingTrackAlias}`)
     }
 
@@ -302,42 +328,63 @@ export class MoqtClientWrapper {
       options.deliveryTimeout
     )
 
-    return response
+    const subscribeOk = await response
+    return { requestId, subscribeOk }
   }
 
   async fetch(
-    requestId: bigint,
     trackNamespace: string[],
     trackName: string,
     startGroupId: bigint,
     startObjectId: bigint,
     endGroupId: bigint,
-    endObjectId: bigint
-  ): Promise<FetchOkMessage> {
+    endObjectId: bigint,
+    options: FetchOptions = {}
+  ): Promise<FetchResult> {
     const client = this.requireConnectedClient()
-    const response = new Promise<FetchOkMessage>((resolve, reject) => {
-      const handler: FetchResponseHandler = (msg) => {
-        this.onFetchResponseHandler = null
-        if (msg instanceof FetchOkMessage) {
-          resolve(msg)
-        } else {
-          reject(new Error(`FETCH_ERROR: ${(msg as RequestErrorMessage).reasonPhrase}`))
-        }
+    const requestId = options.requestId ?? this.issueRequestId()
+    if (options.onObject) {
+      this.setOnFetchObjectHandler(requestId, options.onObject)
+    }
+    const response = this.awaitFetchOk()
+    try {
+      await client.sendFetch(requestId, trackNamespace, trackName, startGroupId, startObjectId, endGroupId, endObjectId)
+      const fetchOk = await response
+      return { requestId, fetchOk }
+    } catch (error) {
+      if (options.onObject) {
+        this.clearFetchObjectHandler(requestId)
       }
-      this.onFetchResponseHandler = handler
-    })
-    await client.sendFetch(requestId, trackNamespace, trackName, startGroupId, startObjectId, endGroupId, endObjectId)
-    return response
+      throw error
+    }
   }
 
   async relativeJoiningFetch(
-    requestId: bigint,
     joiningRequestId: bigint,
-    joiningStart: bigint
-  ): Promise<FetchOkMessage> {
+    joiningStart: bigint,
+    options: FetchOptions = {}
+  ): Promise<FetchResult> {
     const client = this.requireConnectedClient()
-    const response = new Promise<FetchOkMessage>((resolve, reject) => {
-      const handler: FetchResponseHandler = (msg) => {
+    const requestId = options.requestId ?? this.issueRequestId()
+    if (options.onObject) {
+      this.setOnFetchObjectHandler(requestId, options.onObject)
+    }
+    const response = this.awaitFetchOk()
+    try {
+      await client.sendRelativeJoiningFetch(requestId, joiningRequestId, joiningStart)
+      const fetchOk = await response
+      return { requestId, fetchOk }
+    } catch (error) {
+      if (options.onObject) {
+        this.clearFetchObjectHandler(requestId)
+      }
+      throw error
+    }
+  }
+
+  private awaitFetchOk(): Promise<FetchOkMessage> {
+    return new Promise<FetchOkMessage>((resolve, reject) => {
+      this.onFetchResponseHandler = (msg) => {
         this.onFetchResponseHandler = null
         if (msg instanceof FetchOkMessage) {
           resolve(msg)
@@ -345,10 +392,7 @@ export class MoqtClientWrapper {
           reject(new Error(`FETCH_ERROR: ${(msg as RequestErrorMessage).reasonPhrase}`))
         }
       }
-      this.onFetchResponseHandler = handler
     })
-    await client.sendRelativeJoiningFetch(requestId, joiningRequestId, joiningStart)
-    return response
   }
 
   setOnFetchObjectHandler(requestId: bigint, handler: FetchObjectHandler): void {
@@ -540,9 +584,13 @@ export class MoqtClientWrapper {
     client.incrementSubgroupObject(trackAlias)
   }
 
+  // MOQ-T draft-14 §9.1: client-initiated Request IDs start at 0 and increase by
+  // 2 (clients use even ids, servers odd). One counter covers every request type
+  // (PUBLISH_NAMESPACE / SUBSCRIBE_NAMESPACE / SUBSCRIBE / FETCH) so ids stay
+  // unique within the session.
   private issueRequestId(): bigint {
     const requestId = this.nextRequestId
-    this.nextRequestId += 1n
+    this.nextRequestId += 2n
     return requestId
   }
 

--- a/examples/rust/fetch-e2e/src/main.rs
+++ b/examples/rust/fetch-e2e/src/main.rs
@@ -105,6 +105,84 @@ async fn run_fetch(
     Ok(())
 }
 
+async fn run_joining_fetch(
+    subscriber: &mut moqt::Subscriber<QUIC>,
+    joining_request_id: u64,
+    joining_start: u64,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        "[carol] joining fetch request_id={} joining_start={}",
+        joining_request_id,
+        joining_start
+    );
+    let handle = subscriber
+        .fetch_relative_joining(joining_request_id, joining_start, FetchOption::default())
+        .await?;
+    let mut receiver: FetchDataReceiver<QUIC> = subscriber.accept_fetch_receiver(&handle).await?;
+    loop {
+        match receiver.receive().await {
+            Ok(Fetch::Header(_)) => {}
+            Ok(Fetch::Object(obj)) => {
+                let payload = match &obj.fetch_object {
+                    FetchObject::Payload(b) => String::from_utf8_lossy(b).to_string(),
+                    FetchObject::Status(s) => format!("{:?}", s),
+                };
+                tracing::info!(
+                    "[carol] joining g{}:o{} = {}",
+                    obj.group_id,
+                    obj.object_id,
+                    payload
+                );
+            }
+            Ok(Fetch::End) => {
+                tracing::info!("[carol] joining fetch done");
+                break;
+            }
+            Err(e) => {
+                tracing::info!("[carol] joining fetch done (error): {}", e);
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn carol(
+    cert_path: String,
+    ready_rx: tokio::sync::oneshot::Receiver<()>,
+    done_tx: tokio::sync::oneshot::Sender<()>,
+) -> anyhow::Result<()> {
+    // Wait until Bob has finished his standalone fetches (cache is fully populated).
+    let _ = ready_rx.await;
+
+    let session = new_session(&cert_path).await?;
+    let mut subscriber = session.subscriber();
+    let subscription = subscriber
+        .subscribe(
+            NAMESPACE.to_string(),
+            TRACK_NAME.to_string(),
+            SubscribeOption {
+                subscriber_priority: 128,
+                group_order: GroupOrder::Ascending,
+                forward: true,
+                filter_type: FilterType::LargestObject,
+            },
+        )
+        .await?;
+    tracing::info!(
+        "[carol] subscribe ok, request_id={}, content_exists={:?}",
+        subscription.request_id(),
+        subscription.content_exists()
+    );
+
+    // Joining Fetch: 1 group back from largest_at_subscribe.
+    run_joining_fetch(&mut subscriber, subscription.request_id(), 1).await?;
+
+    tracing::info!("[carol] all done");
+    let _ = done_tx.send(());
+    Ok(())
+}
+
 async fn alice(cert_path: String) -> anyhow::Result<()> {
     let session = new_session(&cert_path).await?;
     session
@@ -136,7 +214,11 @@ async fn alice(cert_path: String) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn bob(cert_path: String) -> anyhow::Result<()> {
+async fn bob(
+    cert_path: String,
+    carol_ready_tx: tokio::sync::oneshot::Sender<()>,
+    carol_done_rx: tokio::sync::oneshot::Receiver<()>,
+) -> anyhow::Result<()> {
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let session = new_session(&cert_path).await?;
@@ -224,6 +306,11 @@ async fn bob(cert_path: String) -> anyhow::Result<()> {
     )
     .await?;
 
+    // Signal Carol that standalone fetches are done and the cache is fully populated.
+    let _ = carol_ready_tx.send(());
+    // Keep this session alive until Carol completes her Joining Fetch.
+    let _ = carol_done_rx.await;
+
     tracing::info!("[bob] all done");
     Ok(())
 }
@@ -241,12 +328,16 @@ async fn main() -> anyhow::Result<()> {
         std::env::current_dir()?.to_str().unwrap()
     );
 
+    let (carol_ready_tx, carol_ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let (carol_done_tx, carol_done_rx) = tokio::sync::oneshot::channel::<()>();
+
     let alice_handle = tokio::spawn(alice(cert_path.clone()));
-    let bob_handle = tokio::spawn(bob(cert_path));
+    let bob_handle = tokio::spawn(bob(cert_path.clone(), carol_ready_tx, carol_done_rx));
+    tokio::spawn(carol(cert_path, carol_ready_rx, carol_done_tx));
 
     tokio::select! {
-        r = alice_handle => { r??; }
         r = bob_handle => { r??; }
+        r = alice_handle => { r??; }
         _ = tokio::signal::ctrl_c() => {}
     }
 

--- a/moqt/src/modules/moqt/data_plane/codec/control_message_decoder.rs
+++ b/moqt/src/modules/moqt/data_plane/codec/control_message_decoder.rs
@@ -165,7 +165,16 @@ impl ControlMessageDecoder {
                     }
                 }
             }
-            ControlMessageType::FetchError => todo!(),
+            ControlMessageType::FetchError => {
+                tracing::debug!("Event: Fetch error");
+                match RequestError::decode(&mut cursor_buf) {
+                    Some(v) => ReceivedMessage::FetchError(v),
+                    None => {
+                        tracing::error!("Protocol violation is detected.");
+                        ReceivedMessage::FatalError()
+                    }
+                }
+            }
             ControlMessageType::FetchCancel => todo!(),
             ControlMessageType::TrackStatusRequest => todo!(),
             ControlMessageType::TrackStatus => todo!(),

--- a/moqt/src/modules/moqt/data_plane/stream/received_message.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/received_message.rs
@@ -25,6 +25,7 @@ pub(crate) enum ReceivedMessage {
     Unsubscribe(Unsubscribe),
     Fetch(Fetch),
     FetchOk(FetchOk),
+    FetchError(RequestError),
     FatalError(),
 }
 
@@ -49,6 +50,7 @@ impl std::fmt::Debug for ReceivedMessage {
             ReceivedMessage::Unsubscribe(_) => "Unsubscribe",
             ReceivedMessage::Fetch(_) => "Fetch",
             ReceivedMessage::FetchOk(_) => "FetchOk",
+            ReceivedMessage::FetchError(_) => "FetchError",
             ReceivedMessage::FatalError() => "FatalError",
         };
 

--- a/moqt/src/modules/moqt/domains/subscriber.rs
+++ b/moqt/src/modules/moqt/domains/subscriber.rs
@@ -237,6 +237,78 @@ impl<T: TransportProtocol> Subscriber<T> {
 
     #[tracing::instrument(
         level = "info",
+        name = "moqt.subscriber.fetch_relative_joining",
+        skip_all,
+        fields(joining_request_id = %joining_request_id, joining_start = %joining_start)
+    )]
+    pub async fn fetch_relative_joining(
+        &mut self,
+        joining_request_id: u64,
+        joining_start: u64,
+        option: FetchOption,
+    ) -> anyhow::Result<FetchHandle> {
+        let request_id = self.session.get_request_id();
+
+        let (fetch_stream_tx, fetch_stream_rx) =
+            tokio::sync::mpsc::unbounded_channel::<IncomingObject<T>>();
+        self.session
+            .fetch_notification_map
+            .write()
+            .await
+            .insert(request_id, fetch_stream_tx);
+        self.session
+            .fetch_receiver_map
+            .lock()
+            .await
+            .insert(request_id, fetch_stream_rx);
+
+        let (fetch_message_tx, fetch_message_rx) =
+            tokio::sync::oneshot::channel::<ResponseMessage>();
+        self.session
+            .sender_map
+            .lock()
+            .expect("sender_map poisoned")
+            .insert(request_id, fetch_message_tx);
+        let fetch = Fetch {
+            request_id,
+            subscriber_priority: option.subscriber_priority,
+            group_order: option.group_order,
+            fetch_type: FetchType::RelativeJoining {
+                joining_request_id,
+                joining_start,
+            },
+            authorization_tokens: vec![],
+        };
+        self.session
+            .send_stream
+            .send(ControlMessageType::Fetch, fetch.encode())
+            .await?;
+        let result = fetch_message_rx.await;
+        if let Err(e) = result {
+            bail!("Failed to receive message: {}", e)
+        }
+        let response = result.unwrap();
+        match response {
+            ResponseMessage::FetchOk(fetch_ok) => Ok(FetchHandle::new(fetch_ok)),
+            ResponseMessage::FetchError(_, _, _) => {
+                self.session
+                    .fetch_notification_map
+                    .write()
+                    .await
+                    .remove(&request_id);
+                self.session
+                    .fetch_receiver_map
+                    .lock()
+                    .await
+                    .remove(&request_id);
+                bail!("Fetch error")
+            }
+            _ => bail!("Protocol violation"),
+        }
+    }
+
+    #[tracing::instrument(
+        level = "info",
         name = "moqt.subscriber.unsubscribe",
         skip_all,
         fields(subscribe_id = %subscribe_id)

--- a/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
+++ b/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
@@ -213,6 +213,15 @@ impl ControlMessageReceiveTask {
                 let response = ResponseMessage::FetchOk(fetch_ok);
                 DepacketizeResult::ResponseMessage(request_id, response)
             }
+            ReceivedMessage::FetchError(fetch_error) => {
+                tracing::debug!("Event: Fetch error");
+                let response = ResponseMessage::FetchError(
+                    fetch_error.request_id,
+                    fetch_error.error_code,
+                    fetch_error.reason_phrase,
+                );
+                DepacketizeResult::ResponseMessage(fetch_error.request_id, response)
+            }
             _ => todo!(),
         }
     }

--- a/relay/src/modules/enums.rs
+++ b/relay/src/modules/enums.rs
@@ -91,6 +91,26 @@ impl GroupOrder {
     }
 }
 
+// https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.18
+// FETCH_ERROR error codes.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub(crate) enum FetchErrorCode {
+    InternalError = 0x0,
+    Unauthorized = 0x1,
+    Timeout = 0x2,
+    NotSupported = 0x3,
+    TrackDoesNotExist = 0x4,
+    InvalidRange = 0x5,
+    NoObjects = 0x6,
+    InvalidJoiningRequestId = 0x7,
+    UnknownStatusInRange = 0x8,
+    MalformedTrack = 0x9,
+    MalformedAuthToken = 0x10,
+    ExpiredAuthToken = 0x12,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum ContentExists {
     False,

--- a/relay/src/modules/sequences/fetch.rs
+++ b/relay/src/modules/sequences/fetch.rs
@@ -2,12 +2,46 @@ use tracing::Span;
 
 use crate::modules::{
     core::handler::fetch::FetchHandler,
+    enums::FetchErrorCode,
     relay::egress::coordinator::{EgressCommand, EgressFetchRequest},
     sequences::tables::table::LocalPubSubDirectory,
-    types::SessionId,
+    types::{SessionId, TrackKey},
 };
 
 pub(crate) struct Fetch;
+
+/// A Fetch resolved to a concrete track and Object range.
+struct ResolvedFetch {
+    track_key: TrackKey,
+    start_location: moqt::Location,
+    end_location: moqt::Location,
+}
+
+/// A reason a FETCH could not be resolved, mapped to a FETCH_ERROR.
+#[derive(Debug)]
+enum FetchError {
+    TrackNotFound,
+    UnknownJoiningRequestId,
+    NoObjectsPublished,
+}
+
+impl FetchError {
+    fn code(&self) -> FetchErrorCode {
+        match self {
+            Self::TrackNotFound => FetchErrorCode::TrackDoesNotExist,
+            Self::UnknownJoiningRequestId => FetchErrorCode::InvalidJoiningRequestId,
+            Self::NoObjectsPublished => FetchErrorCode::InvalidRange,
+        }
+    }
+
+    fn reason(&self) -> &'static str {
+        match self {
+            Self::TrackNotFound => "Track not found",
+            Self::UnknownJoiningRequestId => "Unknown joining request id",
+            Self::NoObjectsPublished => "No objects published",
+        }
+    }
+}
 
 impl Fetch {
     #[tracing::instrument(
@@ -25,36 +59,145 @@ impl Fetch {
         egress_sender: &tokio::sync::mpsc::Sender<EgressCommand>,
         handler: Box<dyn FetchHandler>,
     ) {
-        let (track_namespace, track_name, start_group, start_object, end_group, end_object) =
-            match handler.fetch_type() {
-                // TODO: implement relative/absolute joining fetch.
-                moqt::wire::FetchType::Standalone {
+        // Resolve the target track and the Object range to deliver.
+        let ResolvedFetch {
+            track_key,
+            start_location,
+            end_location,
+        } = match self
+            .resolve_fetch(session_id, handler.fetch_type(), table)
+            .await
+        {
+            Ok(r) => r,
+            Err(err) => {
+                let _ = handler
+                    .error(err.code() as u64, err.reason().to_string())
+                    .await;
+                return;
+            }
+        };
+
+        // Send FETCH_OK on the control stream.
+        if let Err(e) = handler.ok(false, end_location).await {
+            tracing::error!(?e, "Failed to send FETCH_OK");
+            return;
+        }
+
+        // Delegate data delivery to egress.
+        let fetch_request = EgressFetchRequest {
+            subscriber_session_id: session_id,
+            request_id: handler.request_id(),
+            track_key,
+            start_location,
+            end_location,
+        };
+        if let Err(e) = egress_sender
+            .send(EgressCommand::StartFetch(fetch_request))
+            .await
+        {
+            tracing::error!(?e, "Failed to send fetch request to egress");
+        }
+    }
+
+    async fn resolve_fetch(
+        &self,
+        session_id: SessionId,
+        fetch_type: moqt::wire::FetchType,
+        table: &dyn LocalPubSubDirectory,
+    ) -> Result<ResolvedFetch, FetchError> {
+        match fetch_type {
+            moqt::wire::FetchType::Standalone {
+                track_namespace,
+                track_name,
+                start_location,
+                end_location,
+            } => {
+                self.resolve_standalone(
+                    table,
                     track_namespace,
                     track_name,
                     start_location,
                     end_location,
-                } => (
-                    track_namespace.join("/"),
-                    track_name,
-                    start_location.group_id,
-                    start_location.object_id,
-                    end_location.group_id,
-                    end_location.object_id,
-                ),
-                moqt::wire::FetchType::RelativeJoining { .. }
-                | moqt::wire::FetchType::AbsoluteJoining { .. } => {
-                    tracing::warn!("Joining fetch is not yet implemented");
-                    // 0 = Internal Error (TODO: use proper FetchErrorCode enum)
-                    let _ = handler
-                        .error(0, "Joining fetch is not yet implemented".to_string())
-                        .await;
-                    return;
-                }
-            };
+                )
+                .await
+            }
+            moqt::wire::FetchType::RelativeJoining {
+                joining_request_id,
+                joining_start,
+            } => {
+                self.resolve_relative_joining(session_id, joining_request_id, joining_start, table)
+                    .await
+            }
+            moqt::wire::FetchType::AbsoluteJoining {
+                joining_request_id,
+                joining_start,
+            } => {
+                self.resolve_absolute_joining(session_id, joining_request_id, joining_start, table)
+                    .await
+            }
+        }
+    }
 
-        // FIXME: Fetch fails if publisher has disconnected, even if cached data exists.
-        // Root cause: active_upstream_subscriptions are cleared on publisher disconnect,
-        // so track_key cannot be resolved after that.
+    async fn resolve_relative_joining(
+        &self,
+        session_id: SessionId,
+        joining_request_id: u64,
+        joining_start: u64,
+        table: &dyn LocalPubSubDirectory,
+    ) -> Result<ResolvedFetch, FetchError> {
+        let (track_key, largest) = self
+            .resolve_joined_subscription(session_id, joining_request_id, table)
+            .await?;
+        Ok(ResolvedFetch {
+            track_key,
+            // Relative: Start = {Largest.Group - n, 0}.
+            start_location: moqt::Location {
+                group_id: largest.group_id.saturating_sub(joining_start),
+                object_id: 0,
+            },
+            // §9.16.2.1: End = {Largest.Group, Largest.Object + 1}.
+            end_location: moqt::Location {
+                group_id: largest.group_id,
+                object_id: largest.object_id + 1,
+            },
+        })
+    }
+
+    async fn resolve_absolute_joining(
+        &self,
+        session_id: SessionId,
+        joining_request_id: u64,
+        joining_start: u64,
+        table: &dyn LocalPubSubDirectory,
+    ) -> Result<ResolvedFetch, FetchError> {
+        let (track_key, largest) = self
+            .resolve_joined_subscription(session_id, joining_request_id, table)
+            .await?;
+        Ok(ResolvedFetch {
+            track_key,
+            // Absolute: Start = {n, 0}.
+            start_location: moqt::Location {
+                group_id: joining_start,
+                object_id: 0,
+            },
+            // §9.16.2.1: End = {Largest.Group, Largest.Object + 1}.
+            end_location: moqt::Location {
+                group_id: largest.group_id,
+                object_id: largest.object_id + 1,
+            },
+        })
+    }
+
+    async fn resolve_standalone(
+        &self,
+        table: &dyn LocalPubSubDirectory,
+        track_namespace: Vec<String>,
+        track_name: String,
+        start_location: moqt::Location,
+        end_location: moqt::Location,
+    ) -> Result<ResolvedFetch, FetchError> {
+        let track_namespace = track_namespace.join("/");
+        // FIXME: fails if publisher has disconnected (active_upstream_subscriptions cleared on disconnect).
         let active_upstream_keys =
             table.find_active_upstream_subscriptions(&track_namespace, &track_name);
         let Some(key) = active_upstream_keys.into_iter().next() else {
@@ -63,9 +206,7 @@ impl Fetch {
                 track_name,
                 "No active upstream subscription found for fetch"
             );
-            // TODO: use proper FetchErrorCode enum. 0x4 = TRACK_DOES_NOT_EXIST
-            let _ = handler.error(0x4, "Track not found".to_string()).await;
-            return;
+            return Err(FetchError::TrackNotFound);
         };
         let Some(active_upstream) = table.get_active_upstream_subscription(
             key.publisher_session_id,
@@ -77,40 +218,128 @@ impl Fetch {
                 track_name,
                 "Active upstream subscription data not found"
             );
-            let _ = handler.error(0x4, "Track not found".to_string()).await;
-            return;
+            return Err(FetchError::TrackNotFound);
         };
-        let track_key = active_upstream.track_key;
-
-        // Send FETCH_OK on the control stream.
-        // FIXME: end_location should reflect the last object actually available in cache,
-        // not the requested end.
-        let end_location = moqt::Location {
-            group_id: end_group,
-            object_id: end_object,
-        };
-
-        if let Err(e) = handler.ok(false, end_location).await {
-            tracing::error!(?e, "Failed to send FETCH_OK");
-            return;
-        }
-
-        // Delegate data delivery to egress.
-        let fetch_request = EgressFetchRequest {
-            subscriber_session_id: session_id,
-            request_id: handler.request_id(),
-            track_key,
-            start_location: moqt::Location {
-                group_id: start_group,
-                object_id: start_object,
-            },
+        // FIXME: end_location should reflect what is actually available in cache,
+        // not the client-requested end.
+        Ok(ResolvedFetch {
+            track_key: active_upstream.track_key,
+            start_location,
             end_location,
+        })
+    }
+
+    /// Resolves the joined subscription's track and its Largest Location at subscribe time,
+    /// shared by Relative and Absolute Joining Fetch.
+    async fn resolve_joined_subscription(
+        &self,
+        session_id: SessionId,
+        joining_request_id: u64,
+        table: &dyn LocalPubSubDirectory,
+    ) -> Result<(TrackKey, moqt::Location), FetchError> {
+        // TODO: validate the joined Subscribe has Filter Type Largest Object;
+        // otherwise close the session with PROTOCOL_VIOLATION (§9.16.2).
+
+        let Some(downstream_sub) =
+            table.get_downstream_subscription(session_id, joining_request_id)
+        else {
+            tracing::warn!(
+                joining_request_id,
+                "Joining fetch references unknown subscription"
+            );
+            return Err(FetchError::UnknownJoiningRequestId);
         };
-        if let Err(e) = egress_sender
-            .send(EgressCommand::StartFetch(fetch_request))
+
+        let Some(active_upstream) = table.get_active_upstream_subscription(
+            downstream_sub.upstream_key.publisher_session_id,
+            &downstream_sub.upstream_key.track_namespace,
+            &downstream_sub.upstream_key.track_name,
+        ) else {
+            tracing::warn!("Joined subscription has no active upstream subscription");
+            return Err(FetchError::TrackNotFound);
+        };
+
+        let Some(largest) = downstream_sub.largest_at_subscribe else {
+            tracing::warn!("Joining fetch: no objects published at subscribe time");
+            return Err(FetchError::NoObjectsPublished);
+        };
+
+        Ok((active_upstream.track_key, largest))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::{
+        enums::ContentExists,
+        sequences::tables::{
+            hashmap_table::InMemoryLocalPubSubDirectory,
+            table::{
+                ActiveUpstreamSubscription, UpstreamSubscriptionKey, UpstreamSubscriptionOrigin,
+            },
+        },
+    };
+
+    fn setup_upstream(
+        table: &InMemoryLocalPubSubDirectory,
+        track_key: TrackKey,
+    ) -> UpstreamSubscriptionKey {
+        let key = UpstreamSubscriptionKey {
+            publisher_session_id: 1,
+            track_namespace: "ns".to_string(),
+            track_name: "track".to_string(),
+        };
+        table.register_upstream_subscription(
+            key.clone(),
+            ActiveUpstreamSubscription {
+                upstream_request_id: 1,
+                track_key,
+                expires: None,
+                content_exists: ContentExists::False,
+                downstream_subscriber_count: 0,
+                origin: UpstreamSubscriptionOrigin::Subscribe,
+            },
+        );
+        key
+    }
+
+    #[tokio::test]
+    async fn resolve_joined_subscription_unknown_request_id() {
+        let table = InMemoryLocalPubSubDirectory::new();
+        let result = Fetch.resolve_joined_subscription(1, 999, &table).await;
+        assert!(matches!(result, Err(FetchError::UnknownJoiningRequestId)));
+    }
+
+    #[tokio::test]
+    async fn resolve_joined_subscription_no_objects_published() {
+        let table = InMemoryLocalPubSubDirectory::new();
+        let key = setup_upstream(&table, 42);
+        table.register_downstream_subscription(2, 100, key, None);
+        let result = Fetch.resolve_joined_subscription(2, 100, &table).await;
+        assert!(matches!(result, Err(FetchError::NoObjectsPublished)));
+    }
+
+    #[tokio::test]
+    async fn resolve_joined_subscription_returns_stored_largest() {
+        let table = InMemoryLocalPubSubDirectory::new();
+        let largest = moqt::Location {
+            group_id: 10,
+            object_id: 5,
+        };
+        let key = setup_upstream(&table, 42);
+        table.register_downstream_subscription(2, 100, key, Some(largest));
+        let (track_key, loc) = Fetch
+            .resolve_joined_subscription(2, 100, &table)
             .await
-        {
-            tracing::error!(?e, "Failed to send fetch request to egress");
-        }
+            .unwrap();
+        assert_eq!(track_key, 42);
+        assert_eq!(
+            loc,
+            moqt::Location {
+                group_id: 10,
+                object_id: 5
+            }
+        );
     }
 }

--- a/relay/src/modules/sequences/fetch.rs
+++ b/relay/src/modules/sequences/fetch.rs
@@ -259,7 +259,7 @@ impl Fetch {
             return Err(FetchError::TrackNotFound);
         };
 
-        let Some(largest) = downstream_sub.largest_at_subscribe else {
+        let Some(largest) = downstream_sub.start_location else {
             tracing::warn!("Joining fetch: no objects published at subscribe time");
             return Err(FetchError::NoObjectsPublished);
         };

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -317,15 +317,16 @@ impl Subscribe {
 
         // Derive content_exists from the largest cached object when available,
         // falling back to the upstream-advertised value.
-        let content_exists = match cache_store.get(active_upstream.track_key) {
-            Some(cache) => match cache.largest_location().await {
-                Some(loc) => ContentExists::True {
-                    location: Location {
-                        group_id: loc.group_id,
-                        object_id: loc.object_id,
-                    },
+        let largest_at_subscribe = match cache_store.get(active_upstream.track_key) {
+            Some(cache) => cache.largest_location().await,
+            None => None,
+        };
+        let content_exists = match &largest_at_subscribe {
+            Some(loc) => ContentExists::True {
+                location: Location {
+                    group_id: loc.group_id,
+                    object_id: loc.object_id,
                 },
-                None => active_upstream.content_exists.clone(),
             },
             None => active_upstream.content_exists.clone(),
         };
@@ -334,6 +335,7 @@ impl Subscribe {
             session_id,
             handler.subscribe_id(),
             upstream_key.clone(),
+            largest_at_subscribe,
         ) {
             tracing::error!("Failed to register downstream subscription.");
             return;

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -315,13 +315,13 @@ impl Subscribe {
     ) {
         let subscriber_track_alias = handler.allocate_track_alias();
 
-        // Derive content_exists from the largest cached object when available,
-        // falling back to the upstream-advertised value.
-        let largest_at_subscribe = match cache_store.get(active_upstream.track_key) {
+        // The subscription's start location: the Largest Object Location at subscribe time.
+        // Also used to derive content_exists, falling back to the upstream-advertised value.
+        let start_location = match cache_store.get(active_upstream.track_key) {
             Some(cache) => cache.largest_location().await,
             None => None,
         };
-        let content_exists = match &largest_at_subscribe {
+        let content_exists = match &start_location {
             Some(loc) => ContentExists::True {
                 location: Location {
                     group_id: loc.group_id,
@@ -335,7 +335,7 @@ impl Subscribe {
             session_id,
             handler.subscribe_id(),
             upstream_key.clone(),
-            largest_at_subscribe,
+            start_location,
         ) {
             tracing::error!("Failed to register downstream subscription.");
             return;

--- a/relay/src/modules/sequences/tables/hashmap_table.rs
+++ b/relay/src/modules/sequences/tables/hashmap_table.rs
@@ -6,8 +6,9 @@ use tokio::sync::RwLock;
 use crate::modules::{
     core::handler::publish::PublishHandler,
     sequences::tables::table::{
-        ActiveUpstreamSubscription, LocalPubSubDirectory, RemovedDownstreamSubscription,
-        RemovedSessionSubscriptions, UpstreamSubscriptionKey, UpstreamSubscriptionOrigin,
+        ActiveUpstreamSubscription, DownstreamSubscription, LocalPubSubDirectory,
+        RemovedDownstreamSubscription, RemovedSessionSubscriptions, UpstreamSubscriptionKey,
+        UpstreamSubscriptionOrigin,
     },
     types::{SessionId, TrackNamespace, TrackNamespacePrefix},
 };
@@ -27,7 +28,7 @@ pub(crate) struct InMemoryLocalPubSubDirectory {
     pub(crate) track_alias_links: DashMap<(SessionId, u64, SessionId), u64>,
     pub(crate) active_upstream_subscriptions:
         DashMap<UpstreamSubscriptionKey, ActiveUpstreamSubscription>,
-    pub(crate) downstream_subscriptions: DashMap<(SessionId, u64), UpstreamSubscriptionKey>,
+    pub(crate) downstream_subscriptions: DashMap<(SessionId, u64), DownstreamSubscription>,
 }
 
 #[async_trait::async_trait]
@@ -132,7 +133,9 @@ impl LocalPubSubDirectory for InMemoryLocalPubSubDirectory {
             let downstream_keys: Vec<_> = self
                 .downstream_subscriptions
                 .iter()
-                .filter_map(|entry| (entry.value() == &upstream_key).then_some(*entry.key()))
+                .filter_map(|entry| {
+                    (entry.value().upstream_key == upstream_key).then_some(*entry.key())
+                })
                 .collect();
             for (downstream_session_id, downstream_subscribe_id) in downstream_keys {
                 self.downstream_subscriptions
@@ -414,6 +417,16 @@ impl LocalPubSubDirectory for InMemoryLocalPubSubDirectory {
             .map(|entry| entry.value().clone())
     }
 
+    fn get_downstream_subscription(
+        &self,
+        downstream_session_id: SessionId,
+        downstream_subscribe_id: u64,
+    ) -> Option<DownstreamSubscription> {
+        self.downstream_subscriptions
+            .get(&(downstream_session_id, downstream_subscribe_id))
+            .map(|entry| entry.value().clone())
+    }
+
     fn register_upstream_subscription(
         &self,
         key: UpstreamSubscriptionKey,
@@ -427,6 +440,7 @@ impl LocalPubSubDirectory for InMemoryLocalPubSubDirectory {
         downstream_session_id: SessionId,
         downstream_subscribe_id: u64,
         upstream_key: UpstreamSubscriptionKey,
+        largest_at_subscribe: Option<moqt::Location>,
     ) -> bool {
         let Some(mut entry) = self.active_upstream_subscriptions.get_mut(&upstream_key) else {
             return false;
@@ -436,7 +450,10 @@ impl LocalPubSubDirectory for InMemoryLocalPubSubDirectory {
 
         self.downstream_subscriptions.insert(
             (downstream_session_id, downstream_subscribe_id),
-            upstream_key,
+            DownstreamSubscription {
+                upstream_key,
+                largest_at_subscribe,
+            },
         );
         true
     }
@@ -446,9 +463,10 @@ impl LocalPubSubDirectory for InMemoryLocalPubSubDirectory {
         downstream_session_id: SessionId,
         downstream_subscribe_id: u64,
     ) -> Option<RemovedDownstreamSubscription> {
-        let (_, upstream_key) = self
+        let (_, downstream_sub) = self
             .downstream_subscriptions
             .remove(&(downstream_session_id, downstream_subscribe_id))?;
+        let upstream_key = downstream_sub.upstream_key;
         let mut entry = self.active_upstream_subscriptions.get_mut(&upstream_key)?;
         if entry.downstream_subscriber_count > 0 {
             entry.downstream_subscriber_count -= 1;
@@ -664,6 +682,75 @@ mod tests {
 
         // Assert: Keep multiple publishers regardless of whether they came from namespace or track state.
         assert_eq!(upstream_publishers, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn register_downstream_subscription_stores_largest_at_subscribe() {
+        let table = InMemoryLocalPubSubDirectory::new();
+        let upstream_key = UpstreamSubscriptionKey {
+            publisher_session_id: 1,
+            track_namespace: "ns".to_string(),
+            track_name: "track".to_string(),
+        };
+        table.register_upstream_subscription(
+            upstream_key.clone(),
+            ActiveUpstreamSubscription {
+                upstream_request_id: 1,
+                track_key: 42,
+                expires: None,
+                content_exists: ContentExists::False,
+                downstream_subscriber_count: 0,
+                origin: UpstreamSubscriptionOrigin::Subscribe,
+            },
+        );
+        let largest = moqt::Location {
+            group_id: 5,
+            object_id: 3,
+        };
+
+        assert!(table.register_downstream_subscription(
+            2,
+            100,
+            upstream_key.clone(),
+            Some(largest)
+        ));
+
+        let sub = table.get_downstream_subscription(2, 100).unwrap();
+        assert_eq!(sub.upstream_key, upstream_key);
+        assert_eq!(
+            sub.largest_at_subscribe,
+            Some(moqt::Location {
+                group_id: 5,
+                object_id: 3
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn register_downstream_subscription_none_largest_at_subscribe() {
+        let table = InMemoryLocalPubSubDirectory::new();
+        let upstream_key = UpstreamSubscriptionKey {
+            publisher_session_id: 1,
+            track_namespace: "ns".to_string(),
+            track_name: "track".to_string(),
+        };
+        table.register_upstream_subscription(
+            upstream_key.clone(),
+            ActiveUpstreamSubscription {
+                upstream_request_id: 1,
+                track_key: 42,
+                expires: None,
+                content_exists: ContentExists::False,
+                downstream_subscriber_count: 0,
+                origin: UpstreamSubscriptionOrigin::Subscribe,
+            },
+        );
+
+        assert!(table.register_downstream_subscription(2, 100, upstream_key.clone(), None));
+
+        let sub = table.get_downstream_subscription(2, 100).unwrap();
+        assert_eq!(sub.upstream_key, upstream_key);
+        assert!(sub.largest_at_subscribe.is_none());
     }
 
     #[tokio::test]

--- a/relay/src/modules/sequences/tables/hashmap_table.rs
+++ b/relay/src/modules/sequences/tables/hashmap_table.rs
@@ -440,7 +440,7 @@ impl LocalPubSubDirectory for InMemoryLocalPubSubDirectory {
         downstream_session_id: SessionId,
         downstream_subscribe_id: u64,
         upstream_key: UpstreamSubscriptionKey,
-        largest_at_subscribe: Option<moqt::Location>,
+        start_location: Option<moqt::Location>,
     ) -> bool {
         let Some(mut entry) = self.active_upstream_subscriptions.get_mut(&upstream_key) else {
             return false;
@@ -452,7 +452,7 @@ impl LocalPubSubDirectory for InMemoryLocalPubSubDirectory {
             (downstream_session_id, downstream_subscribe_id),
             DownstreamSubscription {
                 upstream_key,
-                largest_at_subscribe,
+                start_location,
             },
         );
         true
@@ -685,7 +685,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_downstream_subscription_stores_largest_at_subscribe() {
+    async fn register_downstream_subscription_stores_start_location() {
         let table = InMemoryLocalPubSubDirectory::new();
         let upstream_key = UpstreamSubscriptionKey {
             publisher_session_id: 1,
@@ -718,7 +718,7 @@ mod tests {
         let sub = table.get_downstream_subscription(2, 100).unwrap();
         assert_eq!(sub.upstream_key, upstream_key);
         assert_eq!(
-            sub.largest_at_subscribe,
+            sub.start_location,
             Some(moqt::Location {
                 group_id: 5,
                 object_id: 3
@@ -727,7 +727,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_downstream_subscription_none_largest_at_subscribe() {
+    async fn register_downstream_subscription_none_start_location() {
         let table = InMemoryLocalPubSubDirectory::new();
         let upstream_key = UpstreamSubscriptionKey {
             publisher_session_id: 1,
@@ -750,7 +750,7 @@ mod tests {
 
         let sub = table.get_downstream_subscription(2, 100).unwrap();
         assert_eq!(sub.upstream_key, upstream_key);
-        assert!(sub.largest_at_subscribe.is_none());
+        assert!(sub.start_location.is_none());
     }
 
     #[tokio::test]

--- a/relay/src/modules/sequences/tables/table.rs
+++ b/relay/src/modules/sequences/tables/table.rs
@@ -32,6 +32,12 @@ pub(crate) enum UpstreamSubscriptionOrigin {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct DownstreamSubscription {
+    pub(crate) upstream_key: UpstreamSubscriptionKey,
+    pub(crate) largest_at_subscribe: Option<moqt::Location>,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct RemovedDownstreamSubscription {
     pub(crate) downstream_session_id: SessionId,
     pub(crate) downstream_subscribe_id: u64,
@@ -97,6 +103,14 @@ pub(crate) trait LocalPubSubDirectory: Send + Sync + 'static + Debug {
         track_namespace: &str,
         track_name: &str,
     ) -> Option<ActiveUpstreamSubscription>;
+    /// Resolves the upstream subscription key linked to a downstream
+    /// subscription identified by its Request ID, scoped to the given session.
+    /// Used by Joining Fetch to find the subscription it joins.
+    fn get_downstream_subscription(
+        &self,
+        downstream_session_id: SessionId,
+        downstream_subscribe_id: u64,
+    ) -> Option<DownstreamSubscription>;
     fn register_upstream_subscription(
         &self,
         key: UpstreamSubscriptionKey,
@@ -107,6 +121,7 @@ pub(crate) trait LocalPubSubDirectory: Send + Sync + 'static + Debug {
         downstream_session_id: SessionId,
         downstream_subscribe_id: u64,
         upstream_key: UpstreamSubscriptionKey,
+        largest_at_subscribe: Option<moqt::Location>,
     ) -> bool;
     fn remove_downstream_subscription(
         &self,

--- a/relay/src/modules/sequences/tables/table.rs
+++ b/relay/src/modules/sequences/tables/table.rs
@@ -34,7 +34,8 @@ pub(crate) enum UpstreamSubscriptionOrigin {
 #[derive(Clone, Debug)]
 pub(crate) struct DownstreamSubscription {
     pub(crate) upstream_key: UpstreamSubscriptionKey,
-    pub(crate) largest_at_subscribe: Option<moqt::Location>,
+    /// The subscription's start location: the Largest Object Location at subscribe time.
+    pub(crate) start_location: Option<moqt::Location>,
 }
 
 #[derive(Clone, Debug)]
@@ -121,7 +122,7 @@ pub(crate) trait LocalPubSubDirectory: Send + Sync + 'static + Debug {
         downstream_session_id: SessionId,
         downstream_subscribe_id: u64,
         upstream_key: UpstreamSubscriptionKey,
-        largest_at_subscribe: Option<moqt::Location>,
+        start_location: Option<moqt::Location>,
     ) -> bool;
     fn remove_downstream_subscription(
         &self,


### PR DESCRIPTION
## Summary

- Implement MoQT Joining Fetch (RelativeJoining / AbsoluteJoining).
- Switch the call app's catalog backfill from Standalone Fetch to Joining Fetch.
- Add FetchError control message handling on the moqt client side.

## Test

- fetch-e2e: Verify that a Joining Fetch delivers the correct cached objects to a late-joining subscriber.
- call app: Verify that the catalog is successfully backfilled via Joining Fetch when a third participant joins.