### PR TITLE
feat(relay): deduplicate objects by id (draft-14 §8.1)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/cascading-relay-e2e.sh"
       - "scripts/fetch-e2e.sh"
       - "scripts/multiple-publishers-e2e.sh"
+      - "scripts/object-dedup-e2e.sh"
       - "docker-compose.yml"
       - "examples/browser/**"
       - "bindings/wasm/**"
@@ -25,6 +26,7 @@ on:
       - "tests/cascading-relay-e2e/**"
       - "tests/fetch-e2e/**"
       - "tests/multiple-publishers-e2e/**"
+      - "tests/object-dedup-e2e/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain"
@@ -47,6 +49,7 @@ on:
       - "scripts/cascading-relay-e2e.sh"
       - "scripts/fetch-e2e.sh"
       - "scripts/multiple-publishers-e2e.sh"
+      - "scripts/object-dedup-e2e.sh"
       - "docker-compose.yml"
       - "examples/browser/**"
       - "bindings/wasm/**"
@@ -56,6 +59,7 @@ on:
       - "tests/cascading-relay-e2e/**"
       - "tests/fetch-e2e/**"
       - "tests/multiple-publishers-e2e/**"
+      - "tests/object-dedup-e2e/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain"
@@ -77,6 +81,7 @@ jobs:
       cascading: ${{ steps.filter.outputs.cascading }}
       fetch: ${{ steps.filter.outputs.fetch }}
       multipub: ${{ steps.filter.outputs.multipub }}
+      dedup: ${{ steps.filter.outputs.dedup }}
       relay: ${{ steps.filter.outputs.relay }}
       relay_image_source: ${{ steps.filter.outputs.relay_image_source }}
     steps:
@@ -99,6 +104,7 @@ jobs:
             cascading=true
             fetch=true
             multipub=true
+            dedup=true
           else
             base="${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}"
 
@@ -113,6 +119,7 @@ jobs:
             cascading=false
             fetch=false
             multipub=false
+            dedup=false
 
             while IFS= read -r path; do
               case "$path" in
@@ -144,10 +151,16 @@ jobs:
                   multipub=true
                   ;;
               esac
+
+              case "$path" in
+                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/object-dedup-e2e.sh|scripts/ensure-relay-certs.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/object-dedup-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                  dedup=true
+                  ;;
+              esac
             done < changed-files.txt
           fi
 
-          if [[ "$call" == "true" || "$cascading" == "true" || "$fetch" == "true" || "$multipub" == "true" ]]; then
+          if [[ "$call" == "true" || "$cascading" == "true" || "$fetch" == "true" || "$multipub" == "true" || "$dedup" == "true" ]]; then
             relay=true
           else
             relay=false
@@ -169,6 +182,7 @@ jobs:
             echo "cascading=$cascading"
             echo "fetch=$fetch"
             echo "multipub=$multipub"
+            echo "dedup=$dedup"
             echo "relay=$relay"
             echo "relay_image_source=$relay_image_source"
           } >> "$GITHUB_OUTPUT"
@@ -547,3 +561,66 @@ jobs:
         env:
           CI: "true"
         run: ./scripts/multiple-publishers-e2e.sh
+
+  object_dedup_e2e:
+    needs: [changes, relay_image_local, relay_image]
+    if: ${{ always() && needs.changes.outputs.dedup == 'true' && ((needs.changes.outputs.relay_image_source == 'local' && needs.relay_image_local.result == 'success') || (needs.changes.outputs.relay_image_source == 'prebuilt' && needs.relay_image.result == 'success')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout repository
+        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust toolchain
+        # dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 = v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache Rust build artifacts
+        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+
+      - name: Download local relay image
+        if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
+        # actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 = v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: relay-image-local
+          path: ${{ runner.temp }}/relay-image
+
+      - name: Load local relay image
+        if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
+        run: |
+          gunzip -c "${RUNNER_TEMP}/relay-image/relay-image.tar.gz" | docker load
+          docker tag moqt-relay:local-source moqt-relay:local
+
+      - name: Log in to GHCR
+        if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
+        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull prebuilt relay image
+        if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
+        run: |
+          docker pull "${{ needs.relay_image.outputs.image }}"
+          docker tag "${{ needs.relay_image.outputs.image }}" moqt-relay:local
+
+      - name: Log out from GHCR
+        if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
+        run: docker logout ghcr.io
+
+      - name: Run object dedup E2E
+        env:
+          CI: "true"
+        run: ./scripts/object-dedup-e2e.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,6 +3622,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object-dedup-e2e"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "moqt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     'tests/cascading-relay-e2e',
     'tests/fetch-e2e',
     'tests/multiple-publishers-e2e',
+    'tests/object-dedup-e2e',
     'examples/cross-protocol-test/publisher',
     'examples/cross-protocol-test/quic-subscriber',
     'bindings/wasm',

--- a/examples/browser/examples/call/src/media/mediaPublisher.ts
+++ b/examples/browser/examples/call/src/media/mediaPublisher.ts
@@ -1437,6 +1437,10 @@ export class MediaPublisher {
     const aliases = Array.from(client.getTrackSubscribers(this.trackNamespace, CATALOG_TRACK_NAME), (value) =>
       BigInt(value)
     )
+    console.info('[call][catalog] broadcast', {
+      subscribers: aliases.length,
+      tracks: this.catalogTracks.map((t) => t.role)
+    })
     if (!aliases.length) {
       return
     }
@@ -1451,6 +1455,11 @@ export class MediaPublisher {
     const groupId = previousGroup + 1n
     this.catalogGroupByAlias.set(aliasKey, groupId)
 
+    console.info('[call][catalog] send object', {
+      alias: aliasKey,
+      groupId: groupId.toString(),
+      tracks: this.catalogTracks.map((t) => t.role)
+    })
     const payload = new TextEncoder().encode(buildCallCatalogJson(this.trackNamespace, this.catalogTracks))
     await client.sendSubgroupHeader(trackAlias, groupId, 0n, 0)
     await client.sendSubgroupObject(trackAlias, groupId, 0n, 0n, undefined, payload, undefined)

--- a/examples/browser/examples/call/src/session/localSession.ts
+++ b/examples/browser/examples/call/src/session/localSession.ts
@@ -252,9 +252,15 @@ export class LocalSession {
         reject(new Error('Catalog subscribe timed out'))
       }, timeoutMs)
 
-      const handleCatalogPayload = (payload: string) => {
+      const handleCatalogPayload = (payload: string, source: string, groupId?: bigint) => {
         try {
           const tracks = parseCallCatalogTracks(payload)
+          console.info('[call][catalog] apply', {
+            trackNamespace,
+            source,
+            groupId: groupId?.toString(),
+            tracks: tracks.map((t) => t.role)
+          })
           onTracksUpdated?.(tracks)
           if (settled) return
           settled = true
@@ -284,26 +290,20 @@ export class LocalSession {
           // The fetch id is issued internally by moqtClient; joiningRequestId is the
           // catalog subscribe's request id we just received.
           const contentExists = (subscribeOk as any).contentExists ?? (subscribeOk as any).content_exists
+          console.info('[call][catalog] subscribed', { trackNamespace, contentExists: Boolean(contentExists) })
           if (contentExists) {
-            console.info('[call][catalog] content exists; fetching via Joining Fetch', { trackNamespace })
             await this.client.relativeJoiningFetch(catalogRequestId, 0n, {
               onObject: (msg) => {
                 if (msg.objectPayload.length > 0) {
-                  console.info('[call][catalog] payload received via Joining Fetch')
-                  handleCatalogPayload(new TextDecoder().decode(new Uint8Array(msg.objectPayload)))
+                  handleCatalogPayload(new TextDecoder().decode(new Uint8Array(msg.objectPayload)), 'joining-fetch')
                 }
               }
             })
-          } else {
-            console.info('[call][catalog] no content yet; waiting for subscribe stream', { trackNamespace })
           }
 
           // Always set up stream handler for future catalog updates.
           this.client.setOnSubgroupObjectHandler(trackAlias, (groupId, subgroup) => {
-            console.info('[call][catalog] payload received via subscribe stream', {
-              groupId: groupId.toString()
-            })
-            handleCatalogPayload(new TextDecoder().decode(new Uint8Array(subgroup.objectPayload)))
+            handleCatalogPayload(new TextDecoder().decode(new Uint8Array(subgroup.objectPayload)), 'stream', groupId)
           })
         })
         .catch((error) => {

--- a/examples/browser/tests/call-e2e-arrange.ts
+++ b/examples/browser/tests/call-e2e-arrange.ts
@@ -34,7 +34,7 @@ const E2E_VIDEO_BITRATE = 100_000
 let callClientCounter = 0
 
 const FORWARDED_CONSOLE_TEXT_PATTERN =
-  /\[call\]\[publisher\]\[video\]|\[call\]\[subscriber\]\[video\]|\[call\]\[media-element\]\[video\]|\[videoDecoder\]|Failed|Error|Camera capture started|SUBSCRIBE|PUBLISH_NAMESPACE/
+  /\[call\]\[publisher\]\[video\]|\[call\]\[subscriber\]\[video\]|\[call\]\[media-element\]\[video\]|\[call\]\[catalog\]|\[videoDecoder\]|Failed|Error|Camera capture started|SUBSCRIBE|PUBLISH_NAMESPACE/
 
 async function openCallPage(page: Page): Promise<void> {
   const params = new URLSearchParams({

--- a/relay/src/modules/core/data_object.rs
+++ b/relay/src/modules/core/data_object.rs
@@ -13,4 +13,15 @@ impl DataObject {
             Self::ObjectDatagram(datagram) => Some(datagram.group_id),
         }
     }
+
+    /// Resolves the absolute object_id of this object within its ingest stream.
+    /// `prev_object_id` is the resolved object_id of the previous object on the same
+    /// stream (`None` at the start of a subgroup or right after its header).
+    pub(crate) fn resolve_absolute_object_id(&self, prev_object_id: Option<u64>) -> Option<u64> {
+        match self {
+            Self::SubgroupHeader(_) => None,
+            Self::SubgroupObject(field) => Some(field.resolve_object_id(prev_object_id)),
+            Self::ObjectDatagram(datagram) => datagram.field.object_id(),
+        }
+    }
 }

--- a/relay/src/modules/core/data_object.rs
+++ b/relay/src/modules/core/data_object.rs
@@ -21,7 +21,69 @@ impl DataObject {
         match self {
             Self::SubgroupHeader(_) => None,
             Self::SubgroupObject(field) => Some(field.resolve_object_id(prev_object_id)),
-            Self::ObjectDatagram(datagram) => datagram.field.object_id(),
+            // Datagram types 0x04-0x07 omit the object_id on the wire; it is implicit
+            // (previous + 1, or 0 for the first object in the group).
+            Self::ObjectDatagram(datagram) => Some(
+                datagram
+                    .field
+                    .object_id()
+                    .unwrap_or_else(|| prev_object_id.map_or(0, |prev| prev + 1)),
+            ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use moqt::{DatagramField, ObjectDatagram};
+
+    fn datagram_with_id(object_id: u64) -> DataObject {
+        DataObject::ObjectDatagram(ObjectDatagram::new(
+            0,
+            0,
+            DatagramField::Payload0x00 {
+                object_id,
+                publisher_priority: 0,
+                payload: Bytes::new(),
+            },
+        ))
+    }
+
+    fn datagram_without_id() -> DataObject {
+        // Type 0x06 omits the object_id on the wire (implicit id).
+        DataObject::ObjectDatagram(ObjectDatagram::new(
+            0,
+            0,
+            DatagramField::Payload0x06WithEndOfGroup {
+                publisher_priority: 0,
+                payload: Bytes::new(),
+            },
+        ))
+    }
+
+    #[test]
+    fn datagram_with_explicit_id_uses_that_id() {
+        // Arrange: a datagram carrying object_id 7 on the wire
+        let datagram = datagram_with_id(7);
+        // Act / Assert: the explicit id wins, ignoring prev
+        assert_eq!(datagram.resolve_absolute_object_id(Some(3)), Some(7));
+    }
+
+    #[test]
+    fn datagram_without_id_uses_prev_plus_one() {
+        // Arrange: a datagram with an implicit object_id, prev resolved to 3
+        let datagram = datagram_without_id();
+        // Act / Assert: implicit id is prev + 1
+        assert_eq!(datagram.resolve_absolute_object_id(Some(3)), Some(4));
+    }
+
+    #[test]
+    fn datagram_without_id_starts_at_zero() {
+        // Arrange: the first datagram in a group has no prev
+        let datagram = datagram_without_id();
+        // Act / Assert: implicit id starts at 0
+        assert_eq!(datagram.resolve_absolute_object_id(None), Some(0));
     }
 }

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -16,14 +16,6 @@ pub(crate) struct GroupCache {
     notify: Notify,
 }
 
-fn resolve_absolute_object_id(object: &DataObject, prev_object_id: Option<u64>) -> Option<u64> {
-    match object {
-        DataObject::SubgroupHeader(_) => None,
-        DataObject::SubgroupObject(field) => Some(field.resolve_object_id(prev_object_id)),
-        DataObject::ObjectDatagram(datagram) => datagram.field.object_id(),
-    }
-}
-
 impl GroupCache {
     pub(crate) fn new() -> Self {
         Self {
@@ -33,10 +25,8 @@ impl GroupCache {
         }
     }
 
-    pub(crate) async fn append(&self, object: Arc<DataObject>) -> u64 {
+    pub(crate) async fn append(&self, object_id: Option<u64>, object: Arc<DataObject>) -> u64 {
         let mut objects = self.objects.write().await;
-        let prev_object_id = objects.last().and_then(|o| o.object_id);
-        let object_id = resolve_absolute_object_id(&object, prev_object_id);
         objects.push(CachedObject {
             object_id,
             data: object,

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -1,17 +1,12 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use tokio::sync::{Notify, RwLock};
 
 use crate::modules::core::data_object::DataObject;
 
-#[derive(Clone)]
-pub(crate) struct CachedObject {
-    pub(crate) object_id: Option<u64>,
-    pub(crate) data: Arc<DataObject>,
-}
-
 pub(crate) struct GroupCache {
-    objects: RwLock<Vec<CachedObject>>,
+    header: RwLock<Option<Arc<DataObject>>>,
+    objects: RwLock<BTreeMap<u64, Arc<DataObject>>>,
     end_of_group: RwLock<bool>,
     notify: Notify,
 }
@@ -19,40 +14,76 @@ pub(crate) struct GroupCache {
 impl GroupCache {
     pub(crate) fn new() -> Self {
         Self {
-            objects: RwLock::new(Vec::new()),
+            header: RwLock::new(None),
+            objects: RwLock::new(BTreeMap::new()),
             end_of_group: RwLock::new(false),
             notify: Notify::new(),
         }
     }
 
-    pub(crate) async fn append(&self, object_id: Option<u64>, object: Arc<DataObject>) -> u64 {
-        let mut objects = self.objects.write().await;
-        objects.push(CachedObject {
-            object_id,
-            data: object,
-        });
-        let index = objects.len().saturating_sub(1) as u64;
-        drop(objects);
+    // FIXME: §8.1 also requires treating a duplicate whose payload/subgroup/priority
+    // differs (or an invalid status transition) as Malformed (MUST). Not implemented;
+    // we only ignore duplicates (first-wins).
+    pub(crate) async fn append(&self, object_id: Option<u64>, object: Arc<DataObject>) {
+        match object_id {
+            // No object_id = subgroup header. Keep the first one (first-wins).
+            None => {
+                let mut header = self.header.write().await;
+                if header.is_none() {
+                    *header = Some(object);
+                }
+            }
+            // A later object with the same object_id is ignored (draft-14 §8.1 dedup).
+            Some(object_id) => {
+                self.objects
+                    .write()
+                    .await
+                    .entry(object_id)
+                    .or_insert(object);
+            }
+        }
         self.notify.notify_waiters();
-        index
     }
 
-    pub(crate) async fn get(&self, index: u64) -> Option<Arc<DataObject>> {
-        let objects = self.objects.read().await;
-        objects.get(index as usize).map(|o| o.data.clone())
+    pub(crate) async fn header(&self) -> Option<Arc<DataObject>> {
+        self.header.read().await.clone()
     }
 
-    pub(crate) async fn last_object_id(&self) -> Option<u64> {
-        self.objects.read().await.last().and_then(|o| o.object_id)
+    pub(crate) async fn largest_object_id(&self) -> Option<u64> {
+        self.objects
+            .read()
+            .await
+            .last_key_value()
+            .map(|(&id, _)| id)
     }
 
-    /// Waits until the object at `index` is available, or returns `None` if the group is closed.
-    pub(crate) async fn get_or_wait(&self, index: u64) -> Option<Arc<DataObject>> {
+    /// Waits until the subgroup header is available, or returns `None` if the group is
+    /// closed before it arrives.
+    pub(crate) async fn header_or_wait(&self) -> Option<Arc<DataObject>> {
         loop {
-            // Create notified() before get() to avoid a race between the check and the wait.
+            // Create notified() before the check to avoid a race between it and the wait.
             let notified = self.notify.notified();
-            if let Some(obj) = self.get(index).await {
-                return Some(obj);
+            if let Some(header) = self.header().await {
+                return Some(header);
+            }
+            if self.is_closed().await {
+                return None;
+            }
+            notified.await;
+        }
+    }
+
+    /// Returns the first object whose id is `>= object_id` (inclusive), waiting if none is
+    /// available yet. Returns `None` once the group is closed and no such object exists.
+    pub(crate) async fn object_from_or_wait(
+        &self,
+        object_id: u64,
+    ) -> Option<(u64, Arc<DataObject>)> {
+        loop {
+            // Create notified() before the check to avoid a race between it and the wait.
+            let notified = self.notify.notified();
+            if let Some((&id, object)) = self.objects.read().await.range(object_id..).next() {
+                return Some((id, object.clone()));
             }
             if self.is_closed().await {
                 return None;
@@ -72,7 +103,124 @@ impl GroupCache {
         *self.end_of_group.read().await
     }
 
-    pub(crate) async fn snapshot(&self) -> Vec<CachedObject> {
-        self.objects.read().await.clone()
+    /// Returns all cached objects in object_id order. The subgroup header is not included.
+    pub(crate) async fn objects_snapshot(&self) -> Vec<(u64, Arc<DataObject>)> {
+        self.objects
+            .read()
+            .await
+            .iter()
+            .map(|(&id, object)| (id, object.clone()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use moqt::{ExtensionHeaders, SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField};
+
+    fn payload_object(payload: &[u8]) -> Arc<DataObject> {
+        let message_type =
+            SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false).message_type;
+        Arc::new(DataObject::SubgroupObject(SubgroupObjectField {
+            message_type,
+            object_id_delta: 0,
+            extension_headers: ExtensionHeaders {
+                prior_group_id_gap: vec![],
+                prior_object_id_gap: vec![],
+                immutable_extensions: vec![],
+            },
+            subgroup_object: SubgroupObject::new_payload(Bytes::from(payload.to_vec())),
+        }))
+    }
+
+    fn payload_of(object: &DataObject) -> Bytes {
+        match object {
+            DataObject::SubgroupObject(f) => match &f.subgroup_object {
+                SubgroupObject::Payload { data, .. } => data.clone(),
+                _ => panic!("expected payload"),
+            },
+            _ => panic!("expected SubgroupObject"),
+        }
+    }
+
+    fn header_object(publisher_priority: u8) -> Arc<DataObject> {
+        Arc::new(DataObject::SubgroupHeader(SubgroupHeader::new(
+            0,
+            0,
+            SubgroupId::Value(0),
+            publisher_priority,
+            false,
+            false,
+        )))
+    }
+
+    #[tokio::test]
+    async fn append_same_object_id_keeps_first() {
+        // Arrange: two objects with the same object_id but distinct payloads
+        let cache = GroupCache::new();
+        cache.append(Some(0), payload_object(b"first")).await;
+        cache.append(Some(0), payload_object(b"second")).await;
+        // Act
+        let snapshot = cache.objects_snapshot().await;
+        // Assert: only the first object survives (first-wins dedup)
+        assert_eq!(snapshot.len(), 1);
+        let (id, object) = &snapshot[0];
+        assert_eq!(*id, 0);
+        assert_eq!(payload_of(object), Bytes::from_static(b"first"));
+    }
+
+    #[tokio::test]
+    async fn append_header_twice_keeps_first() {
+        // Arrange: two subgroup headers distinguished by publisher_priority
+        let cache = GroupCache::new();
+        cache.append(None, header_object(1)).await;
+        cache.append(None, header_object(2)).await;
+        // Act
+        let header = cache.header().await.unwrap();
+        // Assert: the first header survives (first-wins)
+        match header.as_ref() {
+            DataObject::SubgroupHeader(h) => assert_eq!(h.publisher_priority, 1),
+            _ => panic!("expected SubgroupHeader"),
+        }
+    }
+
+    #[tokio::test]
+    async fn object_from_or_wait_returns_exact_match() {
+        // Arrange: objects at ids 0, 3, 5
+        let cache = GroupCache::new();
+        cache.append(Some(0), payload_object(b"o0")).await;
+        cache.append(Some(3), payload_object(b"o3")).await;
+        cache.append(Some(5), payload_object(b"o5")).await;
+        // Act: ask for exactly id 3
+        let (id, _) = cache.object_from_or_wait(3).await.unwrap();
+        // Assert: the exact id is returned (inclusive lower bound)
+        assert_eq!(id, 3);
+    }
+
+    #[tokio::test]
+    async fn object_from_or_wait_skips_gap_to_next_id() {
+        // Arrange: objects at ids 0, 3, 5 (no object at 1, 2, 4)
+        let cache = GroupCache::new();
+        cache.append(Some(0), payload_object(b"o0")).await;
+        cache.append(Some(3), payload_object(b"o3")).await;
+        cache.append(Some(5), payload_object(b"o5")).await;
+        // Act: ask for id 4, which has no object
+        let (id, _) = cache.object_from_or_wait(4).await.unwrap();
+        // Assert: the next available id (5) is returned across the gap
+        assert_eq!(id, 5);
+    }
+
+    #[tokio::test]
+    async fn object_from_or_wait_returns_none_when_closed() {
+        // Arrange: one object at id 0, then the group is closed
+        let cache = GroupCache::new();
+        cache.append(Some(0), payload_object(b"o0")).await;
+        cache.mark_end_of_group().await;
+        // Act: ask for id 1, beyond the last object, on a closed group
+        let result = cache.object_from_or_wait(1).await;
+        // Assert: no object exists and the group is closed, so None
+        assert!(result.is_none());
     }
 }

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -66,11 +66,12 @@ impl TrackCache {
         &self,
         group_id: u64,
         subgroup_id: &StreamSubgroupId,
+        object_id: Option<u64>,
         object: DataObject,
     ) -> u64 {
         let group = self.ensure_stream_subgroup(group_id, subgroup_id).await;
         let object = Arc::new(object);
-        let index = group.append(object).await;
+        let index = group.append(object_id, object).await;
         *self.latest.write().await = Some(CacheLocation::Stream {
             group_id,
             subgroup_id: subgroup_id.clone(),
@@ -79,10 +80,15 @@ impl TrackCache {
         index
     }
 
-    pub(crate) async fn append_datagram_object(&self, group_id: u64, object: DataObject) -> u64 {
+    pub(crate) async fn append_datagram_object(
+        &self,
+        group_id: u64,
+        object_id: Option<u64>,
+        object: DataObject,
+    ) -> u64 {
         let group = self.ensure_datagram_group(group_id).await;
         let object = Arc::new(object);
-        let index = group.append(object).await;
+        let index = group.append(object_id, object).await;
         *self.latest.write().await = Some(CacheLocation::Datagram { group_id, index });
         index
     }
@@ -282,6 +288,22 @@ mod tests {
         })
     }
 
+    // Resolves the object_id the way the ingest stream reader does (per-stream prev),
+    // then appends. A SubgroupHeader resolves to None and resets the chain.
+    async fn append_stream(
+        cache: &TrackCache,
+        group_id: u64,
+        subgroup: &StreamSubgroupId,
+        prev_object_id: &mut Option<u64>,
+        object: DataObject,
+    ) {
+        let object_id = object.resolve_absolute_object_id(*prev_object_id);
+        *prev_object_id = object_id;
+        cache
+            .append_stream_object(group_id, subgroup, object_id, object)
+            .await;
+    }
+
     #[tokio::test]
     async fn largest_location_returns_none_when_empty() {
         // Arrange: empty cache
@@ -295,9 +317,8 @@ mod tests {
         // Arrange: append a SubgroupHeader only, no SubgroupObject
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
-            .append_stream_object(0, &subgroup, make_header(0))
-            .await;
+        let mut prev = None;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
         // Act / Assert: a header is not an object, so None is returned
         assert!(cache.largest_location().await.is_none());
     }
@@ -307,12 +328,9 @@ mod tests {
         // Arrange: one SubgroupObject with delta=0 in group_id=0
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
-            .append_stream_object(0, &subgroup, make_header(0))
-            .await;
-        cache
-            .append_stream_object(0, &subgroup, make_object(0))
-            .await;
+        let mut prev = None;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await;
         // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: object_id resolves to 0 (delta=0, no previous)
@@ -325,18 +343,11 @@ mod tests {
         // Arrange: three objects with delta=0, yielding object_ids 0, 1, 2
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
-            .append_stream_object(0, &subgroup, make_header(0))
-            .await;
-        cache
-            .append_stream_object(0, &subgroup, make_object(0))
-            .await; // object_id = 0
-        cache
-            .append_stream_object(0, &subgroup, make_object(0))
-            .await; // object_id = 1
-        cache
-            .append_stream_object(0, &subgroup, make_object(0))
-            .await; // object_id = 2
+        let mut prev = None;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await; // object_id = 0
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await; // object_id = 1
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await; // object_id = 2
         // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: largest object_id in the delta chain is returned
@@ -349,15 +360,10 @@ mod tests {
         // Arrange: first object has delta=5 (object_id=5), second has delta=2 (object_id=8)
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
-            .append_stream_object(0, &subgroup, make_header(0))
-            .await;
-        cache
-            .append_stream_object(0, &subgroup, make_object(5))
-            .await; // object_id = 5
-        cache
-            .append_stream_object(0, &subgroup, make_object(2))
-            .await; // object_id = 5+1+2 = 8
+        let mut prev = None;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(5)).await; // object_id = 5
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(2)).await; // object_id = 5+1+2 = 8
         // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: delta gaps are resolved correctly
@@ -370,18 +376,11 @@ mod tests {
         // Arrange: objects in group 0 and group 1
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
-            .append_stream_object(0, &subgroup, make_header(0))
-            .await;
-        cache
-            .append_stream_object(0, &subgroup, make_object(0))
-            .await; // group=0, object_id=0
-        cache
-            .append_stream_object(1, &subgroup, make_header(1))
-            .await;
-        cache
-            .append_stream_object(1, &subgroup, make_object(0))
-            .await; // group=1, object_id=0
+        let mut prev = None;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await; // group=0, object_id=0
+        append_stream(&cache, 1, &subgroup, &mut prev, make_header(1)).await;
+        append_stream(&cache, 1, &subgroup, &mut prev, make_object(0)).await; // group=1, object_id=0
         // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: the latest group's location is returned
@@ -391,14 +390,11 @@ mod tests {
 
     async fn fill_group(cache: &TrackCache, group_id: u64, count: u64) {
         let subgroup = StreamSubgroupId::Value(0);
-        cache
-            .append_stream_object(group_id, &subgroup, make_header(group_id))
-            .await;
+        let mut prev = None;
+        append_stream(cache, group_id, &subgroup, &mut prev, make_header(group_id)).await;
         // count objects with delta=0 -> object_ids 0, 1, ..., count-1
         for _ in 0..count {
-            cache
-                .append_stream_object(group_id, &subgroup, make_object(0))
-                .await;
+            append_stream(cache, group_id, &subgroup, &mut prev, make_object(0)).await;
         }
     }
 

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -4,16 +4,12 @@ use tokio::sync::RwLock;
 
 use crate::modules::{
     core::data_object::DataObject,
-    relay::{
-        cache::group_cache::GroupCache,
-        types::{CacheLocation, StreamSubgroupId},
-    },
+    relay::{cache::group_cache::GroupCache, types::StreamSubgroupId},
 };
 
 pub(crate) struct TrackCache {
     stream_groups: RwLock<BTreeMap<u64, BTreeMap<StreamSubgroupId, Arc<GroupCache>>>>,
     datagram_groups: RwLock<BTreeMap<u64, Arc<GroupCache>>>,
-    latest: RwLock<Option<CacheLocation>>,
 }
 
 impl TrackCache {
@@ -21,7 +17,6 @@ impl TrackCache {
         Self {
             stream_groups: RwLock::new(BTreeMap::new()),
             datagram_groups: RwLock::new(BTreeMap::new()),
-            latest: RwLock::new(None),
         }
     }
 
@@ -68,16 +63,9 @@ impl TrackCache {
         subgroup_id: &StreamSubgroupId,
         object_id: Option<u64>,
         object: DataObject,
-    ) -> u64 {
+    ) {
         let group = self.ensure_stream_subgroup(group_id, subgroup_id).await;
-        let object = Arc::new(object);
-        let index = group.append(object_id, object).await;
-        *self.latest.write().await = Some(CacheLocation::Stream {
-            group_id,
-            subgroup_id: subgroup_id.clone(),
-            index,
-        });
-        index
+        group.append(object_id, Arc::new(object)).await;
     }
 
     pub(crate) async fn append_datagram_object(
@@ -85,12 +73,14 @@ impl TrackCache {
         group_id: u64,
         object_id: Option<u64>,
         object: DataObject,
-    ) -> u64 {
+    ) {
+        // Datagrams have no subgroup header, so a resolved object_id is always expected.
+        let Some(object_id) = object_id else {
+            tracing::error!(group_id, "unexpected: datagram object without object_id");
+            return;
+        };
         let group = self.ensure_datagram_group(group_id).await;
-        let object = Arc::new(object);
-        let index = group.append(object_id, object).await;
-        *self.latest.write().await = Some(CacheLocation::Datagram { group_id, index });
-        index
+        group.append(Some(object_id), Arc::new(object)).await;
     }
 
     pub(crate) async fn close_stream_subgroup(
@@ -118,15 +108,14 @@ impl TrackCache {
 
         Some(moqt::Location {
             group_id,
-            object_id: cache.last_object_id().await?,
+            object_id: cache.largest_object_id().await?,
         })
     }
 
-    pub(crate) async fn get_stream_object_or_wait(
+    pub(crate) async fn get_stream_header_or_wait(
         &self,
         group_id: u64,
         subgroup_id: &StreamSubgroupId,
-        index: u64,
     ) -> Option<Arc<DataObject>> {
         let group = self
             .stream_groups
@@ -135,16 +124,32 @@ impl TrackCache {
             .get(&group_id)
             .and_then(|subgroups| subgroups.get(subgroup_id))
             .cloned()?;
-        group.get_or_wait(index).await
+        group.header_or_wait().await
     }
 
-    pub(crate) async fn get_datagram_object_or_wait(
+    pub(crate) async fn stream_object_from_or_wait(
         &self,
         group_id: u64,
-        index: u64,
-    ) -> Option<Arc<DataObject>> {
+        subgroup_id: &StreamSubgroupId,
+        object_id: u64,
+    ) -> Option<(u64, Arc<DataObject>)> {
+        let group = self
+            .stream_groups
+            .read()
+            .await
+            .get(&group_id)
+            .and_then(|subgroups| subgroups.get(subgroup_id))
+            .cloned()?;
+        group.object_from_or_wait(object_id).await
+    }
+
+    pub(crate) async fn datagram_object_from_or_wait(
+        &self,
+        group_id: u64,
+        object_id: u64,
+    ) -> Option<(u64, Arc<DataObject>)> {
         let group = self.datagram_groups.read().await.get(&group_id).cloned()?;
-        group.get_or_wait(index).await
+        group.object_from_or_wait(object_id).await
     }
 
     pub(crate) async fn has_stream_group(&self, group_id: u64) -> bool {
@@ -193,28 +198,22 @@ impl TrackCache {
         //   group=2: include object_id 0,1,2,3,4 -> stop before 5 (exclusive)
         let mut fetch_objects = Vec::new();
         for (group_id, cache) in caches_in_range {
-            let subgroup_objects = cache.snapshot().await;
-
-            let Some(header) = subgroup_objects.first() else {
-                tracing::error!("unexpected: GroupCache is empty");
+            let Some(header) = cache.header().await else {
+                tracing::error!("unexpected: GroupCache has no subgroup header");
                 continue;
             };
-            let (publisher_priority, subgroup_id) = match header.data.as_ref() {
+            let (publisher_priority, subgroup_id) = match header.as_ref() {
                 DataObject::SubgroupHeader(h) => (h.publisher_priority, h.subgroup_id.resolve()),
                 _ => {
-                    tracing::error!("unexpected: GroupCache does not start with SubgroupHeader");
+                    tracing::error!("unexpected: GroupCache header is not a SubgroupHeader");
                     continue;
                 }
             };
 
-            // skip index=0 which is SubgroupHeader
-            for cached in subgroup_objects.iter().skip(1) {
-                let field = match cached.data.as_ref() {
+            for (current_object_id, object) in cache.objects_snapshot().await {
+                let field = match object.as_ref() {
                     DataObject::SubgroupObject(f) => f,
                     _ => continue,
-                };
-                let Some(current_object_id) = cached.object_id else {
-                    continue;
                 };
 
                 // Apply range filter for first and last groups
@@ -288,22 +287,6 @@ mod tests {
         })
     }
 
-    // Resolves the object_id the way the ingest stream reader does (per-stream prev),
-    // then appends. A SubgroupHeader resolves to None and resets the chain.
-    async fn append_stream(
-        cache: &TrackCache,
-        group_id: u64,
-        subgroup: &StreamSubgroupId,
-        prev_object_id: &mut Option<u64>,
-        object: DataObject,
-    ) {
-        let object_id = object.resolve_absolute_object_id(*prev_object_id);
-        *prev_object_id = object_id;
-        cache
-            .append_stream_object(group_id, subgroup, object_id, object)
-            .await;
-    }
-
     #[tokio::test]
     async fn largest_location_returns_none_when_empty() {
         // Arrange: empty cache
@@ -317,70 +300,55 @@ mod tests {
         // Arrange: append a SubgroupHeader only, no SubgroupObject
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        let mut prev = None;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
+        cache
+            .append_stream_object(0, &subgroup, None, make_header(0))
+            .await;
         // Act / Assert: a header is not an object, so None is returned
         assert!(cache.largest_location().await.is_none());
     }
 
     #[tokio::test]
     async fn largest_location_returns_single_object() {
-        // Arrange: one SubgroupObject with delta=0 in group_id=0
+        // Arrange: one object at id 0 in group 0
         let cache = TrackCache::new();
-        let subgroup = StreamSubgroupId::Value(0);
-        let mut prev = None;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await;
+        fill_group_with_ids(&cache, 0, &[0]).await;
         // Act
         let loc = cache.largest_location().await.unwrap();
-        // Assert: object_id resolves to 0 (delta=0, no previous)
+        // Assert: the only object's location is returned
         assert_eq!(loc.group_id, 0);
         assert_eq!(loc.object_id, 0);
     }
 
     #[tokio::test]
-    async fn largest_location_resolves_sequential_delta_chain() {
-        // Arrange: three objects with delta=0, yielding object_ids 0, 1, 2
+    async fn largest_location_returns_max_object_id() {
+        // Arrange: sequential object_ids 0, 1, 2 in group 0
         let cache = TrackCache::new();
-        let subgroup = StreamSubgroupId::Value(0);
-        let mut prev = None;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await; // object_id = 0
-        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await; // object_id = 1
-        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await; // object_id = 2
+        fill_group_with_ids(&cache, 0, &[0, 1, 2]).await;
         // Act
         let loc = cache.largest_location().await.unwrap();
-        // Assert: largest object_id in the delta chain is returned
+        // Assert: the largest object_id is returned
         assert_eq!(loc.group_id, 0);
         assert_eq!(loc.object_id, 2);
     }
 
     #[tokio::test]
-    async fn largest_location_resolves_delta_with_gap() {
-        // Arrange: first object has delta=5 (object_id=5), second has delta=2 (object_id=8)
+    async fn largest_location_returns_max_id_across_gap() {
+        // Arrange: gapped object_ids 5, 8 in group 0
         let cache = TrackCache::new();
-        let subgroup = StreamSubgroupId::Value(0);
-        let mut prev = None;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_object(5)).await; // object_id = 5
-        append_stream(&cache, 0, &subgroup, &mut prev, make_object(2)).await; // object_id = 5+1+2 = 8
+        fill_group_with_ids(&cache, 0, &[5, 8]).await;
         // Act
         let loc = cache.largest_location().await.unwrap();
-        // Assert: delta gaps are resolved correctly
+        // Assert: the largest object_id is returned even with a gap
         assert_eq!(loc.group_id, 0);
         assert_eq!(loc.object_id, 8);
     }
 
     #[tokio::test]
     async fn largest_location_returns_latest_group() {
-        // Arrange: objects in group 0 and group 1
+        // Arrange: one object at id 0 in each of group 0 and group 1
         let cache = TrackCache::new();
-        let subgroup = StreamSubgroupId::Value(0);
-        let mut prev = None;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_header(0)).await;
-        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await; // group=0, object_id=0
-        append_stream(&cache, 1, &subgroup, &mut prev, make_header(1)).await;
-        append_stream(&cache, 1, &subgroup, &mut prev, make_object(0)).await; // group=1, object_id=0
+        fill_group_with_ids(&cache, 0, &[0]).await;
+        fill_group_with_ids(&cache, 1, &[0]).await;
         // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: the latest group's location is returned
@@ -389,12 +357,21 @@ mod tests {
     }
 
     async fn fill_group(cache: &TrackCache, group_id: u64, count: u64) {
+        // object_ids 0, 1, ..., count-1
+        let object_ids: Vec<u64> = (0..count).collect();
+        fill_group_with_ids(cache, group_id, &object_ids).await;
+    }
+
+    // Fills a group with objects at the given (non-sequential) absolute object_ids.
+    async fn fill_group_with_ids(cache: &TrackCache, group_id: u64, object_ids: &[u64]) {
         let subgroup = StreamSubgroupId::Value(0);
-        let mut prev = None;
-        append_stream(cache, group_id, &subgroup, &mut prev, make_header(group_id)).await;
-        // count objects with delta=0 -> object_ids 0, 1, ..., count-1
-        for _ in 0..count {
-            append_stream(cache, group_id, &subgroup, &mut prev, make_object(0)).await;
+        cache
+            .append_stream_object(group_id, &subgroup, None, make_header(group_id))
+            .await;
+        for &id in object_ids {
+            cache
+                .append_stream_object(group_id, &subgroup, Some(id), make_object(0))
+                .await;
         }
     }
 
@@ -447,6 +424,28 @@ mod tests {
             object_ids(&objects),
             vec![(0, 0), (0, 1), (0, 2), (0, 3), (0, 4)]
         );
+    }
+
+    #[tokio::test]
+    async fn get_fetch_objects_filters_range_with_gaps() {
+        // Arrange: group 0 with gapped object_ids 0, 3, 5, 8
+        let cache = TrackCache::new();
+        fill_group_with_ids(&cache, 0, &[0, 3, 5, 8]).await;
+        // Act: fetch [{0,3}, {0,8}) -> start 3 inclusive, end 8 exclusive
+        let objects = cache
+            .get_fetch_objects(
+                moqt::Location {
+                    group_id: 0,
+                    object_id: 3,
+                },
+                moqt::Location {
+                    group_id: 0,
+                    object_id: 8,
+                },
+            )
+            .await;
+        // Assert: 0 skipped (< start), 8 excluded (>= end); 3 and 5 survive across the gaps
+        assert_eq!(object_ids(&objects), vec![(0, 3), (0, 5)]);
     }
 
     #[tokio::test]

--- a/relay/src/modules/relay/egress/group_sender.rs
+++ b/relay/src/modules/relay/egress/group_sender.rs
@@ -15,13 +15,6 @@ use crate::modules::{
 
 use super::scheduler::GroupSendTask;
 
-// FIXME: assumes gapless object_ids (cache position == object_id + 1, +1 for the
-// subgroup header). With object_id gaps, non-zero starts (LargestObject/
-// AbsoluteStart) resolve to the wrong cache position.
-fn stream_object_id_to_cache_index(object_id: u64) -> u64 {
-    object_id + 1
-}
-
 /// Receives `GroupSendTask` entries and spawns per-group send tasks.
 pub(crate) struct GroupSender {
     track_key: TrackKey,
@@ -139,7 +132,7 @@ impl GroupSender {
         let span = Span::current();
         let mut object_count = 0u64;
         let Some(header) = cache
-            .get_stream_object_or_wait(group_id, &subgroup_id, 0)
+            .get_stream_header_or_wait(group_id, &subgroup_id)
             .await
         else {
             span.record("object_count", object_count);
@@ -174,24 +167,17 @@ impl GroupSender {
             return;
         }
 
-        let mut next_index = stream_object_id_to_cache_index(object_id);
-        while let Some(object) = cache
-            .get_stream_object_or_wait(group_id, &subgroup_id, next_index)
+        let mut cursor = object_id;
+        while let Some((id, object)) = cache
+            .stream_object_from_or_wait(group_id, &subgroup_id, cursor)
             .await
         {
-            let object_id_delta = match &*object {
-                crate::modules::core::data_object::DataObject::SubgroupObject(field) => {
-                    Some(field.object_id_delta)
-                }
-                _ => None,
-            };
             tracing::debug!(
                 track_key = %track_key,
                 track_alias,
                 group_id,
                 subgroup_id = ?subgroup_id,
-                object_id_delta,
-                cache_index = next_index,
+                object_id = id,
                 "egress sending subgroup object"
             );
             if sender.send_object((*object).clone()).await.is_err() {
@@ -202,13 +188,13 @@ impl GroupSender {
                     track_alias,
                     group_id,
                     subgroup_id = ?subgroup_id,
-                    object_index = next_index,
+                    object_id = id,
                     "failed to send subgroup object"
                 );
                 return;
             }
             object_count += 1;
-            next_index += 1;
+            cursor = id + 1;
         }
         span.record("object_count", object_count);
         span.record("end_reason", "cache_closed");
@@ -231,30 +217,18 @@ impl GroupSender {
         cache: Arc<TrackCache>,
         mut sender: Box<dyn DataSender>,
     ) {
-        // FIXME: assumes gapless object_ids (cache position == object_id). With object_id
-        // gaps, non-zero starts resolve to the wrong cache position.
-        let mut next_index = object_id;
-        while let Some(object) = cache
-            .get_datagram_object_or_wait(group_id, next_index)
-            .await
-        {
-            let datagram_object_id = match &*object {
-                crate::modules::core::data_object::DataObject::ObjectDatagram(datagram) => {
-                    datagram.field.object_id()
-                }
-                _ => None,
-            };
+        let mut cursor = object_id;
+        while let Some((id, object)) = cache.datagram_object_from_or_wait(group_id, cursor).await {
             tracing::debug!(
                 track_alias,
                 group_id,
-                object_id = datagram_object_id,
-                cache_index = next_index,
+                object_id = id,
                 "egress sending datagram object"
             );
             if sender.send_object((*object).clone()).await.is_err() {
                 return;
             }
-            next_index += 1;
+            cursor = id + 1;
         }
     }
 }

--- a/relay/src/modules/relay/egress/scheduler.rs
+++ b/relay/src/modules/relay/egress/scheduler.rs
@@ -334,6 +334,22 @@ mod tests {
         })
     }
 
+    // Resolves the object_id the way the ingest stream reader does (per-stream prev),
+    // then appends. A SubgroupHeader resolves to None and resets the chain.
+    async fn append_stream(
+        cache: &TrackCache,
+        group_id: u64,
+        subgroup: &StreamSubgroupId,
+        prev_object_id: &mut Option<u64>,
+        object: DataObject,
+    ) {
+        let object_id = object.resolve_absolute_object_id(*prev_object_id);
+        *prev_object_id = object_id;
+        cache
+            .append_stream_object(group_id, subgroup, object_id, object)
+            .await;
+    }
+
     // Largest Object (0x2) filter must start delivery just after the Largest
     // Object (§9.7: Start = {Largest.Group, Largest.Object + 1}), not include it.
     #[tokio::test]
@@ -341,12 +357,9 @@ mod tests {
         let cache = Arc::new(TrackCache::new());
         let subgroup = StreamSubgroupId::Value(0);
         // index 0: subgroup header, index 1: the Largest Object
-        cache
-            .append_stream_object(0, &subgroup, make_header())
-            .await;
-        cache
-            .append_stream_object(0, &subgroup, make_object(0))
-            .await;
+        let mut prev = None;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_header()).await;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await;
 
         let (info_tx, _info_rx) = broadcast::channel(16);
         let (task_tx, mut task_rx) = mpsc::channel(16);
@@ -392,12 +405,9 @@ mod tests {
         let cache = Arc::new(TrackCache::new());
         let subgroup = StreamSubgroupId::Value(0);
         for group_id in 0..3 {
-            cache
-                .append_stream_object(group_id, &subgroup, make_header())
-                .await;
-            cache
-                .append_stream_object(group_id, &subgroup, make_object(0))
-                .await;
+            let mut prev = None;
+            append_stream(&cache, group_id, &subgroup, &mut prev, make_header()).await;
+            append_stream(&cache, group_id, &subgroup, &mut prev, make_object(0)).await;
         }
 
         let (info_tx, _info_rx) = broadcast::channel(16);
@@ -492,12 +502,9 @@ mod tests {
     async fn new_upstream_largest_object_without_content_starts_from_first_object() {
         let cache = Arc::new(TrackCache::new());
         let subgroup = StreamSubgroupId::Value(0);
-        cache
-            .append_stream_object(0, &subgroup, make_header())
-            .await;
-        cache
-            .append_stream_object(0, &subgroup, make_object(0))
-            .await;
+        let mut prev = None;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_header()).await;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await;
 
         let (info_tx, _info_rx) = broadcast::channel(16);
         let (task_tx, mut task_rx) = mpsc::channel(16);
@@ -532,15 +539,10 @@ mod tests {
     async fn new_upstream_largest_object_with_content_starts_after_subscribe_ok_location() {
         let cache = Arc::new(TrackCache::new());
         let subgroup = StreamSubgroupId::Value(0);
-        cache
-            .append_stream_object(0, &subgroup, make_header())
-            .await;
-        cache
-            .append_stream_object(0, &subgroup, make_object(0))
-            .await;
-        cache
-            .append_stream_object(0, &subgroup, make_object(1))
-            .await;
+        let mut prev = None;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_header()).await;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(0)).await;
+        append_stream(&cache, 0, &subgroup, &mut prev, make_object(1)).await;
 
         let (info_tx, _info_rx) = broadcast::channel(16);
         let (task_tx, mut task_rx) = mpsc::channel(16);

--- a/relay/src/modules/relay/ingress/datagram_reader.rs
+++ b/relay/src/modules/relay/ingress/datagram_reader.rs
@@ -134,7 +134,10 @@ impl DatagramReader {
                         current_group_id = Some(group_id);
                         let _ = notify.send(TrackEvent::DatagramOpened { group_id });
                     }
-                    cache.append_datagram_object(group_id, object).await;
+                    let object_id = object.resolve_absolute_object_id(None);
+                    cache
+                        .append_datagram_object(group_id, object_id, object)
+                        .await;
                 }
                 Err(_) => {
                     // Ensure the last group is closed before exiting.

--- a/relay/src/modules/relay/ingress/datagram_reader.rs
+++ b/relay/src/modules/relay/ingress/datagram_reader.rs
@@ -110,6 +110,7 @@ impl DatagramReader {
         object_notify_producer_map: Arc<ObjectNotifyProducerMap>,
     ) {
         let mut current_group_id: Option<u64> = None;
+        let mut prev_object_id: Option<u64> = None;
         let cache = cache_store.get_or_create(&track_key);
         let notify = object_notify_producer_map.get_or_create(&track_key);
         loop {
@@ -132,9 +133,11 @@ impl DatagramReader {
                             cache.close_datagram_group(old_group).await;
                         }
                         current_group_id = Some(group_id);
+                        prev_object_id = None;
                         let _ = notify.send(TrackEvent::DatagramOpened { group_id });
                     }
-                    let object_id = object.resolve_absolute_object_id(None);
+                    let object_id = object.resolve_absolute_object_id(prev_object_id);
+                    prev_object_id = object_id;
                     cache
                         .append_datagram_object(group_id, object_id, object)
                         .await;

--- a/relay/src/modules/relay/ingress/stream_reader.rs
+++ b/relay/src/modules/relay/ingress/stream_reader.rs
@@ -78,6 +78,7 @@ impl StreamReader {
         let mut group_id = 0u64;
         let mut subgroup_id = StreamSubgroupId::None;
         let mut has_subgroup = false;
+        let mut prev_object_id: Option<u64> = None;
         let cache = cache_store.get_or_create(&track_key);
         let notify = object_notify_producer_map.get_or_create(&track_key);
         loop {
@@ -99,12 +100,14 @@ impl StreamReader {
                     group_id = header.group_id;
                     subgroup_id = StreamSubgroupId::from(&header.subgroup_id);
                     has_subgroup = true;
+                    prev_object_id = None;
                     span.record("group_id", group_id);
                     span.record("subgroup_id", tracing::field::debug(&subgroup_id));
                     cache
                         .append_stream_object(
                             group_id,
                             &subgroup_id,
+                            None,
                             DataObject::SubgroupHeader(header),
                         )
                         .await;
@@ -130,8 +133,10 @@ impl StreamReader {
                         },
                         _ => None,
                     };
+                    let object_id = object.resolve_absolute_object_id(prev_object_id);
+                    prev_object_id = object_id;
                     cache
-                        .append_stream_object(group_id, &subgroup_id, object)
+                        .append_stream_object(group_id, &subgroup_id, object_id, object)
                         .await;
                     if let Some(end_reason) = end_reason {
                         span.record("end_reason", end_reason);

--- a/relay/src/modules/relay/types.rs
+++ b/relay/src/modules/relay/types.rs
@@ -14,16 +14,3 @@ impl From<&moqt::SubgroupId> for StreamSubgroupId {
         }
     }
 }
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum CacheLocation {
-    Stream {
-        group_id: u64,
-        subgroup_id: StreamSubgroupId,
-        index: u64,
-    },
-    Datagram {
-        group_id: u64,
-        index: u64,
-    },
-}

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -30,6 +30,45 @@ enum LargestObjectSource {
     SubscribeOk(Option<moqt::Location>),
 }
 
+/// Return the location with the greater `(group_id, object_id)`, treating
+/// `None` as "no content" (i.e. smaller than any location).
+fn max_location(a: Option<moqt::Location>, b: Option<moqt::Location>) -> Option<moqt::Location> {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            if (a.group_id, a.object_id) >= (b.group_id, b.object_id) {
+                Some(a)
+            } else {
+                Some(b)
+            }
+        }
+        (some, None) | (None, some) => some,
+    }
+}
+
+/// Resolve the subscribe-time Largest Object for a downstream subscription,
+/// from the upstream SUBSCRIBE_OK and/or the local cache for this track.
+///
+/// The cache is always consulted, even for a freshly created upstream: a
+/// publisher that left and rejoined under the same track leaves its prior
+/// objects cached, and ignoring them (when the new upstream reports no content)
+/// makes the relay advertise contentExists=false and replay the stale cache
+/// from {0,0}. Taking the max also covers a publisher that already had content
+/// at SUBSCRIBE_OK time before the cache caught up.
+async fn resolve_subscribe_largest(
+    largest_source: &LargestObjectSource,
+    track_key: &TrackKey,
+    cache_store: &TrackCacheStore,
+) -> Option<moqt::Location> {
+    let cached = match cache_store.get(track_key) {
+        Some(cache) => cache.largest_location().await,
+        None => None,
+    };
+    match largest_source {
+        LargestObjectSource::LocalCache => cached,
+        LargestObjectSource::SubscribeOk(location) => max_location(*location, cached),
+    }
+}
+
 enum UpstreamSubscriptionError {
     PublisherNotFound,
     SubscribeFailed,
@@ -371,13 +410,9 @@ impl Subscribe {
 
         // Determined here so the Largest Location advertised in SUBSCRIBE_OK
         // and the egress delivery start agree.
-        let largest_location = match &largest_source {
-            LargestObjectSource::SubscribeOk(location) => *location,
-            LargestObjectSource::LocalCache => match cache_store.get(&active_upstream.track_key) {
-                Some(cache) => cache.largest_location().await,
-                None => None,
-            },
-        };
+        let largest_location =
+            resolve_subscribe_largest(&largest_source, &active_upstream.track_key, cache_store)
+                .await;
         let content_exists = match &largest_location {
             Some(loc) => ContentExists::True {
                 location: Location {
@@ -496,5 +531,110 @@ impl Subscribe {
             "Sending `SUBSCRIBE_ERROR`"
         );
         handler.error(code, reason_phrase).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::core::data_object::DataObject;
+    use crate::modules::relay::cache::track_cache::TrackCache;
+    use crate::modules::relay::types::StreamSubgroupId;
+    use bytes::Bytes;
+    use moqt::{ExtensionHeaders, SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField};
+
+    fn make_header() -> DataObject {
+        DataObject::SubgroupHeader(SubgroupHeader::new(
+            0,
+            0,
+            SubgroupId::Value(0),
+            0,
+            false,
+            false,
+        ))
+    }
+
+    fn make_object() -> DataObject {
+        let message_type =
+            SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false).message_type;
+        DataObject::SubgroupObject(SubgroupObjectField {
+            message_type,
+            object_id_delta: 0,
+            extension_headers: ExtensionHeaders {
+                prior_group_id_gap: vec![],
+                prior_object_id_gap: vec![],
+                immutable_extensions: vec![],
+            },
+            subgroup_object: SubgroupObject::new_payload(Bytes::from(vec![])),
+        })
+    }
+
+    // Append a single object (id 0) to `group_id` so the cache reports it as content.
+    async fn append_one_object(cache: &TrackCache, group_id: u64) {
+        let subgroup = StreamSubgroupId::Value(0);
+        cache
+            .append_stream_object(group_id, &subgroup, None, make_header())
+            .await;
+        cache
+            .append_stream_object(group_id, &subgroup, Some(0), make_object())
+            .await;
+    }
+
+    // A publisher that left a catalog cache (groups 0..=4) then reconnected as a
+    // fresh upstream reporting no content (SubscribeOk(None)) must still resolve
+    // the cached Largest Object (group 4), not None. Returning None makes the
+    // relay advertise contentExists=false and replay the stale cache from {0,0}
+    // out of order, leaving the subscriber on an old catalog version.
+    #[tokio::test]
+    async fn subscribe_largest_uses_cache_when_fresh_upstream_reports_no_content() {
+        let cache_store = TrackCacheStore::new();
+        let track_key = TrackKey::new("e2e-room/bob", "catalog");
+        let cache = cache_store.get_or_create(&track_key);
+        for group_id in 0..=4 {
+            append_one_object(&cache, group_id).await;
+        }
+
+        let largest = resolve_subscribe_largest(
+            &LargestObjectSource::SubscribeOk(None),
+            &track_key,
+            &cache_store,
+        )
+        .await;
+
+        assert_eq!(
+            largest,
+            Some(moqt::Location {
+                group_id: 4,
+                object_id: 0,
+            })
+        );
+    }
+
+    // When the publisher already had content at SUBSCRIBE_OK time but the cache
+    // has not caught up yet, the SUBSCRIBE_OK location is larger and must win.
+    #[tokio::test]
+    async fn subscribe_largest_prefers_subscribe_ok_when_ahead_of_cache() {
+        let cache_store = TrackCacheStore::new();
+        let track_key = TrackKey::new("e2e-room/bob", "catalog");
+        let cache = cache_store.get_or_create(&track_key);
+        append_one_object(&cache, 3).await;
+
+        let largest = resolve_subscribe_largest(
+            &LargestObjectSource::SubscribeOk(Some(moqt::Location {
+                group_id: 10,
+                object_id: 0,
+            })),
+            &track_key,
+            &cache_store,
+        )
+        .await;
+
+        assert_eq!(
+            largest,
+            Some(moqt::Location {
+                group_id: 10,
+                object_id: 0,
+            })
+        );
     }
 }

--- a/scripts/object-dedup-e2e.sh
+++ b/scripts/object-dedup-e2e.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export RELAY_STDOUT_FILTER="${RELAY_STDOUT_FILTER:-relay=info,moqt=info}"
+export RELAY_LOG_FILTER="${RELAY_LOG_FILTER:-relay=info,moqt=info}"
+LOGS_PID=""
+
+cleanup() {
+  if [[ -n "$LOGS_PID" ]]; then
+    kill "$LOGS_PID" 2>/dev/null || true
+    for _ in {1..10}; do
+      if ! kill -0 "$LOGS_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.1
+    done
+    kill -9 "$LOGS_PID" 2>/dev/null || true
+  fi
+  docker compose down -v --remove-orphans
+}
+trap cleanup EXIT
+
+node scripts/ensure-relay-certs.mjs
+
+# Reuse a prebuilt relay image when present (pulled from the registry in CI);
+# otherwise build it locally.
+if docker image inspect moqt-relay:local >/dev/null 2>&1; then
+  echo "Reusing existing moqt-relay:local image (skipping build)."
+else
+  docker compose build relay-common
+fi
+# object-dedup-e2e talks to a single relay, so only relay-a (and its redis)
+# is needed.
+docker compose up -d redis relay-a
+docker compose logs -f --no-color relay-a &
+LOGS_PID=$!
+
+# bob asserts group 0 deduplicates to o0..o4 and panics on a duplicate, so a
+# non-zero exit is the only failure signal needed.
+cargo run -p object-dedup-e2e

--- a/tests/object-dedup-e2e/Cargo.toml
+++ b/tests/object-dedup-e2e/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "object-dedup-e2e"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+moqt = { path = "../../moqt" }
+tokio = { version = "1.52.3", features = ["full", "tracing"] }
+tracing = "0.1.44"
+anyhow = { version = "1.0.102", features = ["backtrace"] }
+url = "2.5.8"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/tests/object-dedup-e2e/src/main.rs
+++ b/tests/object-dedup-e2e/src/main.rs
@@ -1,0 +1,190 @@
+//! Manual e2e for per-object dedup when the same track is published twice.
+//!
+//!   1. alice publishes group 0 (o0..o4) on a track, then disconnects.
+//!   2. alice publishes the same Full Track Name and group 0 again.
+//!   3. bob FETCHes the whole of group 0 and must receive exactly o0..o4.
+//!
+//! Without dedup the relay appends the second group 0 after the first, so the
+//! fetch returns 10 objects (each object id 0..4 twice) and the assertion fails.
+//!
+//! Run a relay on localhost:4433, then `cargo run -p object-dedup-e2e`.
+
+use std::net::ToSocketAddrs;
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use moqt::{
+    ClientConfig, Endpoint, ExtensionHeaders, Fetch, FetchDataReceiver, FetchObject, FetchOption,
+    Location, PublishOption, QUIC, Session, StreamDataSenderFactory, SubgroupId, SubgroupObject,
+};
+
+const RELAY_URL: &str = "moqt://localhost:4433";
+const NAMESPACE: &str = "room/main";
+const PUBLISHER_PRIORITY: u8 = 128;
+const GROUP_ID: u64 = 0;
+const OBJECTS_PER_GROUP: u64 = 5;
+
+async fn new_session() -> anyhow::Result<Session<QUIC>> {
+    let url = url::Url::from_str(RELAY_URL).unwrap();
+    let host = url.host_str().unwrap();
+    let remote = (host, url.port().unwrap_or(4433))
+        .to_socket_addrs()?
+        .next()
+        .unwrap();
+    let endpoint = Endpoint::<QUIC>::create_client(&ClientConfig {
+        port: 0,
+        verify_certificate: false,
+    })?;
+    let connecting = endpoint.connect(remote, host).await?;
+    connecting.await
+}
+
+/// A fresh track name per run so a relay's persistent cache (it never evicts)
+/// is not polluted by objects from earlier runs of this test.
+fn unique_track_name() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("data-{}", nanos)
+}
+
+async fn send_group(factory: &StreamDataSenderFactory<QUIC>, attempt: &str) -> anyhow::Result<()> {
+    let sender = factory.next().await?;
+    let header = sender.create_header(GROUP_ID, SubgroupId::None, PUBLISHER_PRIORITY, false, false);
+    let mut stream = sender.send_header(header).await?;
+    for obj_id in 0..OBJECTS_PER_GROUP {
+        // Tag the payload with the publish attempt so the duplication is visible.
+        let payload = format!("alice:{}:g{}:o{}", attempt, GROUP_ID, obj_id);
+        let obj = stream.create_object_field(
+            0,
+            ExtensionHeaders {
+                prior_group_id_gap: vec![],
+                prior_object_id_gap: vec![],
+                immutable_extensions: vec![],
+            },
+            SubgroupObject::new_payload(payload.into()),
+        );
+        stream.send(obj).await?;
+        tracing::info!("[alice:{}] sent g{}:o{}", attempt, GROUP_ID, obj_id);
+    }
+    stream.close().await
+}
+
+/// Connects, PUBLISHes the track, sends group 0, then drops the session
+/// (disconnect). The trailing sleep lets the relay ingest the objects and, on
+/// return, tear the session down before the next publish.
+async fn publish_once(track_name: &str, attempt: &str) -> anyhow::Result<()> {
+    let session = new_session().await?;
+    let publisher = session.publisher();
+    let subscription = publisher
+        .publish(
+            NAMESPACE.to_string(),
+            track_name.to_string(),
+            PublishOption::default(),
+        )
+        .await?;
+    tracing::info!("[alice:{}] publish ok", attempt);
+    let factory = publisher.create_stream(&subscription);
+    send_group(&factory, attempt).await?;
+    tracing::info!(
+        "[alice:{}] group sent; waiting for relay to ingest",
+        attempt
+    );
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
+
+/// Runs one standalone FETCH and returns the received (group_id, object_id,
+/// payload) in delivery order.
+async fn run_fetch(
+    subscriber: &mut moqt::Subscriber<QUIC>,
+    track_name: &str,
+    start: Location,
+    end: Location,
+) -> anyhow::Result<Vec<(u64, u64, String)>> {
+    let handle = subscriber
+        .fetch(
+            NAMESPACE.to_string(),
+            track_name.to_string(),
+            start,
+            end,
+            FetchOption::default(),
+        )
+        .await?;
+    let mut receiver: FetchDataReceiver<QUIC> = subscriber.accept_fetch_receiver(&handle).await?;
+    let mut received = Vec::new();
+    loop {
+        match receiver.receive().await {
+            Ok(Fetch::Header(_)) => {}
+            Ok(Fetch::Object(obj)) => {
+                let payload = match &obj.fetch_object {
+                    FetchObject::Payload(b) => String::from_utf8_lossy(b).to_string(),
+                    FetchObject::Status(s) => format!("{:?}", s),
+                };
+                tracing::info!("[bob] g{}:o{} = {}", obj.group_id, obj.object_id, payload);
+                received.push((obj.group_id, obj.object_id, payload));
+            }
+            Ok(Fetch::End) => break,
+            Err(e) => return Err(anyhow::anyhow!("[bob] fetch failed: {}", e)),
+        }
+    }
+    Ok(received)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_line_number(true)
+        .try_init()
+        .ok();
+
+    let track_name = unique_track_name();
+    tracing::info!("[main] track = {}/{}", NAMESPACE, track_name);
+
+    // 1. alice publishes group 0, then disconnects.
+    publish_once(&track_name, "1st").await?;
+    // Let the relay finish tearing down alice's ingress so the single-writer
+    // guard is cleared before the same track is published again.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // 2. alice publishes the *same* group 0 again.
+    publish_once(&track_name, "2nd").await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // 3. bob fetches the whole of group 0. End object_id 0 means "entire group",
+    // so the range is not clamped and every cached object is returned.
+    let session = new_session().await?;
+    let mut subscriber = session.subscriber();
+    let received = run_fetch(
+        &mut subscriber,
+        &track_name,
+        Location {
+            group_id: GROUP_ID,
+            object_id: 0,
+        },
+        Location {
+            group_id: GROUP_ID,
+            object_id: 0,
+        },
+    )
+    .await?;
+
+    let ids: Vec<(u64, u64)> = received.iter().map(|(g, o, _)| (*g, *o)).collect();
+    let expected: Vec<(u64, u64)> = (0..OBJECTS_PER_GROUP).map(|o| (GROUP_ID, o)).collect();
+    tracing::info!("[bob] received {} objects: {:?}", received.len(), received);
+
+    // The relay must deduplicate by (Full Track Name, Group ID, Object ID):
+    // publishing the same group 0 twice must not duplicate it.
+    assert_eq!(
+        ids,
+        expected,
+        "group 0 must contain exactly o0..o4 after being published twice; got {} objects: {:?}",
+        received.len(),
+        received
+    );
+
+    tracing::info!("[bob] OK: group 0 deduplicated to o0..o4");
+    Ok(())
+}


### PR DESCRIPTION
## 概要

draft-14 §8.1 に従い、リレーのキャッシュが `(Full Track Name, Group ID, Object ID)` 単位でオブジェクトを重複排除（dedup）するようにした。Publisher の切断・再 publish で同じ object が二重にキャッシュされ、SUBSCRIBE/FETCH が重複を返す不具合を解消した。

## 変更内容

- object id の解決を ingest 時に行うよう変更した。object id は wire 上では直前からの差分（delta）で送られるため絶対 id への変換が必要だが、旧実装は変換に使う直前 id をキャッシュ（`Vec`）の末尾要素から読んでいた。そのため id を持たない再送 header が末尾に来ると id が 0 に巻き戻り重複が生じていた。リーダ側で `prev_object_id` を保持して解決するようにした。
- キャッシュを object id でキー化した。`GroupCache` は header を別枠に持ち、オブジェクトを `BTreeMap<object_id, _>` に格納するようにした。同じ `(group, object_id)` は `entry().or_insert()` で無視（first-wins）し、2 本目の header も無視するようにした。
- オブジェクトの参照を Vec の位置（index）から object id 直接引きに変更した。egress / fetch / datagram の各経路は、これまで object id を Vec の index に換算して位置で読んでいたが、object id で直接引く（`BTreeMap` の range 検索）方式にした。これにより id に gap があっても正しく読めるようになり、既存の gapless FIXME も解消した。
- datagram の暗黙 object id に対応した。種別 `0x04-0x07` は wire に object id を持たないため、直前 +1（先頭は 0）で解決するようにした。

dedup ポリシーは object 単位の first-wins とした（最初に受けたものを保持し、以降の重複は publisher を問わず無視）。

## スコープ外

- 同一 Object の MALFORMED 検出は未実装。該当箇所に FIXME を残した。
- Multiple Publisher は変更なし。ingest は first-writer-wins を維持した。(GOAWAY 実装時に対応)

## テスト

- E2E: `tests/object-dedup-e2e` で再接続による重複を再現した。修正後は group 0 の FETCH が o0..o4 の 5 個（すべて最初の publish 由来）を返す（修正前は 10 個）。CI に `object_dedup_e2e` ジョブを追加した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
