### PR TITLE
chore(gitignore): ignore media files to guard against license violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,41 @@ log/*
 test-results
 
 cargo-flamegraph.trace/*
+
+# Media files (license-violation guard; allow specific files with `!path/to/file.ext`)
+# Images
+*.jpg
+*.jpeg
+*.png
+*.gif
+*.svg
+*.webp
+*.bmp
+*.heic
+*.heif
+*.tiff
+*.tif
+*.ico
+*.psd
+# Video
+*.mp4
+*.mov
+*.avi
+*.mkv
+*.webm
+*.wmv
+*.flv
+*.mpeg
+*.mpg
+*.m4v
+*.3gp
+# Audio
+*.mp3
+*.wav
+*.aac
+*.flac
+*.m4a
+*.ogg
+*.opus
+*.aiff
+*.wma


### PR DESCRIPTION
## 概要

不適切なコンテンツの混入を防ぐため、画像・映像・音声の拡張子を `.gitignore` に追加する。

blacklist + 個別例外（`!path/to/file.ext`）方式で、実質ホワイトリスト的に運用できる。

## 追加した拡張子

- 画像: jpg/jpeg/png/gif/svg/webp/bmp/heic/heif/tiff/tif/ico/psd
- 映像: mp4/mov/avi/mkv/webm/wmv/flv/mpeg/mpg/m4v/3gp
- 音声: mp3/wav/aac/flac/m4a/ogg/opus/aiff/wma

🤖 Generated with [Claude Code](https://claude.com/claude-code)