### PR TITLE
fix(wasm): decode call video delta frames

### DIFF
--- a/examples/browser/examples/call/src/media/mediaSubscriber.ts
+++ b/examples/browser/examples/call/src/media/mediaSubscriber.ts
@@ -488,13 +488,6 @@ export class MediaSubscriber {
   }
 
   private forwardToWorker(worker: Worker, groupId: bigint, message: SubgroupObjectMessageWithLoc) {
-    console.info('[call][moqt] received subgroup object', {
-      groupId: groupId.toString(),
-      subgroupId: message.subgroupId?.toString() ?? '0',
-      objectIdDelta: message.objectIdDelta.toString(),
-      objectPayloadLength: message.objectPayloadLength,
-      objectStatus: message.objectStatus
-    })
     const payload = new Uint8Array(message.objectPayload)
     const payloadLength = message.objectPayloadLength
     worker.postMessage(

--- a/examples/browser/examples/call/src/session/localSession.ts
+++ b/examples/browser/examples/call/src/session/localSession.ts
@@ -199,14 +199,6 @@ export class LocalSession {
     const resolvedRole = role ?? this.resolveTrackRole(trackName)
     if (resolvedRole === 'chat') {
       this.client.setOnSubgroupObjectHandler(trackAlias, (groupId, subgroup) => {
-        console.info('[call][moqt] received subgroup object', {
-          trackAlias: trackAlias.toString(),
-          groupId: groupId.toString(),
-          subgroupId: subgroup.subgroupId?.toString() ?? '0',
-          objectIdDelta: subgroup.objectIdDelta.toString(),
-          objectPayloadLength: subgroup.objectPayloadLength,
-          objectStatus: subgroup.objectStatus
-        })
         try {
           const payload = new Uint8Array(subgroup.objectPayload)
           const decoded = new TextDecoder().decode(payload)

--- a/examples/browser/lib/moqt/moqtClient.ts
+++ b/examples/browser/lib/moqt/moqtClient.ts
@@ -544,17 +544,15 @@ export class MoqtClientWrapper {
       this.onObjectDatagramStatusHandler?.(message)
     })
     this.client.onSubgroupHeader((header: SubgroupHeaderMessage) => {
+      console.debug('[moqt] received subgroup header', {
+        trackAlias: header.trackAlias.toString(),
+        groupId: header.groupId.toString(),
+        subgroupId: header.subgroupId?.toString() ?? '0',
+        publisherPriority: header.publisherPriority
+      })
       this.onSubgroupHeaderHandler?.(header)
     })
     this.client.onSubgroupObject((trackAlias: bigint, groupId: bigint, subgroupObject: SubgroupObjectMessage) => {
-      console.log('[moqt] received subgroup object', {
-        trackAlias: trackAlias.toString(),
-        groupId: groupId.toString(),
-        subgroupId: subgroupObject.subgroupId?.toString() ?? '0',
-        objectIdDelta: subgroupObject.objectIdDelta.toString(),
-        objectPayloadLength: subgroupObject.objectPayloadLength,
-        objectStatus: subgroupObject.objectStatus
-      })
       const handler = this.subscriptionState.getSubgroupObjectHandler(trackAlias)
       if (handler) {
         handler(groupId, subgroupObject)

--- a/examples/browser/tests/call-e2e.spec.ts
+++ b/examples/browser/tests/call-e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 import {
   arrangeCallClient,
   enableMedia,
@@ -26,6 +26,40 @@ async function expectVideoPlaying(video: import('@playwright/test').Locator): Pr
     .toBeGreaterThan(0)
   // Assert: pause 状態でないことを確認する。
   await expect.poll(async () => video.evaluate((el) => (el as HTMLVideoElement).paused)).toBe(false)
+}
+
+// Wait until the debug video pipeline reports that a decoded frame with the target chunk type reached output.
+function waitForDecodedVideoFrameOutput(page: Page, chunkType: 'key' | 'delta'): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Timed out waiting for decoded ${chunkType} video frame output`))
+    }, 30_000)
+    const onConsole = (message: import('@playwright/test').ConsoleMessage) => {
+      const text = message.text()
+      if (!text.startsWith('[videoDecoder][output]')) {
+        return
+      }
+      const jsonStart = text.indexOf('{')
+      if (jsonStart === -1) {
+        return
+      }
+      try {
+        const output = JSON.parse(text.slice(jsonStart)) as { event?: string; chunkType?: string }
+        if (output.event === 'output-frame' && output.chunkType === chunkType) {
+          cleanup()
+          resolve()
+        }
+      } catch {
+        // Ignore unrelated console payloads.
+      }
+    }
+    const cleanup = () => {
+      clearTimeout(timeout)
+      page.off('console', onConsole)
+    }
+    page.on('console', onConsole)
+  })
 }
 
 // Assert that an audio element has an active source object (track is being received).
@@ -97,6 +131,8 @@ test('cross-relay: two clients on different relays see each other and receive vi
     await expect(getCatalogStatus(client2.page.page, 'alice')).toHaveText('Subscribed', { timeout: 60_000 })
 
     // Act: Client1/Client2 が相手の映像・音声を明示的に購読する。
+    const bobDeltaOutput = waitForDecodedVideoFrameOutput(client1.page.page, 'delta')
+    const aliceDeltaOutput = waitForDecodedVideoFrameOutput(client2.page.page, 'delta')
     await subscribeMedia(client1.page.page, 'bob')
     await subscribeMedia(client2.page.page, 'alice')
 
@@ -109,6 +145,10 @@ test('cross-relay: two clients on different relays see each other and receive vi
     await expectVideoPlaying(getMemberVideo(client2.page.page, 'alice'))
     // Assert: Client2 が alice の音声を受信していることを確認する。
     await expectAudioReceiving(getMemberAudio(client2.page.page, 'alice'))
+
+    // Assert: both directions decode at least one inter-frame, not only keyframes.
+    await bobDeltaOutput
+    await aliceDeltaOutput
   } finally {
     await client1.context.close()
     await client2.context.close()

--- a/examples/browser/utils/media/decoders/videoDecoder.ts
+++ b/examples/browser/utils/media/decoders/videoDecoder.ts
@@ -198,7 +198,6 @@ let receivedFrameTimes: Map<string, number> = new Map()
 let lastOutputMetaResetAtMs = Number.NEGATIVE_INFINITY
 let decodedInputLogCount = 0
 let decodedOutputLogCount = 0
-let keyframeFlushInFlight: Promise<void> | null = null
 
 type OutputMeta = {
   groupId: bigint
@@ -982,7 +981,6 @@ async function decode(
   }
 
   try {
-    const wasWaitingForKeyFrame = waitingForKeyFrame
     lastDecodingObject = {
       groupId: groupId.toString(),
       objectId: subgroupStreamObject.objectId.toString(),
@@ -999,9 +997,6 @@ async function decode(
     await videoDecoder.decode(encodedVideoChunk)
     if (decoded.metadata.type === 'key') {
       waitingForKeyFrame = false
-      if (wasWaitingForKeyFrame) {
-        flushWaitingKeyframe(videoDecoder, lastDecodingObject)
-      }
     }
   } catch (error) {
     if (isKeyFrameRequiredError(error)) {
@@ -1016,55 +1011,6 @@ async function decode(
     }
     throw error
   }
-}
-
-function flushWaitingKeyframe(decoder: VideoDecoder, object: LastDecodingObjectInfo | null): void {
-  if (keyframeFlushInFlight || decoder.state === 'closed') {
-    return
-  }
-  if (debugVideoPipeline) {
-    console.info(
-      '[videoDecoder][flush]',
-      JSON.stringify({
-        event: 'start',
-        groupId: object?.groupId,
-        objectId: object?.objectId,
-        chunkType: object?.chunkType,
-        codec: object?.codec,
-        decodeQueueSize: decoder.decodeQueueSize
-      })
-    )
-  }
-  keyframeFlushInFlight = decoder
-    .flush()
-    .then(() => {
-      if (debugVideoPipeline) {
-        console.info(
-          '[videoDecoder][flush]',
-          JSON.stringify({
-            event: 'done',
-            groupId: object?.groupId,
-            objectId: object?.objectId,
-            chunkType: object?.chunkType,
-            codec: object?.codec,
-            decodeQueueSize: decoder.state === 'closed' ? null : decoder.decodeQueueSize
-          })
-        )
-      }
-    })
-    .catch((error) => {
-      waitingForKeyFrame = true
-      resetPlayoutTiming('error')
-      console.warn('[videoDecoder][flush] failed after waiting keyframe', {
-        groupId: object?.groupId,
-        objectId: object?.objectId,
-        chunkType: object?.chunkType,
-        error: error instanceof Error ? error.message : String(error)
-      })
-    })
-    .finally(() => {
-      keyframeFlushInFlight = null
-    })
 }
 
 function reportPacingStatus(action: 'decode' | 'wait' | 'config' | 'error' | 'jump', detailMs?: number) {


### PR DESCRIPTION
## 何を対応するか
call アプリでキーフレームしか描画されないように見える問題を修正します。

## 変更内容
- `VideoDecoder.flush()` を keyframe 復帰時に呼ばないようにし、直後の delta frame が `A key frame is required` で拒否されないようにしました。
- call E2E に、delta frame が decoder output まで到達することを確認する assertion を追加しました。
- SubgroupObject の重複ログを削除し、SubgroupHeader の受信ログを debug に落としました。

## なぜ
WebCodecs の `VideoDecoder.flush()` は decoder を次の keyframe が必要な状態に戻すため、keyframe ごとに flush すると後続の delta frame が捨てられます。call アプリではその結果、キーフレーム単位でしか映像が更新されない挙動になっていました。

## 確認
- `npm --prefix examples/browser run lint`
- `node scripts/run-call-e2e.mjs`