### PR TITLE
fix(examples): close remote monitoring video group streams

### DIFF
--- a/examples/browser/examples/remote-monitoring/src/publisher/cameraPublisher.ts
+++ b/examples/browser/examples/remote-monitoring/src/publisher/cameraPublisher.ts
@@ -1,5 +1,7 @@
 import { MediaTransportState } from '../../../../utils/media/transportState'
-import { sendVideoChunkViaMoqt } from '../../../../utils/media/videoTransport'
+import { sendVideoChunkViaMoqt, type VideoChunkSender } from '../../../../utils/media/videoTransport'
+import type { LocHeader } from '../../../../utils/media/loc'
+import type { MOQTClient } from '../../../../pkg/moqt_client_wasm'
 import type { PublisherSession } from './publisherSession'
 import { type CameraId, type VideoSource } from '../types/monitoring'
 
@@ -7,6 +9,7 @@ const log = (...args: unknown[]) => console.log('[pub][camera]', ...args)
 
 const KEYFRAME_INTERVAL_FRAMES = 30 // 30fps × 1s = 1 GoP per second
 const BITRATE_LOG_INTERVAL_CHUNKS = 900 // ~30 seconds at 30fps
+const OBJECT_STATUS_END_OF_GROUP = 3
 const VIDEO_CONFIG = {
   codec: 'avc1.640028', // H.264 High Profile Level 4.0
   width: 1280,
@@ -23,11 +26,16 @@ const CAM_COLORS: Record<CameraId, string> = {
   cam04: '#7a4a10'
 }
 
+type GroupState = { groupId: bigint; lastObjectId: bigint }
+
 export class CameraPublisher {
   private worker: Worker | null = null
   private stream: MediaStream | null = null
   private videoEl: HTMLVideoElement | null = null
   private readonly transportState = new MediaTransportState()
+  private readonly videoGroupStates = new Map<bigint, GroupState>()
+  private readonly activeAliases = new Set<string>()
+  private sendQueue: Promise<void> = Promise.resolve()
   private chunkCount = 0
   private rafId: number | null = null
 
@@ -67,9 +75,7 @@ export class CameraPublisher {
           log('bitrate', { camId: this.camId, kbps: e.data.kbps })
         }
         this.chunkCount++
-        this.sendChunk(chunk, metadata, captureTimestampMicros).catch((err) =>
-          console.error('[pub][camera] sendChunk error', { camId: this.camId, err })
-        )
+        this.enqueueChunk(chunk, metadata, captureTimestampMicros)
       } else if (e.data.type === 'bitrate') {
         if (this.chunkCount % BITRATE_LOG_INTERVAL_CHUNKS === 0 && this.chunkCount > 0) {
           log('bitrate', { camId: this.camId, kbps: e.data.kbps })
@@ -84,6 +90,16 @@ export class CameraPublisher {
     this.worker.postMessage({ type: 'videoStream', videoStream }, [videoStream])
 
     return this.stream
+  }
+
+  private enqueueChunk(
+    chunk: EncodedVideoChunk,
+    metadata: EncodedVideoChunkMetadata | undefined,
+    captureTimestampMicros?: number
+  ): void {
+    this.sendQueue = this.sendQueue
+      .then(() => this.sendChunk(chunk, metadata, captureTimestampMicros))
+      .catch((err) => console.error('[pub][camera] sendChunk error', { camId: this.camId, err }))
   }
 
   // Canvas outputs BGRA frames. Switch to prefer-software to avoid HW encoder issues with BGRA.
@@ -185,10 +201,14 @@ export class CameraPublisher {
     metadata: EncodedVideoChunkMetadata | undefined,
     captureTimestampMicros?: number
   ): Promise<void> {
-    const aliases = this.session.getVideoTrackAliases()
+    const aliases = this.collectVideoAliases()
     if (aliases.length === 0) return
 
     const rawClient = this.session.getRawClient()
+    const sender: VideoChunkSender = async (alias, groupId, subgroupId, objectId, payload, client, locHeader) => {
+      await this.sendVideoObject(alias, groupId, subgroupId, objectId, payload, client, locHeader)
+    }
+
     await sendVideoChunkViaMoqt({
       chunk,
       metadata,
@@ -197,10 +217,71 @@ export class CameraPublisher {
       publisherPriority: 0,
       client: rawClient,
       transportState: this.transportState,
-      sender: async (alias, groupId, subgroupId, objectId, payload, client, locHeader) => {
-        await client.sendSubgroupObject(alias, groupId, subgroupId, objectId, undefined, payload, locHeader)
-      }
+      sender
     })
+  }
+
+  private collectVideoAliases(): bigint[] {
+    const aliases = this.session.getVideoTrackAliases()
+    const latestKeys = new Set(aliases.map((alias) => alias.toString()))
+
+    for (const key of this.activeAliases) {
+      if (!latestKeys.has(key)) {
+        this.transportState.resetAlias(key)
+        this.videoGroupStates.delete(BigInt(key))
+      }
+    }
+
+    this.activeAliases.clear()
+    for (const alias of aliases) {
+      this.activeAliases.add(alias.toString())
+    }
+
+    return aliases
+  }
+
+  private async sendVideoObject(
+    trackAlias: bigint,
+    groupId: bigint,
+    subgroupId: bigint,
+    objectId: bigint,
+    payload: Uint8Array,
+    client: MOQTClient,
+    locHeader?: LocHeader
+  ): Promise<void> {
+    const previousState = this.videoGroupStates.get(trackAlias)
+    if (previousState && previousState.groupId !== groupId) {
+      const endObjectId = previousState.lastObjectId + 1n
+      try {
+        await this.sendEndOfGroup(client, trackAlias, previousState.groupId, endObjectId)
+      } catch (err) {
+        console.warn('[pub][camera] EndOfGroup send failed', {
+          camId: this.camId,
+          trackAlias: trackAlias.toString(),
+          err
+        })
+      }
+    }
+
+    await client.sendSubgroupObject(trackAlias, groupId, subgroupId, objectId, undefined, payload, locHeader)
+    this.videoGroupStates.set(trackAlias, { groupId, lastObjectId: objectId })
+  }
+
+  private async sendEndOfGroup(
+    client: MOQTClient,
+    trackAlias: bigint,
+    groupId: bigint,
+    endObjectId: bigint
+  ): Promise<void> {
+    await client.sendSubgroupObject(
+      trackAlias,
+      groupId,
+      0n,
+      endObjectId,
+      OBJECT_STATUS_END_OF_GROUP,
+      new Uint8Array(0),
+      undefined
+    )
   }
 
   stop(): void {
@@ -215,5 +296,7 @@ export class CameraPublisher {
       this.videoEl.src = ''
       this.videoEl = null
     }
+    this.activeAliases.clear()
+    this.videoGroupStates.clear()
   }
 }


### PR DESCRIPTION
## 何を対応するか
remote monitoring ツールで映像受信が一定時間後に固まる問題に対応します。

## 変更内容
- remote monitoring publisher で alias ごとの video group 状態を保持するようにしました。
- video group が切り替わるときに前 group へ EndOfGroup を送るようにしました。
- chunk 送信を直列化し、group/object 状態の更新順序が競合しないようにしました。
- subscriber alias が消えた場合に transport state と group state を cleanup するようにしました。

## なぜ
共通の video transport helper は EndOfGroup 送信を呼び出し側に任せていますが、remote monitoring 側では送信していませんでした。そのため keyframe ごとに開かれる subgroup stream が閉じられず、WebTransport stream 数の上限に達して受信が停止する可能性がありました。

## 確認
- npm --prefix examples/browser run lint
- npm --prefix examples/browser exec prettier -- --check examples/browser/examples/remote-monitoring/src/publisher/cameraPublisher.ts