### PR TITLE
fix(relay): keep listener after setup failures

### DIFF
--- a/relay/src/modules/session_handler.rs
+++ b/relay/src/modules/session_handler.rs
@@ -55,25 +55,36 @@ impl SessionHandler {
                         session_peer_relay_id = session_peer_relay_id,
                         relay_hostname = %relay_hostname,
                     );
-                    let Ok(connecting) = async {
-                        endpoint.accept().await.inspect_err(|e| {
-                            tracing::error!("failed to accept: {}", e);
+                    let connecting = async {
+                        endpoint.accept().await.inspect_err(|error| {
+                            if Self::is_endpoint_closing(error) {
+                                tracing::info!(%error, "transport endpoint closed");
+                            } else {
+                                tracing::warn!(%error, "failed to accept transport connection");
+                            }
                         })
                     }
                     .instrument(session_span.clone())
-                    .await
-                    else {
-                        break;
+                    .await;
+                    let connecting = match connecting {
+                        Ok(connecting) => connecting,
+                        Err(error) => {
+                            if Self::is_endpoint_closing(&error) {
+                                break;
+                            }
+                            continue;
+                        }
                     };
-                    let Ok(session) = async {
-                        connecting.await.inspect_err(|e| {
-                            tracing::error!("failed to accept: {}", e);
+                    let session = async {
+                        connecting.await.inspect_err(|error| {
+                            tracing::warn!(%error, "failed to establish session");
                         })
                     }
                     .instrument(session_span.clone())
-                    .await
-                    else {
-                        break;
+                    .await;
+                    let session = match session {
+                        Ok(session) => session,
+                        Err(_) => continue,
                     };
                     let session_add_span = tracing::info_span!(
                         parent: &session_span,
@@ -112,11 +123,62 @@ impl SessionHandler {
             })
             .unwrap()
     }
+
+    fn is_endpoint_closing(error: &anyhow::Error) -> bool {
+        error
+            .chain()
+            .any(|cause| cause.to_string() == "Endpoint is closing")
+    }
 }
 
 impl Drop for SessionHandler {
     fn drop(&mut self) {
         tracing::info!("Handle dropped.");
         self.join_handle.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+
+    use super::SessionHandler;
+
+    #[test]
+    fn endpoint_closing_error_stops_accept_loop() {
+        // Arrange
+        let error = anyhow::anyhow!("Endpoint is closing");
+
+        // Act
+        let should_stop = SessionHandler::is_endpoint_closing(&error);
+
+        // Assert
+        assert!(should_stop);
+    }
+
+    #[test]
+    fn wrapped_endpoint_closing_error_stops_accept_loop() {
+        // Arrange
+        let error = Err::<(), _>(anyhow::anyhow!("Endpoint is closing"))
+            .context("accept failed")
+            .unwrap_err();
+
+        // Act
+        let should_stop = SessionHandler::is_endpoint_closing(&error);
+
+        // Assert
+        assert!(should_stop);
+    }
+
+    #[test]
+    fn connection_timeout_error_keeps_accept_loop_running() {
+        // Arrange
+        let error = anyhow::anyhow!("connection error: timed out");
+
+        // Act
+        let should_stop = SessionHandler::is_endpoint_closing(&error);
+
+        // Assert
+        assert!(!should_stop);
     }
 }


### PR DESCRIPTION
## 何を対応するか
Relay の外部 transport listener が、個別接続の session setup timeout で終了して UDP listen を止めてしまう問題を修正します。

## 変更内容
- `SessionHandler` の accept loop で、`Endpoint is closing` の場合だけ loop を終了するようにしました。
- transport accept や session setup の一時的な失敗は WARN ログを出して次の接続受付へ戻すようにしました。
- `connection error: timed out` が listener 停止扱いにならないことを unit test で確認しました。

## なぜ
実機ログで `failed to accept: connection error: timed out` の後に外部 UDP `:443` の listen が消え、inner `:444` だけ残る状態が確認されました。個別接続の timeout は listener 自体の fatal error ではないため、Relay が継続して新規接続を受け付けられるようにします。

## 確認
- `cargo test -p relay`
- `cargo clippy -p relay --all-targets`
- `cargo clippy`
- `cargo fmt --check`
- `npm --prefix examples/browser run lint`
- `npm --prefix examples/browser run build`
- local cascading relay E2E: Redis `6380` + local relay processes, `cascading relay e2e passed`
- local call E2E: Redis `6380` + local relay processes on `4433`/`4434`, `6 passed`

