### PR TITLE
feat(relay): TTL/strong_count cache eviction

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/media-e2e-helpers.mjs"
       - "scripts/ensure-relay-certs.mjs"
       - "scripts/chrome_linux.sh"
+      - "scripts/cache-eviction-e2e.sh"
       - "scripts/cascading-relay-e2e.sh"
       - "scripts/fetch-e2e.sh"
       - "scripts/multiple-publishers-e2e.sh"
@@ -23,6 +24,7 @@ on:
       - "relay/**"
       - "moqt/**"
       - "shared/**"
+      - "tests/cache-eviction-e2e/**"
       - "tests/cascading-relay-e2e/**"
       - "tests/fetch-e2e/**"
       - "tests/multiple-publishers-e2e/**"
@@ -46,6 +48,7 @@ on:
       - "scripts/media-e2e-helpers.mjs"
       - "scripts/ensure-relay-certs.mjs"
       - "scripts/chrome_linux.sh"
+      - "scripts/cache-eviction-e2e.sh"
       - "scripts/cascading-relay-e2e.sh"
       - "scripts/fetch-e2e.sh"
       - "scripts/multiple-publishers-e2e.sh"
@@ -56,6 +59,7 @@ on:
       - "relay/**"
       - "moqt/**"
       - "shared/**"
+      - "tests/cache-eviction-e2e/**"
       - "tests/cascading-relay-e2e/**"
       - "tests/fetch-e2e/**"
       - "tests/multiple-publishers-e2e/**"
@@ -79,6 +83,7 @@ jobs:
       media: ${{ steps.filter.outputs.media }}
       call: ${{ steps.filter.outputs.call }}
       cascading: ${{ steps.filter.outputs.cascading }}
+      cache_eviction: ${{ steps.filter.outputs.cache_eviction }}
       fetch: ${{ steps.filter.outputs.fetch }}
       multipub: ${{ steps.filter.outputs.multipub }}
       dedup: ${{ steps.filter.outputs.dedup }}
@@ -102,6 +107,7 @@ jobs:
             media=true
             call=true
             cascading=true
+            cache_eviction=true
             fetch=true
             multipub=true
             dedup=true
@@ -117,6 +123,7 @@ jobs:
             media=false
             call=false
             cascading=false
+            cache_eviction=false
             fetch=false
             multipub=false
             dedup=false
@@ -141,6 +148,12 @@ jobs:
               esac
 
               case "$path" in
+                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/cache-eviction-e2e.sh|scripts/ensure-relay-certs.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/cache-eviction-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                  cache_eviction=true
+                  ;;
+              esac
+
+              case "$path" in
                 .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/fetch-e2e.sh|scripts/ensure-relay-certs.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/fetch-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   fetch=true
                   ;;
@@ -160,7 +173,7 @@ jobs:
             done < changed-files.txt
           fi
 
-          if [[ "$call" == "true" || "$cascading" == "true" || "$fetch" == "true" || "$multipub" == "true" || "$dedup" == "true" ]]; then
+          if [[ "$call" == "true" || "$cascading" == "true" || "$cache_eviction" == "true" || "$fetch" == "true" || "$multipub" == "true" || "$dedup" == "true" ]]; then
             relay=true
           else
             relay=false
@@ -180,6 +193,7 @@ jobs:
             echo "media=$media"
             echo "call=$call"
             echo "cascading=$cascading"
+            echo "cache_eviction=$cache_eviction"
             echo "fetch=$fetch"
             echo "multipub=$multipub"
             echo "dedup=$dedup"
@@ -435,6 +449,69 @@ jobs:
         env:
           CI: "true"
         run: ./scripts/cascading-relay-e2e.sh
+
+  cache_eviction_e2e:
+    needs: [changes, relay_image_local, relay_image]
+    if: ${{ always() && needs.changes.outputs.cache_eviction == 'true' && ((needs.changes.outputs.relay_image_source == 'local' && needs.relay_image_local.result == 'success') || (needs.changes.outputs.relay_image_source == 'prebuilt' && needs.relay_image.result == 'success')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout repository
+        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust toolchain
+        # dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 = v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache Rust build artifacts
+        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+
+      - name: Download local relay image
+        if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
+        # actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 = v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: relay-image-local
+          path: ${{ runner.temp }}/relay-image
+
+      - name: Load local relay image
+        if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
+        run: |
+          gunzip -c "${RUNNER_TEMP}/relay-image/relay-image.tar.gz" | docker load
+          docker tag moqt-relay:local-source moqt-relay:local
+
+      - name: Log in to GHCR
+        if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
+        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull prebuilt relay image
+        if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
+        run: |
+          docker pull "${{ needs.relay_image.outputs.image }}"
+          docker tag "${{ needs.relay_image.outputs.image }}" moqt-relay:local
+
+      - name: Log out from GHCR
+        if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
+        run: docker logout ghcr.io
+
+      - name: Run cache-eviction E2E
+        env:
+          CI: "true"
+        run: ./scripts/cache-eviction-e2e.sh
 
   fetch_e2e:
     needs: [changes, relay_image_local, relay_image]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cache-eviction-e2e"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "moqt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     'moqt',
     'relay',
     'examples/rust/manual-client',
+    'tests/cache-eviction-e2e',
     'tests/cascading-relay-e2e',
     'tests/fetch-e2e',
     'tests/multiple-publishers-e2e',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       RELAY_STDOUT_FILTER: ${RELAY_STDOUT_FILTER:-relay=info,moqt=info}
       RELAY_OTEL_FILTER: ${RELAY_OTEL_FILTER:-relay=info,moqt=info}
       RELAY_LOG_FILTER: ${RELAY_LOG_FILTER:-relay=info,moqt=info}
+      RELAY_CACHE_TTL_SECS: ${RELAY_CACHE_TTL_SECS:-}
+      RELAY_CACHE_EVICT_INTERVAL_SECS: ${RELAY_CACHE_EVICT_INTERVAL_SECS:-}
     ports:
       - "4433:443/udp"
     # Playwright pins the host certificate SPKI; relay must serve the same keypair.
@@ -66,6 +68,8 @@ services:
       RELAY_STDOUT_FILTER: ${RELAY_STDOUT_FILTER:-relay=info,moqt=info}
       RELAY_OTEL_FILTER: ${RELAY_OTEL_FILTER:-relay=info,moqt=info}
       RELAY_LOG_FILTER: ${RELAY_LOG_FILTER:-relay=info,moqt=info}
+      RELAY_CACHE_TTL_SECS: ${RELAY_CACHE_TTL_SECS:-}
+      RELAY_CACHE_EVICT_INTERVAL_SECS: ${RELAY_CACHE_EVICT_INTERVAL_SECS:-}
     ports:
       - "4434:443/udp"
     # Playwright pins the host certificate SPKI; relay must serve the same keypair.

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -31,3 +31,6 @@ opentelemetry-appender-tracing = "0.32.0"
 tracing-opentelemetry = "0.33.0"
 redis = { version = "1.2.2", features = ["tokio-comp", "connection-manager"] }
 thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1.52.3", features = ["test-util"] }

--- a/relay/src/modules/relay/cache.rs
+++ b/relay/src/modules/relay/cache.rs
@@ -1,3 +1,4 @@
+pub(crate) mod eviction_job;
 pub(crate) mod group_cache;
 pub(crate) mod store;
 pub(crate) mod track_cache;

--- a/relay/src/modules/relay/cache/eviction_job.rs
+++ b/relay/src/modules/relay/cache/eviction_job.rs
@@ -1,0 +1,29 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::{task::JoinHandle, time::MissedTickBehavior};
+
+use crate::modules::relay::cache::store::TrackCacheStore;
+
+const DEFAULT_TTL_SECS: u64 = 30;
+const DEFAULT_INTERVAL_SECS: u64 = 5;
+
+fn duration_from_env(var: &str, default_secs: u64) -> Duration {
+    let secs = std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(default_secs);
+    Duration::from_secs(secs)
+}
+
+pub(crate) fn spawn_cache_eviction_job(cache_store: Arc<TrackCacheStore>) -> JoinHandle<()> {
+    let ttl = duration_from_env("RELAY_CACHE_TTL_SECS", DEFAULT_TTL_SECS);
+    let interval = duration_from_env("RELAY_CACHE_EVICT_INTERVAL_SECS", DEFAULT_INTERVAL_SECS);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            cache_store.evict(ttl).await;
+        }
+    })
+}

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -1,12 +1,15 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use tokio::sync::{Notify, RwLock};
+use tokio::{
+    sync::{Notify, RwLock},
+    time::{Duration, Instant},
+};
 
 use crate::modules::core::data_object::DataObject;
 
 pub(crate) struct GroupCache {
     header: RwLock<Option<Arc<DataObject>>>,
-    objects: RwLock<BTreeMap<u64, Arc<DataObject>>>,
+    objects: RwLock<BTreeMap<u64, (Instant, Arc<DataObject>)>>,
     end_of_group: RwLock<bool>,
     notify: Notify,
 }
@@ -39,10 +42,21 @@ impl GroupCache {
                     .write()
                     .await
                     .entry(object_id)
-                    .or_insert(object);
+                    .or_insert((Instant::now(), object));
             }
         }
         self.notify.notify_waiters();
+    }
+
+    pub(crate) async fn evict_expired_objects(&self, ttl: Duration) {
+        self.objects
+            .write()
+            .await
+            .retain(|_, (inserted, _)| inserted.elapsed() <= ttl);
+    }
+
+    pub(crate) async fn is_evictable(&self) -> bool {
+        self.is_closed().await && self.objects.read().await.is_empty()
     }
 
     pub(crate) async fn header(&self) -> Option<Arc<DataObject>> {
@@ -82,7 +96,7 @@ impl GroupCache {
         loop {
             // Create notified() before the check to avoid a race between it and the wait.
             let notified = self.notify.notified();
-            if let Some((&id, object)) = self.objects.read().await.range(object_id..).next() {
+            if let Some((&id, (_, object))) = self.objects.read().await.range(object_id..).next() {
                 return Some((id, object.clone()));
             }
             if self.is_closed().await {
@@ -109,7 +123,7 @@ impl GroupCache {
             .read()
             .await
             .iter()
-            .map(|(&id, object)| (id, object.clone()))
+            .map(|(&id, (_, object))| (id, object.clone()))
             .collect()
     }
 }
@@ -119,6 +133,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use moqt::{ExtensionHeaders, SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField};
+    use std::time::Duration;
 
     fn payload_object(payload: &[u8]) -> Arc<DataObject> {
         let message_type =
@@ -210,6 +225,36 @@ mod tests {
         let (id, _) = cache.object_from_or_wait(4).await.unwrap();
         // Assert: the next available id (5) is returned across the gap
         assert_eq!(id, 5);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_removes_objects_older_than_ttl() {
+        // Arrange: object 0 at t=0, object 1 at t=6s, TTL=10s
+        let ttl = Duration::from_secs(10);
+        let cache = GroupCache::new();
+        cache.append(Some(0), payload_object(b"old")).await;
+        tokio::time::advance(Duration::from_secs(6)).await;
+        cache.append(Some(1), payload_object(b"new")).await;
+        // Act: at t=11s, object 0 is 11s old (>10), object 1 is 5s old (<=10)
+        tokio::time::advance(Duration::from_secs(5)).await;
+        cache.evict_expired_objects(ttl).await;
+        // Assert: only the expired object 0 is removed
+        let snapshot = cache.objects_snapshot().await;
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].0, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_keeps_object_at_exactly_ttl() {
+        // Arrange: object 0 at t=0, TTL=10s
+        let ttl = Duration::from_secs(10);
+        let cache = GroupCache::new();
+        cache.append(Some(0), payload_object(b"o")).await;
+        // Act: at exactly t=10s, age == TTL, which is not `> TTL`
+        tokio::time::advance(Duration::from_secs(10)).await;
+        cache.evict_expired_objects(ttl).await;
+        // Assert: the boundary object survives
+        assert_eq!(cache.objects_snapshot().await.len(), 1);
     }
 
     #[tokio::test]

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use dashmap::DashMap;
 
@@ -25,5 +25,53 @@ impl TrackCacheStore {
             .entry(track_key.clone())
             .or_insert_with(|| Arc::new(TrackCache::new()))
             .clone()
+    }
+
+    pub(crate) async fn evict(&self, ttl: Duration) {
+        // Snapshot handles so per-track eviction runs without holding a shard lock.
+        let entries: Vec<(TrackKey, Arc<TrackCache>)> = self
+            .caches
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+        for (_, track) in &entries {
+            track.evict(ttl).await;
+        }
+        // Drop the snapshot Arcs before the strong_count check so it counts only real holders.
+        let keys: Vec<TrackKey> = entries.into_iter().map(|(key, _)| key).collect();
+        for key in keys {
+            self.caches
+                .remove_if(&key, |_, track| Arc::strong_count(track) == 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn evict_removes_unreferenced_track() {
+        // Arrange: a track held only by the store (the returned Arc is dropped immediately)
+        let store = TrackCacheStore::new();
+        let key = TrackKey::new("ns", "track");
+        store.get_or_create(&key);
+        // Act
+        store.evict(Duration::from_secs(10)).await;
+        // Assert: strong_count == 1, so the track is reclaimed
+        assert!(store.get(&key).is_none());
+    }
+
+    #[tokio::test]
+    async fn evict_keeps_referenced_track() {
+        // Arrange: a track someone else still holds (simulating an active ingress/egress)
+        let store = TrackCacheStore::new();
+        let key = TrackKey::new("ns", "track");
+        let _held = store.get_or_create(&key);
+        // Act
+        store.evict(Duration::from_secs(10)).await;
+        // Assert: strong_count > 1, so the track survives (new-join race avoidance)
+        assert!(store.get(&key).is_some());
     }
 }

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use tokio::sync::RwLock;
 
@@ -95,6 +95,60 @@ impl TrackCache {
     pub(crate) async fn close_datagram_group(&self, group_id: u64) {
         let group = self.ensure_datagram_group(group_id).await;
         group.mark_end_of_group().await;
+    }
+
+    pub(crate) async fn evict(&self, ttl: Duration) {
+        // Snapshot group handles so per-group eviction runs without holding the map lock.
+        let stream_groups: Vec<(u64, StreamSubgroupId, Arc<GroupCache>)> = {
+            let groups = self.stream_groups.read().await;
+            groups
+                .iter()
+                .flat_map(|(&group_id, subgroups)| {
+                    subgroups.iter().map(move |(subgroup_id, group)| {
+                        (group_id, subgroup_id.clone(), group.clone())
+                    })
+                })
+                .collect()
+        };
+        let mut removable_streams: Vec<(u64, StreamSubgroupId)> = Vec::new();
+        for (group_id, subgroup_id, group) in stream_groups {
+            group.evict_expired_objects(ttl).await;
+            if group.is_evictable().await {
+                removable_streams.push((group_id, subgroup_id));
+            }
+        }
+        if !removable_streams.is_empty() {
+            let mut groups = self.stream_groups.write().await;
+            for (group_id, subgroup_id) in removable_streams {
+                if let Some(subgroups) = groups.get_mut(&group_id) {
+                    subgroups.remove(&subgroup_id);
+                    if subgroups.is_empty() {
+                        groups.remove(&group_id);
+                    }
+                }
+            }
+        }
+
+        let datagram_groups: Vec<(u64, Arc<GroupCache>)> = {
+            let groups = self.datagram_groups.read().await;
+            groups
+                .iter()
+                .map(|(&group_id, group)| (group_id, group.clone()))
+                .collect()
+        };
+        let mut removable_datagrams: Vec<u64> = Vec::new();
+        for (group_id, group) in datagram_groups {
+            group.evict_expired_objects(ttl).await;
+            if group.is_evictable().await {
+                removable_datagrams.push(group_id);
+            }
+        }
+        if !removable_datagrams.is_empty() {
+            let mut groups = self.datagram_groups.write().await;
+            for group_id in removable_datagrams {
+                groups.remove(&group_id);
+            }
+        }
     }
 
     /// Returns the Largest Location as defined in the MoQT spec.
@@ -260,6 +314,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use moqt::{ExtensionHeaders, SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField};
+    use std::time::Duration;
 
     fn make_header(group_id: u64) -> DataObject {
         DataObject::SubgroupHeader(SubgroupHeader::new(
@@ -354,6 +409,53 @@ mod tests {
         // Assert: the latest group's location is returned
         assert_eq!(loc.group_id, 1);
         assert_eq!(loc.object_id, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_removes_closed_group_after_objects_drain() {
+        // Arrange: a closed group whose objects will all expire, TTL=10s
+        let ttl = Duration::from_secs(10);
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        fill_group(&cache, 0, 3).await;
+        cache.close_stream_subgroup(0, &subgroup).await;
+        // Act: at t=11s, all objects have drained via object TTL
+        tokio::time::advance(Duration::from_secs(11)).await;
+        cache.evict(ttl).await;
+        // Assert: the closed, drained group (header included) is reclaimed
+        assert!(!cache.has_stream_group(0).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_keeps_open_group_without_objects() {
+        // Arrange: an open group with only a header, no objects yet, TTL=10s
+        let ttl = Duration::from_secs(10);
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        cache
+            .append_stream_object(0, &subgroup, None, make_header(0))
+            .await;
+        // Act: long past the TTL, but the group is still open
+        tokio::time::advance(Duration::from_secs(100)).await;
+        cache.evict(ttl).await;
+        // Assert: an open group is never evicted, so no resurrection can occur
+        assert!(cache.has_stream_group(0).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_keeps_closed_group_with_remaining_objects() {
+        // Arrange: a closed group whose objects are still within TTL
+        let ttl = Duration::from_secs(10);
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        fill_group(&cache, 0, 3).await;
+        cache.close_stream_subgroup(0, &subgroup).await;
+        // Act: at t=5s, the objects have not drained yet
+        tokio::time::advance(Duration::from_secs(5)).await;
+        cache.evict(ttl).await;
+        // Assert: the group survives until its objects drain
+        assert!(cache.has_stream_group(0).await);
+        assert_eq!(cache.largest_location().await.unwrap().object_id, 2);
     }
 
     async fn fill_group(cache: &TrackCache, group_id: u64, count: u64) {

--- a/relay/src/relay_server/runtime.rs
+++ b/relay/src/relay_server/runtime.rs
@@ -6,7 +6,8 @@ use crate::modules::{
     event_handler::EventHandler,
     inter_relay::InterRelayConnectionManager,
     relay::{
-        egress::coordinator::EgressCoordinator, ingress::ingress_coordinator::IngressCoordinator,
+        cache::eviction_job::spawn_cache_eviction_job, egress::coordinator::EgressCoordinator,
+        ingress::ingress_coordinator::IngressCoordinator,
     },
     route_registry::RelayRouteRegistry,
     session_event::SessionEvent,
@@ -19,6 +20,7 @@ pub(crate) struct RelayRuntime {
     _ingress: IngressCoordinator,
     _egress: EgressCoordinator,
     _manager: EventHandler,
+    _evict_job: tokio::task::JoinHandle<()>,
 }
 
 impl RelayRuntime {
@@ -56,12 +58,14 @@ impl RelayRuntime {
             upstream_publisher_resolver,
             store.cache_store.clone(),
         );
+        let evict_job = spawn_cache_eviction_job(store.cache_store.clone());
         (
             sender,
             Self {
                 _ingress: ingress,
                 _egress: egress,
                 _manager: manager,
+                _evict_job: evict_job,
             },
         )
     }

--- a/scripts/cache-eviction-e2e.sh
+++ b/scripts/cache-eviction-e2e.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export RELAY_STDOUT_FILTER="${RELAY_STDOUT_FILTER:-relay=info,moqt=info}"
+export RELAY_LOG_FILTER="${RELAY_LOG_FILTER:-relay=info,moqt=info}"
+# Shorten eviction so the client's before/after-TTL assertions run in seconds.
+# The client sleeps assume TTL=5s / interval=1s (see tests/cache-eviction-e2e).
+export RELAY_CACHE_TTL_SECS="${RELAY_CACHE_TTL_SECS:-5}"
+export RELAY_CACHE_EVICT_INTERVAL_SECS="${RELAY_CACHE_EVICT_INTERVAL_SECS:-1}"
+LOGS_PID=""
+
+cleanup() {
+  if [[ -n "$LOGS_PID" ]]; then
+    kill "$LOGS_PID" 2>/dev/null || true
+    for _ in {1..10}; do
+      if ! kill -0 "$LOGS_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.1
+    done
+    kill -9 "$LOGS_PID" 2>/dev/null || true
+  fi
+  docker compose down -v --remove-orphans
+}
+trap cleanup EXIT
+
+node scripts/ensure-relay-certs.mjs
+
+# Reuse a prebuilt relay image when present (pulled from the registry in CI);
+# otherwise build it locally.
+if docker image inspect moqt-relay:local >/dev/null 2>&1; then
+  echo "Reusing existing moqt-relay:local image (skipping build)."
+else
+  docker compose build relay-common
+fi
+# cache-eviction-e2e talks to a single relay, so only relay-a (and its redis) is needed.
+docker compose up -d redis relay-a
+docker compose logs -f --no-color relay-a &
+LOGS_PID=$!
+
+# The client asserts object-TTL and strong_count reclaim and panics/exits
+# non-zero on mismatch, so a non-zero exit is the only failure signal needed.
+cargo run -p cache-eviction-e2e

--- a/tests/cache-eviction-e2e/Cargo.toml
+++ b/tests/cache-eviction-e2e/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cache-eviction-e2e"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+moqt = { path = "../../moqt" }
+tokio = { version = "1.52.3", features = ["full", "tracing"] }
+tracing = "0.1.44"
+anyhow = { version = "1.0.102", features = ["backtrace"] }
+url = "2.5.8"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/tests/cache-eviction-e2e/src/main.rs
+++ b/tests/cache-eviction-e2e/src/main.rs
@@ -1,0 +1,252 @@
+//! E2E for the relay's cache eviction (TTL object drain + strong_count track reclaim).
+//!
+//! Two independent tracks exercise the two eviction mechanisms. FETCH reads the
+//! relay's object cache directly, so "present vs gone" is observed by fetching.
+//!
+//!   Phase A (object TTL + closed-group reclaim):
+//!     A publisher sends one closed group (o0..o4) on track A. A live subscriber
+//!     (Carol) stays connected to keep the track alive (strong_count >= 2).
+//!       - fetch A/g0 right away          -> 5 objects (cached)
+//!       - fetch A/g0 before TTL          -> 5 objects (not removed early)
+//!       - fetch A/g0 after TTL+interval  -> 0 objects, but the fetch still
+//!         succeeds because the track (held by Carol) is alive; only the
+//!         closed, drained group was reclaimed.
+//!
+//!   Phase B (strong_count track reclaim):
+//!     A publisher sends one closed group on track B. A subscriber (Bob) triggers
+//!     the publish and holds the track during the baseline fetch, then leaves.
+//!       - fetch B/g0 while Bob holds it  -> 5 objects
+//!       - after Bob leaves, wait > interval but < TTL
+//!       - fetch B/g0                     -> FETCH error (TrackNotFound): the
+//!         whole track was reclaimed while its objects were still within TTL,
+//!         which only strong_count reclaim (not object TTL) can explain.
+//!
+//! Run a relay on localhost:4433 with a short TTL, then `cargo run -p
+//! cache-eviction-e2e` from the repo root:
+//!
+//!   RELAY_CACHE_TTL_SECS=5 RELAY_CACHE_EVICT_INTERVAL_SECS=1 cargo run -p relay
+//!   cargo run -p cache-eviction-e2e
+//!
+//! The client sleeps below assume TTL=5s / interval=1s.
+
+use std::net::ToSocketAddrs;
+use std::str::FromStr;
+use std::time::Duration;
+
+use moqt::{
+    ClientConfig, ContentExists, Endpoint, ExtensionHeaders, Fetch, FetchDataReceiver, FetchOption,
+    FilterType, GroupOrder, Location, QUIC, Session, StreamDataSenderFactory, SubgroupId,
+    SubgroupObject, SubscribeOption,
+};
+
+const RELAY_URL: &str = "moqt://localhost:4433";
+const NAMESPACE_A: &str = "evict/a";
+const NAMESPACE_B: &str = "evict/b";
+const TRACK_NAME: &str = "data";
+const PUBLISHER_PRIORITY: u8 = 128;
+const OBJECTS_PER_GROUP: u64 = 5;
+
+async fn new_session() -> anyhow::Result<Session<QUIC>> {
+    let url = url::Url::from_str(RELAY_URL).unwrap();
+    let host = url.host_str().unwrap();
+    let remote = (host, url.port().unwrap_or(4433))
+        .to_socket_addrs()?
+        .next()
+        .unwrap();
+    let endpoint = Endpoint::<QUIC>::create_client(&ClientConfig {
+        port: 0,
+        verify_certificate: false,
+    })?;
+    let connecting = endpoint.connect(remote, host).await?;
+    connecting.await
+}
+
+/// Publishes one closed group (o0..o4) whenever a subscribe arrives, then keeps
+/// the session alive as the upstream publisher.
+async fn publisher(namespace: &'static str) -> anyhow::Result<()> {
+    let session = new_session().await?;
+    session
+        .publisher()
+        .publish_namespace(namespace.to_string())
+        .await?;
+    tracing::info!("[pub {}] publish_namespace ok", namespace);
+
+    loop {
+        match session.receive_event().await? {
+            moqt::SessionEvent::Subscribe(handler) => {
+                let track_alias = handler.ok(0, ContentExists::False).await?;
+                let publication = handler.into_subscription(track_alias);
+                let factory = session.publisher().create_stream(&publication);
+                send_group(&factory, 0).await?;
+                tracing::info!("[pub {}] group 0 published and closed", namespace);
+            }
+            moqt::SessionEvent::Disconnected() => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+async fn send_group(factory: &StreamDataSenderFactory<QUIC>, group_id: u64) -> anyhow::Result<()> {
+    let sender = factory.next().await?;
+    let header = sender.create_header(group_id, SubgroupId::None, PUBLISHER_PRIORITY, false, false);
+    let mut stream = sender.send_header(header).await?;
+    for obj_id in 0..OBJECTS_PER_GROUP {
+        let payload = format!("g{}:o{}", group_id, obj_id);
+        let obj = stream.create_object_field(
+            0,
+            ExtensionHeaders {
+                prior_group_id_gap: vec![],
+                prior_object_id_gap: vec![],
+                immutable_extensions: vec![],
+            },
+            SubgroupObject::new_payload(payload.into()),
+        );
+        stream.send(obj).await?;
+    }
+    // Closing the stream FINs the subgroup, so the relay marks the group closed.
+    stream.close().await
+}
+
+/// Subscribes live and returns the owning session so the caller controls when
+/// the subscription (and thus the relay-side `Arc<TrackCache>`) is released.
+async fn subscribe_live(namespace: &str) -> anyhow::Result<Session<QUIC>> {
+    let session = new_session().await?;
+    let mut subscriber = session.subscriber();
+    subscriber
+        .subscribe(
+            namespace.to_string(),
+            TRACK_NAME.to_string(),
+            SubscribeOption {
+                subscriber_priority: 128,
+                group_order: GroupOrder::Ascending,
+                forward: true,
+                filter_type: FilterType::LargestObject,
+            },
+        )
+        .await?;
+    tracing::info!("[sub {}] subscribe ok", namespace);
+    Ok(session)
+}
+
+/// Fetches the whole of `group_id` on a fresh, short-lived session and returns
+/// the received (group_id, object_id) pairs. A relay FETCH error (e.g. the
+/// track was reclaimed) surfaces as `Err`.
+async fn fetch_group(namespace: &str, group_id: u64) -> anyhow::Result<Vec<(u64, u64)>> {
+    let session = new_session().await?;
+    let mut subscriber = session.subscriber();
+    // start = {g, 0}, end = {g, 0}: end object_id 0 means the entire group.
+    let handle = subscriber
+        .fetch(
+            namespace.to_string(),
+            TRACK_NAME.to_string(),
+            Location {
+                group_id,
+                object_id: 0,
+            },
+            Location {
+                group_id,
+                object_id: 0,
+            },
+            FetchOption::default(),
+        )
+        .await?;
+    let mut receiver: FetchDataReceiver<QUIC> = subscriber.accept_fetch_receiver(&handle).await?;
+    let mut received = Vec::new();
+    loop {
+        match receiver.receive().await {
+            Ok(Fetch::Header(_)) => {}
+            Ok(Fetch::Object(obj)) => received.push((obj.group_id, obj.object_id)),
+            Ok(Fetch::End) => break,
+            Err(e) => return Err(anyhow::anyhow!("fetch receive failed: {}", e)),
+        }
+    }
+    Ok(received)
+}
+
+fn full_group(group_id: u64) -> Vec<(u64, u64)> {
+    (0..OBJECTS_PER_GROUP).map(|o| (group_id, o)).collect()
+}
+
+async fn run_scenario() -> anyhow::Result<()> {
+    // Publishers register their namespaces and publish on demand.
+    tokio::spawn(publisher(NAMESPACE_A));
+    tokio::spawn(publisher(NAMESPACE_B));
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // ---- Phase A: object TTL + closed-group reclaim (track kept alive) ----
+    let carol = subscribe_live(NAMESPACE_A).await?;
+    tokio::time::sleep(Duration::from_millis(800)).await; // let group 0 publish
+
+    let baseline = fetch_group(NAMESPACE_A, 0).await?;
+    assert_eq!(
+        baseline,
+        full_group(0),
+        "[A] group 0 must be cached initially"
+    );
+    tracing::info!("[A] baseline: 5 objects cached");
+
+    tokio::time::sleep(Duration::from_secs(2)).await; // still < TTL
+    let before_ttl = fetch_group(NAMESPACE_A, 0).await?;
+    assert_eq!(
+        before_ttl,
+        full_group(0),
+        "[A] group 0 must still be present before TTL"
+    );
+    tracing::info!("[A] before TTL: still 5 objects (not removed early)");
+
+    tokio::time::sleep(Duration::from_secs(4)).await; // now past TTL + interval
+    let after_ttl = fetch_group(NAMESPACE_A, 0).await?;
+    assert!(
+        after_ttl.is_empty(),
+        "[A] group 0 objects must be evicted by TTL, got {:?}",
+        after_ttl
+    );
+    tracing::info!("[A] after TTL: 0 objects, but fetch still resolved (track alive) — OK");
+
+    drop(carol); // release the track for good measure
+
+    // ---- Phase B: strong_count track reclaim (no holders, before TTL) ----
+    let bob = subscribe_live(NAMESPACE_B).await?;
+    tokio::time::sleep(Duration::from_millis(800)).await; // let group 0 publish
+
+    let baseline_b = fetch_group(NAMESPACE_B, 0).await?;
+    assert_eq!(
+        baseline_b,
+        full_group(0),
+        "[B] group 0 must be cached while Bob holds the track"
+    );
+    tracing::info!("[B] baseline: 5 objects cached");
+
+    drop(bob); // now nobody holds the track (strong_count -> 1)
+    tokio::time::sleep(Duration::from_secs(3)).await; // > interval, still < TTL
+
+    match fetch_group(NAMESPACE_B, 0).await {
+        Err(e) => {
+            tracing::info!(
+                "[B] after Bob left: fetch errored ({}) — track reclaimed, OK",
+                e
+            );
+        }
+        Ok(objects) => {
+            anyhow::bail!(
+                "[B] track should have been reclaimed by strong_count, but fetch returned {:?}",
+                objects
+            );
+        }
+    }
+
+    tracing::info!("ALL OK: object TTL and strong_count reclaim both verified");
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_line_number(true)
+        .try_init()
+        .ok();
+
+    run_scenario().await
+}


### PR DESCRIPTION
## 概要
Relay のキャッシュは削除の仕組みがないため、起動し続けているとメモリが無限に肥大する。

定期ジョブで object, group, track を削除するようにした。

## 削除ロジック
- **Object**: 挿入時刻から TTL 超過で削除
- **Group**: **close 済みかつ空**で削除
  - FIN を送らないクライアントでも、切断/reset/エラーで close されるので leak しない
- **Track**: CacheStore以外に参照がいなければ削除

## テスト
- 各 cache 層の unit テスト
- `tests/cache-eviction-e2e`: CIに短縮TTLで組み込み済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)