### PR TITLE
feat(examples): support local docker relay presets

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/run-call-e2e.mjs"
       - "scripts/media-e2e-helpers.mjs"
       - "scripts/ensure-relay-certs.mjs"
+      - "scripts/resolve-local-relay-url.mjs"
       - "scripts/chrome_linux.sh"
       - "scripts/cache-eviction-e2e.sh"
       - "scripts/cascading-relay-e2e.sh"
@@ -47,6 +48,7 @@ on:
       - "scripts/run-call-e2e.mjs"
       - "scripts/media-e2e-helpers.mjs"
       - "scripts/ensure-relay-certs.mjs"
+      - "scripts/resolve-local-relay-url.mjs"
       - "scripts/chrome_linux.sh"
       - "scripts/cache-eviction-e2e.sh"
       - "scripts/cascading-relay-e2e.sh"
@@ -130,43 +132,43 @@ jobs:
 
             while IFS= read -r path; do
               case "$path" in
-                .github/workflows/e2e.yml|.github/actions/setup-wasm-pack/*|README.md|scripts/setup-media-e2e.mjs|scripts/run-media-e2e.mjs|scripts/media-e2e-helpers.mjs|scripts/ensure-relay-certs.mjs|scripts/chrome_linux.sh|examples/browser/*|bindings/wasm/*|relay/*|moqt/*|shared/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                .github/workflows/e2e.yml|.github/actions/setup-wasm-pack/*|README.md|scripts/setup-media-e2e.mjs|scripts/run-media-e2e.mjs|scripts/media-e2e-helpers.mjs|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|scripts/chrome_linux.sh|examples/browser/*|bindings/wasm/*|relay/*|moqt/*|shared/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   media=true
                   ;;
               esac
 
               case "$path" in
-                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|.github/actions/setup-wasm-pack/*|scripts/setup-media-e2e.mjs|scripts/run-call-e2e.mjs|scripts/media-e2e-helpers.mjs|scripts/ensure-relay-certs.mjs|scripts/chrome_linux.sh|docker-compose.yml|examples/browser/*|bindings/wasm/*|relay/*|moqt/*|shared/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|.github/actions/setup-wasm-pack/*|scripts/setup-media-e2e.mjs|scripts/run-call-e2e.mjs|scripts/media-e2e-helpers.mjs|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|scripts/chrome_linux.sh|docker-compose.yml|examples/browser/*|bindings/wasm/*|relay/*|moqt/*|shared/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   call=true
                   ;;
               esac
 
               case "$path" in
-                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/cascading-relay-e2e.sh|scripts/ensure-relay-certs.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/cascading-relay-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/cascading-relay-e2e.sh|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/cascading-relay-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   cascading=true
                   ;;
               esac
 
               case "$path" in
-                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/cache-eviction-e2e.sh|scripts/ensure-relay-certs.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/cache-eviction-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/cache-eviction-e2e.sh|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/cache-eviction-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   cache_eviction=true
                   ;;
               esac
 
               case "$path" in
-                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/fetch-e2e.sh|scripts/ensure-relay-certs.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/fetch-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/fetch-e2e.sh|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/fetch-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   fetch=true
                   ;;
               esac
 
               case "$path" in
-                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/multiple-publishers-e2e.sh|scripts/ensure-relay-certs.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/multiple-publishers-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/multiple-publishers-e2e.sh|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/multiple-publishers-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   multipub=true
                   ;;
               esac
 
               case "$path" in
-                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/object-dedup-e2e.sh|scripts/ensure-relay-certs.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/object-dedup-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                .github/workflows/e2e.yml|.github/workflows/relay-image.yml|scripts/object-dedup-e2e.sh|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|docker-compose.yml|relay/*|moqt/*|shared/*|tests/object-dedup-e2e/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   dedup=true
                   ;;
               esac

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ export RUSTFLAGS := --cfg tokio_unstable --cfg web_sys_unstable_apis --remap-pat
 
 -include .env
 
+LOCAL_MOQT_URL ?= $(shell node scripts/resolve-local-relay-url.mjs "$(MOQT_URL)")
+LIVE_INGEST_MOQT_URL ?= $(LOCAL_MOQT_URL)
+ONVIF_MOQT_URL ?= $(LOCAL_MOQT_URL)
+
 .PHONY: relay browser chrome chrome\:linux live-ingest onvif onvif-controller ffmpeg-rtmp test lint format relay-certs browser-e2e-media browser-e2e-call browser-e2e-call-headed
 
 # Applications
@@ -19,10 +23,11 @@ chrome\:linux:
 
 # RTMP/SRT Bridges
 live-ingest:
+	@echo "Using MoQT relay URL: $(LIVE_INGEST_MOQT_URL)"
 	RUSTFLAGS="$(RUSTFLAGS)" cargo run -p moqt-bridge-live-ingest -- \
 		--rtmp-addr 0.0.0.0:1935 \
 		--srt-addr 0.0.0.0:9000 \
-		--moqt-url https://127.0.0.1:4433
+		--moqt-url $(LIVE_INGEST_MOQT_URL)
 
 ## Media helpers
 relay-certs:
@@ -43,11 +48,18 @@ onvif:
 		echo "ONVIF_IP/ONVIF_USERNAME/ONVIF_PASSWORD are required (set in .env or environment)"; \
 		exit 1; \
 	fi
+	@echo "Using MoQT relay URL: $(ONVIF_MOQT_URL)"
 	RUSTFLAGS="$(RUSTFLAGS)" cargo run -p moqt-bridge-onvif --bin moqt-onvif-client -- \
 		--ip $(ONVIF_IP) \
 		--username $(ONVIF_USERNAME) \
 		--password $(ONVIF_PASSWORD) \
-		--moqt-url $(MOQT_URL) \
+		--moqt-url $(ONVIF_MOQT_URL) \
+		--publish-namespace onvif/client \
+		--subscribe-namespace onvif/viewer \
+		--video-track video \
+		--audio-track audio \
+		--catalog-track catalog \
+		--command-track command \
 		--dump-keyframe \
 		--payload-format avcc \
 		--insecure-skip-tls-verify

--- a/bridges/live-ingest/README.md
+++ b/bridges/live-ingest/README.md
@@ -11,7 +11,15 @@ make live-ingest
 ```
 
 `make live-ingest` listens for RTMP on `0.0.0.0:1935`, listens for SRT on
-`0.0.0.0:9000`, and publishes to `https://127.0.0.1:4433`.
+`0.0.0.0:9000`, and publishes to the local MoQT relay. On macOS with the
+Docker Compose relay running, the relay URL is resolved to the Docker Desktop
+bridge host automatically.
+
+Override the relay URL when needed:
+
+```shell
+LIVE_INGEST_MOQT_URL=https://relay.example.com:443 make live-ingest
+```
 
 ## Publish Test RTMP
 

--- a/bridges/onvif/README.md
+++ b/bridges/onvif/README.md
@@ -31,6 +31,25 @@ make onvif
 
 `make onvif` publishes RTSP video/audio as profile-specific MoQT tracks and subscribes to ONVIF command datagrams.
 
+When `MOQT_URL` points to `localhost` or `127.0.0.1` and the docker compose `relay-a`
+service is running, `make onvif` rewrites the relay URL to the Docker Desktop bridge
+host used by native Rust clients. Override the resolved URL with `ONVIF_MOQT_URL`, or
+set `MOQT_DOCKER_RELAY_HOST`/`LOCAL_RELAY_HOST` to force a specific relay host.
+
+## MoQT Track Layout
+
+`make onvif` publishes to namespace `onvif/client` and subscribes to commands from namespace `onvif/viewer`.
+
+| Role                    | Namespace      | Track name        |
+| ----------------------- | -------------- | ----------------- |
+| Catalog                 | `onvif/client` | `catalog`         |
+| Video (profile N)       | `onvif/client` | `video/profile_N` |
+| Audio (profile N)       | `onvif/client` | `audio/profile_N` |
+| PTZ command (subscribe) | `onvif/viewer` | `command`         |
+
+Profile indices start at 1 and correspond to the ONVIF media profiles returned by the camera.
+All names are configurable via CLI flags (`--publish-namespace`, `--subscribe-namespace`, `--video-track`, `--audio-track`, `--catalog-track`, `--command-track`).
+
 ## Direct CLI Options
 
 Use `cargo run` directly when you need options that are not exposed by the Makefile helpers.

--- a/examples/browser/examples/call/src/components/JoinRoomForm.tsx
+++ b/examples/browser/examples/call/src/components/JoinRoomForm.tsx
@@ -1,4 +1,5 @@
-import { useState, FormEvent, ChangeEvent } from 'react'
+import { useMemo, useState, FormEvent, ChangeEvent } from 'react'
+import { CLOUD_RELAY_PRESETS, LOAD_BALANCED_RELAY_PRESET, buildLocalRelayPresets } from '../../../../utils/relayPresets'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { Label } from './ui/label'
@@ -7,58 +8,23 @@ interface JoinRoomFormProps {
   onJoin: (roomName: string, userName: string, relayUrl: string) => void
 }
 
-const RELAY_OPTION_GROUPS = [
-  {
-    label: 'Local Relay',
-    options: [
-      {
-        label: 'relay-a',
-        value: 'https://127.0.0.1:4433',
-        helper: 'Docker compose relay-a'
-      },
-      {
-        label: 'relay-b',
-        value: 'https://127.0.0.1:4434',
-        helper: 'Docker compose relay-b'
-      }
-    ]
-  },
-  {
-    label: 'Cloud (LB)',
-    options: [
-      {
-        label: 'relay.moqt.research.skyway.io',
-        value: 'https://relay.moqt.research.skyway.io:443',
-        helper: 'Load-balanced cloud relay'
-      }
-    ]
-  },
-  {
-    label: 'Cloud (specific relay)',
-    options: [
-      {
-        label: 'relay-1',
-        value: 'https://relay-1.moqt.research.skyway.io:443',
-        helper: 'relay-1.moqt.research.skyway.io:443'
-      },
-      {
-        label: 'relay-2',
-        value: 'https://relay-2.moqt.research.skyway.io:443',
-        helper: 'relay-2.moqt.research.skyway.io:443'
-      },
-      {
-        label: 'relay-3',
-        value: 'https://relay-3.moqt.research.skyway.io:443',
-        helper: 'relay-3.moqt.research.skyway.io:443'
-      }
-    ]
-  }
-] as const
+interface RelayOption {
+  label: string
+  value: string
+  helper: string
+  testId?: string
+}
+
+interface RelayOptionGroup {
+  label: string
+  options: RelayOption[]
+}
 
 export function JoinRoomForm({ onJoin }: JoinRoomFormProps) {
+  const relayOptionGroups = useMemo(() => buildRelayOptionGroups(), [])
   const [roomName, setRoomName] = useState('')
   const [userName, setUserName] = useState('')
-  const [relayUrl, setRelayUrl] = useState<string>(RELAY_OPTION_GROUPS[0].options[0].value)
+  const [relayUrl, setRelayUrl] = useState<string>(relayOptionGroups[0].options[0].value)
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
@@ -108,7 +74,7 @@ export function JoinRoomForm({ onJoin }: JoinRoomFormProps) {
           <div className="space-y-4">
             <Label className="text-2xl">Relay</Label>
             <div className="space-y-5">
-              {RELAY_OPTION_GROUPS.map((group) => (
+              {relayOptionGroups.map((group) => (
                 <fieldset key={group.label} className="space-y-3">
                   <legend className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                     {group.label}
@@ -126,13 +92,7 @@ export function JoinRoomForm({ onJoin }: JoinRoomFormProps) {
                           checked={relayUrl === option.value}
                           onChange={() => setRelayUrl(option.value)}
                           className="h-5 w-5 shrink-0 accent-blue-600"
-                          data-testid={
-                            option.value === 'https://127.0.0.1:4433'
-                              ? 'join-relay-a-radio'
-                              : option.value === 'https://127.0.0.1:4434'
-                                ? 'join-relay-b-radio'
-                                : undefined
-                          }
+                          data-testid={option.testId}
                         />
                         <div className="min-w-0">
                           <div className="font-semibold">{option.label}</div>
@@ -158,4 +118,21 @@ export function JoinRoomForm({ onJoin }: JoinRoomFormProps) {
       </div>
     </div>
   )
+}
+
+function buildRelayOptionGroups(): RelayOptionGroup[] {
+  return [
+    {
+      label: 'Local Relay',
+      options: buildLocalRelayPresets()
+    },
+    {
+      label: 'Cloud (LB)',
+      options: [LOAD_BALANCED_RELAY_PRESET]
+    },
+    {
+      label: 'Cloud (specific relay)',
+      options: CLOUD_RELAY_PRESETS
+    }
+  ]
 }

--- a/examples/browser/examples/media-cmaf/index.html
+++ b/examples/browser/examples/media-cmaf/index.html
@@ -26,5 +26,6 @@
         </a>
       </main>
     </div>
+    <script type="module" src="../../utils/preserveQueryLinks.js"></script>
   </body>
 </html>

--- a/examples/browser/examples/media-cmaf/publisher/main.ts
+++ b/examples/browser/examples/media-cmaf/publisher/main.ts
@@ -3,6 +3,7 @@ import type { MOQTClient } from '../../../pkg/moqt_client_wasm'
 import { AUTH_INFO, CMAF_FPS } from '../const'
 import { getFormElement } from '../utils'
 import { MediaTransportState } from '../../../utils/media/transportState'
+import { configureRelayUrlControls } from '../../../utils/relayPresets'
 import { MEDIA_VIDEO_PROFILES, MEDIA_AUDIO_PROFILES, MEDIA_CATALOG_TRACK_NAME, buildCmafCatalogJson } from '../catalog'
 import {
   Output,
@@ -417,6 +418,7 @@ const setupCloseButtonHandler = (): void => {
   })
 }
 
+configureRelayUrlControls()
 setUpStartGetUserMediaButton()
 setupMoqSendVisualizationButton()
 setupClientCallbacks()

--- a/examples/browser/examples/media-cmaf/subscriber/main.ts
+++ b/examples/browser/examples/media-cmaf/subscriber/main.ts
@@ -3,6 +3,7 @@ import { parse_msf_catalog_json } from '../../../pkg/moqt_client_wasm'
 import { AUTH_INFO } from '../const'
 import { getFormElement } from '../utils'
 import { extractCatalogVideoTracks, extractCatalogAudioTracks, type MediaCatalogTrack } from '../catalog'
+import { configureRelayUrlControls } from '../../../utils/relayPresets'
 
 const moqtClient = new MoqtClientWrapper()
 
@@ -871,6 +872,8 @@ moqtClient.setOnSubscribeResponseHandler((subscribeResponse) => {
 })
 
 // --- Init ---
+
+configureRelayUrlControls()
 
 const connectBtn = document.getElementById('connectBtn') as HTMLButtonElement
 connectBtn.addEventListener('click', async () => {

--- a/examples/browser/examples/media/common.ts
+++ b/examples/browser/examples/media/common.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_MOQT_URL = 'https://relay-1.moqt.research.skyway.io:443'
+import { DEFAULT_CLOUD_RELAY_URL, configureRelayUrlControls } from '../../utils/relayPresets'
+
+export const DEFAULT_MOQT_URL = DEFAULT_CLOUD_RELAY_URL
 export type MediaVideoHardwareAcceleration = 'prefer-hardware' | 'prefer-software' | 'no-preference'
 
 export type MediaVideoEncodingOverrides = {
@@ -7,8 +9,7 @@ export type MediaVideoEncodingOverrides = {
 }
 
 export function initializeMediaExamplePage(namespaceInputId: string): void {
-  bindUrlPresetButtons()
-  applyUrlOverride()
+  configureRelayUrlControls({ defaultUrl: DEFAULT_MOQT_URL })
   applyNamespaceOverride(namespaceInputId)
 }
 
@@ -54,36 +55,6 @@ export function getMediaVideoEncodingOverrides(): MediaVideoEncodingOverrides {
     codec: codec ?? undefined,
     hardwareAcceleration
   }
-}
-
-function bindUrlPresetButtons(): void {
-  const preset = document.getElementById('urlPresets')
-  const input = document.getElementById('url')
-  if (!(preset instanceof HTMLElement) || !(input instanceof HTMLInputElement)) {
-    return
-  }
-
-  preset.addEventListener('click', (event) => {
-    const target = event.target
-    if (!(target instanceof HTMLButtonElement)) {
-      return
-    }
-    const value = target.getAttribute('data-url')
-    if (!value) {
-      return
-    }
-    input.value = value
-  })
-}
-
-function applyUrlOverride(): void {
-  const input = document.getElementById('url')
-  if (!(input instanceof HTMLInputElement)) {
-    return
-  }
-
-  const params = new URLSearchParams(window.location.search)
-  input.value = firstNonEmptyValue(params, ['moqtUrl', 'url']) ?? (input.value.trim() || DEFAULT_MOQT_URL)
 }
 
 function applyNamespaceOverride(namespaceInputId: string): void {

--- a/examples/browser/examples/media/index.html
+++ b/examples/browser/examples/media/index.html
@@ -26,5 +26,6 @@
         </a>
       </main>
     </div>
+    <script type="module" src="../../utils/preserveQueryLinks.js"></script>
   </body>
 </html>

--- a/examples/browser/examples/message/main.ts
+++ b/examples/browser/examples/message/main.ts
@@ -10,6 +10,7 @@ import {
   SubscribeOkMessage
 } from '../../pkg/moqt_client_wasm'
 import { MoqtClientWrapper } from '../../lib/moqt/moqtClient'
+import { configureRelayUrlControls } from '../../utils/relayPresets'
 
 type HTMLFormControls = HTMLFormElement & {
   elements: HTMLFormControlsCollection
@@ -593,6 +594,7 @@ function setupActionButtons(): void {
   })
 }
 
+configureRelayUrlControls()
 setupConnectButton()
 setupCloseButton()
 setupActionButtons()

--- a/examples/browser/examples/onvif/main.ts
+++ b/examples/browser/examples/onvif/main.ts
@@ -1,6 +1,7 @@
 import { MoqtClientWrapper } from '@moqt/moqtClient'
 import { parse_msf_catalog_json } from '../../pkg/moqt_client_wasm'
 import type { MOQTClient } from '../../pkg/moqt_client_wasm'
+import { configureRelayUrlControls } from '../../utils/relayPresets'
 
 const moqtClient = new MoqtClientWrapper()
 let audioDecoderWorker: Worker | null = null
@@ -1152,14 +1153,10 @@ function buildCommandUI(): void {
 function setupUrlPresets(): void {
   const urlInput = document.getElementById('moqt-url') as HTMLInputElement | null
   if (!urlInput) return
-  const buttons = document.querySelectorAll<HTMLButtonElement>('button[data-url]')
-  buttons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const url = button.dataset.url
-      if (url) {
-        urlInput.value = url
-      }
-    })
+  const presetContainer = urlInput.closest('form')?.querySelector<HTMLElement>('.button-row')
+  configureRelayUrlControls({
+    input: urlInput,
+    presetContainer
   })
 }
 

--- a/examples/browser/examples/remote-monitoring/src/types/monitoring.ts
+++ b/examples/browser/examples/remote-monitoring/src/types/monitoring.ts
@@ -1,3 +1,5 @@
+import { buildRelayPresets } from '../../../../utils/relayPresets'
+
 export type CameraId = 'cam01' | 'cam02' | 'cam03' | 'cam04'
 export type MonitorMode = 'live' | 'review'
 export type ConnState = 'connected' | 'closed'
@@ -10,9 +12,4 @@ export interface VideoSource {
 
 export const ALL_CAMERA_IDS: CameraId[] = ['cam01', 'cam02', 'cam03', 'cam04']
 
-export const RELAY_PRESETS = [
-  { label: 'Local', value: 'https://127.0.0.1:4433' },
-  { label: 'Relay 1', value: 'https://relay-1.moqt.research.skyway.io:443' },
-  { label: 'Relay 2', value: 'https://relay-2.moqt.research.skyway.io:443' },
-  { label: 'Relay 3', value: 'https://relay-3.moqt.research.skyway.io:443' }
-] as const
+export const RELAY_PRESETS = buildRelayPresets()

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -255,5 +255,6 @@
 
       <p class="note">Tip: 低遅延検証では、まず WebCodecs → Media → Call の順で切り分けると原因特定が速くなります。</p>
     </main>
+    <script type="module" src="./utils/preserveQueryLinks.js"></script>
   </body>
 </html>

--- a/examples/browser/playwright.config.ts
+++ b/examples/browser/playwright.config.ts
@@ -6,6 +6,14 @@ ensureLinuxEnvironment()
 const certificateSpki = computeCertificateSpkiBase64()
 const fakeVideoPath = ensureFakeVideoCaptureFile()
 const baseURL = process.env.MEDIA_E2E_BASE_URL ?? 'http://127.0.0.1:4173'
+const forceQuicOrigins = [
+  process.env.CALL_E2E_RELAY_A_URL ?? 'https://127.0.0.1:4433',
+  process.env.CALL_E2E_RELAY_B_URL ?? 'https://127.0.0.1:4434',
+  process.env.MEDIA_E2E_MOQT_URL ?? 'https://127.0.0.1:4433'
+]
+  .map(toHttp3Authority)
+  .filter((origin, index, origins) => origins.indexOf(origin) === index)
+
 export default defineConfig({
   testDir: './tests',
   testMatch: /(media-e2e|call-e2e)\.spec\.ts/,
@@ -24,8 +32,8 @@ export default defineConfig({
     permissions: ['camera', 'microphone'],
     launchOptions: {
       args: [
-        // Force QUIC on both relays (relay-a at 4433, relay-b at 4434).
-        '--origin-to-force-quic-on=127.0.0.1:4433,127.0.0.1:4434',
+        // Force QUIC on the relay origins used by the E2E runners.
+        `--origin-to-force-quic-on=${forceQuicOrigins.join(',')}`,
         `--ignore-certificate-errors-spki-list=${certificateSpki}`,
         // Fallback for environments where SPKI pinning alone is insufficient.
         '--ignore-certificate-errors',
@@ -39,3 +47,7 @@ export default defineConfig({
     video: 'retain-on-failure'
   }
 })
+
+function toHttp3Authority(url: string): string {
+  return new URL(url).host
+}

--- a/examples/browser/tests/call-e2e-arrange.ts
+++ b/examples/browser/tests/call-e2e-arrange.ts
@@ -1,8 +1,8 @@
 import { expect, type Browser, type BrowserContext, type Locator, type Page } from '@playwright/test'
 import { CALL_INDEX_PATH } from '../playwright.helpers'
 
-export const RELAY_A_URL = 'https://127.0.0.1:4433'
-export const RELAY_B_URL = 'https://127.0.0.1:4434'
+export const RELAY_A_URL = process.env.CALL_E2E_RELAY_A_URL ?? 'https://127.0.0.1:4433'
+export const RELAY_B_URL = process.env.CALL_E2E_RELAY_B_URL ?? 'https://127.0.0.1:4434'
 
 export interface CallClientPageModel {
   page: Page
@@ -43,6 +43,8 @@ async function openCallPage(page: Page): Promise<void> {
     e2eVideoHeight: String(E2E_VIDEO_HEIGHT),
     e2eVideoFramerate: String(E2E_VIDEO_FRAMERATE),
     e2eVideoBitrate: String(E2E_VIDEO_BITRATE),
+    relayAUrl: RELAY_A_URL,
+    relayBUrl: RELAY_B_URL,
     debugVideoPipeline: '1'
   })
   await page.goto(`${CALL_INDEX_PATH}?${params.toString()}`, { waitUntil: 'domcontentloaded' })

--- a/examples/browser/utils/preserveQueryLinks.js
+++ b/examples/browser/utils/preserveQueryLinks.js
@@ -1,0 +1,20 @@
+const sourceEntries = Array.from(new URLSearchParams(window.location.search).entries())
+
+if (sourceEntries.length > 0) {
+  document.querySelectorAll('a[href]').forEach((link) => {
+    const href = link.getAttribute('href')
+    if (!href || href.startsWith('#')) {
+      return
+    }
+
+    const url = new URL(href, window.location.href)
+    if (url.origin !== window.location.origin) {
+      return
+    }
+
+    for (const [name, value] of sourceEntries) {
+      url.searchParams.set(name, value)
+    }
+    link.href = url.toString()
+  })
+}

--- a/examples/browser/utils/relayPresets.ts
+++ b/examples/browser/utils/relayPresets.ts
@@ -1,0 +1,187 @@
+export const DEFAULT_CLOUD_RELAY_URL = 'https://relay-1.moqt.research.skyway.io:443'
+export const DEFAULT_LOCAL_RELAY_A_URL = 'https://127.0.0.1:4433'
+export const DEFAULT_LOCAL_RELAY_B_URL = 'https://127.0.0.1:4434'
+
+export type RelayPreset = {
+  label: string
+  value: string
+  helper: string
+  testId?: string
+}
+
+export const CLOUD_RELAY_PRESETS: RelayPreset[] = [
+  {
+    label: 'relay-1',
+    value: 'https://relay-1.moqt.research.skyway.io:443',
+    helper: 'relay-1.moqt.research.skyway.io:443'
+  },
+  {
+    label: 'relay-2',
+    value: 'https://relay-2.moqt.research.skyway.io:443',
+    helper: 'relay-2.moqt.research.skyway.io:443'
+  },
+  {
+    label: 'relay-3',
+    value: 'https://relay-3.moqt.research.skyway.io:443',
+    helper: 'relay-3.moqt.research.skyway.io:443'
+  }
+]
+
+export const LOAD_BALANCED_RELAY_PRESET: RelayPreset = {
+  label: 'relay.moqt.research.skyway.io',
+  value: 'https://relay.moqt.research.skyway.io:443',
+  helper: 'Load-balanced cloud relay'
+}
+
+const DEFAULT_RELAY_URL_PARAM_NAMES = ['relayUrl', 'moqtUrl', 'url', 'relay'] as const
+
+type RelayUrlControlsOptions = {
+  inputId?: string
+  presetContainerId?: string
+  input?: HTMLInputElement | null
+  presetContainer?: HTMLElement | null
+  defaultUrl?: string
+  queryParamNames?: readonly string[]
+  includeRelayB?: boolean
+}
+
+export function getLocalRelayUrls(): { relayAUrl: string; relayBUrl: string } {
+  return {
+    relayAUrl: readRelayUrlSearchParam(['relayAUrl', ...DEFAULT_RELAY_URL_PARAM_NAMES]) ?? DEFAULT_LOCAL_RELAY_A_URL,
+    relayBUrl: readRelayUrlSearchParam(['relayBUrl']) ?? DEFAULT_LOCAL_RELAY_B_URL
+  }
+}
+
+export function getPrimaryRelayUrl(fallback = DEFAULT_CLOUD_RELAY_URL): string {
+  return readRelayUrlSearchParam(DEFAULT_RELAY_URL_PARAM_NAMES) ?? fallback
+}
+
+export function readRelayUrlSearchParam(paramNames: readonly string[]): string | null {
+  const params = getSearchParams()
+  for (const name of paramNames) {
+    const value = params.get(name)?.trim()
+    if (value) {
+      return value
+    }
+  }
+  return null
+}
+
+export function buildLocalRelayPresets(): RelayPreset[] {
+  const { relayAUrl, relayBUrl } = getLocalRelayUrls()
+  return [
+    {
+      label: 'relay-a',
+      value: relayAUrl,
+      helper: `Docker compose relay-a (${relayAUrl})`,
+      testId: 'join-relay-a-radio'
+    },
+    {
+      label: 'relay-b',
+      value: relayBUrl,
+      helper: `Docker compose relay-b (${relayBUrl})`,
+      testId: 'join-relay-b-radio'
+    }
+  ]
+}
+
+export function buildRelayPresets(): RelayPreset[] {
+  return [...buildLocalRelayPresets(), LOAD_BALANCED_RELAY_PRESET, ...CLOUD_RELAY_PRESETS]
+}
+
+export function configureRelayUrlControls({
+  inputId = 'url',
+  presetContainerId = 'urlPresets',
+  input = getInput(inputId),
+  presetContainer = document.getElementById(presetContainerId),
+  defaultUrl = DEFAULT_CLOUD_RELAY_URL,
+  queryParamNames = DEFAULT_RELAY_URL_PARAM_NAMES,
+  includeRelayB = true
+}: RelayUrlControlsOptions = {}): void {
+  if (!input) {
+    return
+  }
+
+  input.value = readRelayUrlSearchParam(queryParamNames) ?? (input.value.trim() || defaultUrl)
+
+  if (!presetContainer) {
+    return
+  }
+
+  const { relayAUrl, relayBUrl } = getLocalRelayUrls()
+  upsertLocalRelayButton(presetContainer, {
+    presetId: 'relay-a',
+    fallbackValue: DEFAULT_LOCAL_RELAY_A_URL,
+    label: 'Local relay-a',
+    value: relayAUrl
+  })
+  if (includeRelayB) {
+    upsertLocalRelayButton(presetContainer, {
+      presetId: 'relay-b',
+      fallbackValue: DEFAULT_LOCAL_RELAY_B_URL,
+      label: 'Local relay-b',
+      value: relayBUrl
+    })
+  }
+
+  presetContainer.addEventListener('click', (event) => {
+    const target = event.target
+    if (!(target instanceof Element)) {
+      return
+    }
+    const button = target.closest<HTMLButtonElement>('button[data-url]')
+    const value = button?.dataset.url?.trim()
+    if (!value) {
+      return
+    }
+    input.value = value
+  })
+}
+
+function upsertLocalRelayButton(
+  container: HTMLElement,
+  {
+    presetId,
+    fallbackValue,
+    label,
+    value
+  }: {
+    presetId: string
+    fallbackValue: string
+    label: string
+    value: string
+  }
+): void {
+  let button = container.querySelector<HTMLButtonElement>(`button[data-relay-preset="${presetId}"]`)
+  if (!button) {
+    button =
+      Array.from(container.querySelectorAll<HTMLButtonElement>('button[data-url]')).find(
+        (candidate) => candidate.dataset.url === fallbackValue
+      ) ?? null
+  }
+  if (!button) {
+    button = document.createElement('button')
+    button.type = 'button'
+    button.className = firstPresetButtonClassName(container)
+    container.appendChild(button)
+  }
+  button.dataset.relayPreset = presetId
+  button.dataset.url = value
+  button.textContent = `${label}: ${value}`
+}
+
+function getInput(inputId: string): HTMLInputElement | null {
+  const input = document.getElementById(inputId)
+  return input instanceof HTMLInputElement ? input : null
+}
+
+function getSearchParams(): URLSearchParams {
+  if (typeof window === 'undefined') {
+    return new URLSearchParams()
+  }
+  return new URLSearchParams(window.location.search)
+}
+
+function firstPresetButtonClassName(container: HTMLElement): string {
+  return container.querySelector<HTMLButtonElement>('button')?.className ?? ''
+}

--- a/examples/rust/manual-client/src/client.rs
+++ b/examples/rust/manual-client/src/client.rs
@@ -7,7 +7,10 @@ use std::{
     },
 };
 
-use moqt::{DatagramField, Endpoint, Session, SubscribeOption, Subscription, TransportProtocol};
+use moqt::{
+    ClientConfig, DatagramField, Endpoint, Session, SubscribeOption, Subscription,
+    TransportProtocol,
+};
 
 use crate::stream_runner::StreamTaskRunner;
 
@@ -26,11 +29,23 @@ pub struct Client<T: TransportProtocol> {
 }
 
 impl<T: TransportProtocol> Client<T> {
-    pub async fn new(cert_path: String, label: String) -> anyhow::Result<Self> {
-        let endpoint = Endpoint::<T>::create_client_with_custom_cert(0, &cert_path)?;
-        let url = url::Url::from_str("moqt://localhost:4433")?;
+    pub async fn new(
+        cert_path: String,
+        moqt_url: String,
+        verify_certificate: bool,
+        label: String,
+    ) -> anyhow::Result<Self> {
+        let endpoint = if verify_certificate {
+            Endpoint::<T>::create_client_with_custom_cert(0, &cert_path)?
+        } else {
+            Endpoint::<T>::create_client(&ClientConfig {
+                port: 0,
+                verify_certificate: false,
+            })?
+        };
+        let url = url::Url::from_str(&moqt_url)?;
         let host = url.host_str().unwrap();
-        let remote_address = (host, url.port().unwrap_or(4433))
+        let remote_address = (host, url.port_or_known_default().unwrap_or(4433))
             .to_socket_addrs()?
             .next()
             .unwrap();

--- a/examples/rust/manual-client/src/main.rs
+++ b/examples/rust/manual-client/src/main.rs
@@ -1,18 +1,51 @@
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 use tokio::time::sleep;
+use tracing_subscriber::EnvFilter;
 
 use crate::client::Client;
 
 mod client;
 mod stream_runner;
 
+#[derive(Clone, Copy, Debug)]
+enum ManualClientTransport {
+    Quic,
+    WebTransport,
+}
+
+impl ManualClientTransport {
+    fn from_env() -> anyhow::Result<Self> {
+        match std::env::var("MOQT_TRANSPORT")
+            .unwrap_or_else(|_| "quic".to_string())
+            .trim()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "quic" | "moqt" => Ok(Self::Quic),
+            "webtransport" | "web-transport" | "wt" | "https" => Ok(Self::WebTransport),
+            value => anyhow::bail!("unsupported MOQT_TRANSPORT: {value}"),
+        }
+    }
+
+    fn default_url(self) -> &'static str {
+        match self {
+            Self::Quic => "moqt://127.0.0.1:4433",
+            Self::WebTransport => "https://127.0.0.1:4433",
+        }
+    }
+}
+
 // room/user2 is notified from `Publish Namespace`.
-fn create_client_thread(
+fn create_quic_client_thread(
     cert_path: String,
+    moqt_url: String,
+    verify_certificate: bool,
     mut signal_receiver: tokio::sync::broadcast::Receiver<()>,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     tokio::task::spawn(async move {
-        let client = Client::<moqt::QUIC>::new(cert_path, "user1".to_string()).await?;
+        let client =
+            Client::<moqt::QUIC>::new(cert_path, moqt_url, verify_certificate, "user1".to_string())
+                .await?;
         let _ = client.publish_namespace("room1/user1".to_string()).await;
         let _ = client.subscribe_namespace("room".to_string()).await;
         // client
@@ -25,13 +58,17 @@ fn create_client_thread(
 }
 
 // room/user1, room/user2 is notified from `Publish Namespace`.
-fn create_client_thread2(
+fn create_quic_client_thread2(
     cert_path: String,
+    moqt_url: String,
+    verify_certificate: bool,
     mut signal_receiver: tokio::sync::broadcast::Receiver<()>,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     tokio::task::spawn(async move {
         sleep(Duration::from_secs(5)).await;
-        let mut client = Client::<moqt::QUIC>::new(cert_path, "user2".to_string()).await?;
+        let mut client =
+            Client::<moqt::QUIC>::new(cert_path, moqt_url, verify_certificate, "user2".to_string())
+                .await?;
         let _ = client.publish_namespace("room2/user2".to_string()).await;
         let _ = client.subscribe_namespace("room1".to_string()).await;
         client
@@ -51,30 +88,131 @@ fn create_client_thread2(
     })
 }
 
+// room/user2 is notified from `Publish Namespace`.
+fn create_webtransport_client_thread(
+    cert_path: String,
+    moqt_url: String,
+    verify_certificate: bool,
+    mut signal_receiver: tokio::sync::broadcast::Receiver<()>,
+) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+    tokio::task::spawn(async move {
+        let client = Client::<moqt::WEBTRANSPORT>::new(
+            cert_path,
+            moqt_url,
+            verify_certificate,
+            "user1".to_string(),
+        )
+        .await?;
+        let _ = client.publish_namespace("room1/user1".to_string()).await;
+        let _ = client.subscribe_namespace("room".to_string()).await;
+        let _ = signal_receiver.recv().await.ok();
+        Ok(())
+    })
+}
+
+// room/user1, room/user2 is notified from `Publish Namespace`.
+fn create_webtransport_client_thread2(
+    cert_path: String,
+    moqt_url: String,
+    verify_certificate: bool,
+    mut signal_receiver: tokio::sync::broadcast::Receiver<()>,
+) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+    tokio::task::spawn(async move {
+        sleep(Duration::from_secs(5)).await;
+        let mut client = Client::<moqt::WEBTRANSPORT>::new(
+            cert_path,
+            moqt_url,
+            verify_certificate,
+            "user2".to_string(),
+        )
+        .await?;
+        let _ = client.publish_namespace("room2/user2".to_string()).await;
+        let _ = client.subscribe_namespace("room1".to_string()).await;
+        client
+            .active_subscribe(
+                "user2".to_string(),
+                "room1/user1".to_string(),
+                "video".to_string(),
+            )
+            .await;
+        let _ = signal_receiver.recv().await.ok();
+        Ok(())
+    })
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::from_str("manual_client=debug,moqt=debug").unwrap()),
+        )
         .with_line_number(true)
         .try_init()
         .ok();
 
     let current_path = std::env::current_dir().expect("failed to get current path");
     let cert_path = format!("{}{}", current_path.to_str().unwrap(), "/keys/cert.pem");
+    let transport = ManualClientTransport::from_env()?;
+    let moqt_url =
+        std::env::var("MOQT_URL").unwrap_or_else(|_| transport.default_url().to_string());
+    let verify_certificate = !env_flag("MOQT_INSECURE_SKIP_TLS_VERIFY");
     tracing::info!("cert_path: {}", cert_path);
+    tracing::info!("transport: {:?}", transport);
+    tracing::info!("moqt_url: {}", moqt_url);
+    tracing::info!("verify_certificate: {}", verify_certificate);
     let mut thread_vec = vec![];
     let (signal_sender, signal_receiver) = tokio::sync::broadcast::channel::<()>(1);
-    let thread = create_client_thread(cert_path.clone(), signal_receiver);
-    let thread2 = create_client_thread2(cert_path, signal_sender.clone().subscribe());
+    let (thread, thread2) = match transport {
+        ManualClientTransport::Quic => (
+            create_quic_client_thread(
+                cert_path.clone(),
+                moqt_url.clone(),
+                verify_certificate,
+                signal_receiver,
+            ),
+            create_quic_client_thread2(
+                cert_path,
+                moqt_url,
+                verify_certificate,
+                signal_sender.clone().subscribe(),
+            ),
+        ),
+        ManualClientTransport::WebTransport => (
+            create_webtransport_client_thread(
+                cert_path.clone(),
+                moqt_url.clone(),
+                verify_certificate,
+                signal_receiver,
+            ),
+            create_webtransport_client_thread2(
+                cert_path,
+                moqt_url,
+                verify_certificate,
+                signal_sender.clone().subscribe(),
+            ),
+        ),
+    };
     thread_vec.push(thread);
     thread_vec.push(thread2);
 
     tracing::info!("Ctrl+C to shutdown");
     tokio::signal::ctrl_c().await?;
     tracing::info!("shutdown");
-    signal_sender.send(()).unwrap();
+    let _ = signal_sender.send(());
     thread_vec.iter().for_each(|t| {
         t.abort();
     });
     Ok(())
+}
+
+fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
 }

--- a/moqt/src/modules/transport/quic/quic_connection_creator.rs
+++ b/moqt/src/modules/transport/quic/quic_connection_creator.rs
@@ -1,7 +1,7 @@
 use anyhow::Ok;
 use async_trait::async_trait;
 use std::{
-    net::{Ipv6Addr, SocketAddr},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
 };
 
@@ -68,7 +68,7 @@ impl QUICConnectionCreator {
     }
 
     fn create_client(port_num: u16, mut config: rustls::ClientConfig) -> anyhow::Result<Self> {
-        let address = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port_num));
+        let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port_num));
         let mut endpoint = quinn::Endpoint::client(address)?;
 
         let alpn = &[b"moq-00"];

--- a/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
+++ b/moqt/src/modules/transport/webtransport/wt_connection_creator.rs
@@ -1,10 +1,20 @@
-use std::net::SocketAddr;
+use std::{
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
-use quinn::rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+use quinn::rustls::{
+    self,
+    pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject},
+};
 
 use super::wt_connection::WtConnection;
-use crate::modules::transport::transport_connection_creator::TransportConnectionCreator;
+use crate::modules::transport::{
+    crypto_provider::install_default_crypto_provider,
+    quic::skip_certd_validation::SkipVerification,
+    transport_connection_creator::TransportConnectionCreator,
+};
 
 enum WtEndpoint {
     Server(tokio::sync::Mutex<web_transport_quinn::Server>),
@@ -15,17 +25,45 @@ pub struct WtConnectionCreator {
     endpoint: WtEndpoint,
 }
 
+impl WtConnectionCreator {
+    fn create_client(
+        port_num: u16,
+        mut crypto: rustls::ClientConfig,
+    ) -> anyhow::Result<web_transport_quinn::Client> {
+        crypto.alpn_protocols = vec![web_transport_quinn::ALPN.as_bytes().to_vec()];
+
+        let client_config = quinn::ClientConfig::new(Arc::new(
+            quinn::crypto::rustls::QuicClientConfig::try_from(crypto)?,
+        ));
+        let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port_num));
+        let endpoint = quinn::Endpoint::client(address)?;
+
+        Ok(web_transport_quinn::Client::new(endpoint, client_config))
+    }
+}
+
 #[async_trait]
 impl TransportConnectionCreator for WtConnectionCreator {
     type Connection = WtConnection;
 
     fn client(port_num: u16, verify_certificate: bool) -> anyhow::Result<Self> {
+        install_default_crypto_provider();
+
         let client = if verify_certificate {
-            web_transport_quinn::ClientBuilder::new().with_system_roots()?
+            let mut roots = rustls::RootCertStore::empty();
+            for cert in rustls_native_certs::load_native_certs().unwrap() {
+                roots.add(cert)?;
+            }
+            let crypto = rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth();
+            Self::create_client(port_num, crypto)?
         } else {
-            web_transport_quinn::ClientBuilder::new()
+            let crypto = rustls::ClientConfig::builder()
                 .dangerous()
-                .with_no_certificate_verification()?
+                .with_custom_certificate_verifier(Arc::new(SkipVerification))
+                .with_no_client_auth();
+            Self::create_client(port_num, crypto)?
         };
 
         tracing::info!("Client ready! for WebTransport port: {}", port_num);
@@ -36,13 +74,14 @@ impl TransportConnectionCreator for WtConnectionCreator {
     }
 
     fn client_with_custom_cert(port_num: u16, custom_cert_path: &str) -> anyhow::Result<Self> {
+        install_default_crypto_provider();
+
         // 証明書を読み込む
         let certs: Vec<_> = CertificateDer::pem_file_iter(custom_cert_path)
             .inspect_err(|e| tracing::error!("Opening certificate file failed: {:?}", e))?
             .collect::<Result<Vec<_>, _>>()
             .inspect_err(|e| tracing::error!("Parsing certificate failed: {:?}", e))?;
 
-        // 自己署名証明書を信頼するクライアントを作る
         let client = web_transport_quinn::ClientBuilder::new().with_server_certificates(certs)?;
 
         tracing::info!("Client ready! for WebTransport port: {}", port_num);
@@ -58,6 +97,8 @@ impl TransportConnectionCreator for WtConnectionCreator {
         port_num: u16,
         _keep_alive_sec: u64,
     ) -> anyhow::Result<Self> {
+        install_default_crypto_provider();
+
         // 証明書を同期的に読み込む
         let certs: Vec<_> = CertificateDer::pem_file_iter(cert_path)
             .inspect_err(|e| tracing::error!("Opening certificate file failed: {:?}", e))?
@@ -68,7 +109,7 @@ impl TransportConnectionCreator for WtConnectionCreator {
         let key = PrivateKeyDer::from_pem_file(key_path)
             .inspect_err(|e| tracing::error!("Creating private key failed: {:?}", e.to_string()))?;
 
-        let addr: SocketAddr = format!("[::]:{}", port_num).parse()?;
+        let addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port_num));
         let server = web_transport_quinn::ServerBuilder::new()
             .with_addr(addr)
             .with_certificate(certs, key)?;

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -34,7 +34,8 @@ pub fn create_certs_for_test_if_needed() -> anyhow::Result<()> {
         let subject_alt_names = vec![
             "localhost".to_string(),
             "127.0.0.1".to_string(),
-            "moqt.research.skyway.io".to_string(),
+            "relay-a".to_string(),
+            "relay-b".to_string(),
         ];
         let CertifiedKey { cert, signing_key } =
             generate_simple_self_signed(subject_alt_names).unwrap();

--- a/scripts/cache-eviction-e2e.sh
+++ b/scripts/cache-eviction-e2e.sh
@@ -40,7 +40,9 @@ fi
 docker compose up -d redis relay-a
 docker compose logs -f --no-color relay-a &
 LOGS_PID=$!
+RELAY_URL="$(node scripts/resolve-local-relay-url.mjs moqt://127.0.0.1:4433)"
+echo "Using relay URL: $RELAY_URL"
 
 # The client asserts object-TTL and strong_count reclaim and panics/exits
 # non-zero on mismatch, so a non-zero exit is the only failure signal needed.
-cargo run -p cache-eviction-e2e
+MOQT_E2E_RELAY_URL="$RELAY_URL" cargo run -p cache-eviction-e2e

--- a/scripts/cascading-relay-e2e.sh
+++ b/scripts/cascading-relay-e2e.sh
@@ -37,10 +37,13 @@ fi
 docker compose up -d redis relay-a relay-b
 docker compose logs -f --no-color relay-a relay-b &
 LOGS_PID=$!
+RELAY_A_URL="$(node scripts/resolve-local-relay-url.mjs moqt://127.0.0.1:4433)"
+RELAY_B_URL="$(node scripts/resolve-local-relay-url.mjs moqt://127.0.0.1:4434)"
+echo "Using relay URLs: $RELAY_A_URL, $RELAY_B_URL"
 
 if ! cargo run -p cascading-relay-e2e -- \
-  --relay-a-url moqt://localhost:4433 \
-  --relay-b-url moqt://localhost:4434 \
+  --relay-a-url "$RELAY_A_URL" \
+  --relay-b-url "$RELAY_B_URL" \
   --redis-url redis://localhost:6379 \
   --track-namespace App/Channel/UserA \
   --track-name video 2>&1 | tee "$RESULT_LOG"; then

--- a/scripts/chrome_mac.sh
+++ b/scripts/chrome_mac.sh
@@ -39,6 +39,43 @@ CERT_SPKI_BASE64=$(
     | openssl enc -base64
 )
 
+RELAY_A_URL="${MOQT_RELAY_A_URL:-${CALL_RELAY_A_URL:-$(node "${REPO_ROOT}/scripts/resolve-local-relay-url.mjs" https://127.0.0.1:4433)}}"
+RELAY_B_URL="${MOQT_RELAY_B_URL:-${CALL_RELAY_B_URL:-$(node "${REPO_ROOT}/scripts/resolve-local-relay-url.mjs" https://127.0.0.1:4434)}}"
+RELAY_A_AUTHORITY=$(node -e "console.log(new URL(process.argv[1]).host)" "${RELAY_A_URL}")
+RELAY_B_AUTHORITY=$(node -e "console.log(new URL(process.argv[1]).host)" "${RELAY_B_URL}")
+
+BROWSER_APP_ORIGIN="${BROWSER_APP_ORIGIN:-http://localhost:5173}"
+BROWSER_APP_ORIGIN="${BROWSER_APP_ORIGIN%/}"
+DEFAULT_BROWSER_APP_URL="${BROWSER_APP_ORIGIN}/moq-wasm/index.html"
+if [[ -n "${BROWSER_EXAMPLE_PATH:-}" ]]; then
+  if [[ "${BROWSER_EXAMPLE_PATH}" == http://* || "${BROWSER_EXAMPLE_PATH}" == https://* ]]; then
+    BROWSER_APP_URL="${BROWSER_EXAMPLE_PATH}"
+  else
+    NORMALIZED_BROWSER_EXAMPLE_PATH="${BROWSER_EXAMPLE_PATH}"
+    if [[ "${NORMALIZED_BROWSER_EXAMPLE_PATH}" != /* ]]; then
+      NORMALIZED_BROWSER_EXAMPLE_PATH="/${NORMALIZED_BROWSER_EXAMPLE_PATH}"
+    fi
+    BROWSER_APP_URL="${BROWSER_APP_ORIGIN}${NORMALIZED_BROWSER_EXAMPLE_PATH}"
+  fi
+else
+  BROWSER_APP_URL="${BROWSER_APP_URL:-${CALL_APP_URL:-${DEFAULT_BROWSER_APP_URL}}}"
+fi
+
+BROWSER_APP_URL_WITH_RELAYS=$(
+  node -e '
+    const url = new URL(process.argv[1]);
+    const relayAUrl = process.argv[2];
+    const relayBUrl = process.argv[3];
+    url.searchParams.set("relayAUrl", relayAUrl);
+    url.searchParams.set("relayBUrl", relayBUrl);
+    url.searchParams.set("relayUrl", relayAUrl);
+    url.searchParams.set("moqtUrl", relayAUrl);
+    url.searchParams.set("url", relayAUrl);
+    url.searchParams.set("relay", relayAUrl);
+    console.log(url.toString());
+  ' "${BROWSER_APP_URL}" "${RELAY_A_URL}" "${RELAY_B_URL}"
+)
+
 CLEANUP_USER_DATA_DIR=0
 USER_DATA_DIR="${CHROME_USER_DATA_DIR:-}"
 if [[ -z "${USER_DATA_DIR}" ]]; then
@@ -55,10 +92,16 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Launching Chrome with certificate: ${CERT_PEM}"
+echo "Using relay URLs: ${RELAY_A_URL}, ${RELAY_B_URL}"
+echo "Opening browser example: ${BROWSER_APP_URL_WITH_RELAYS}"
 
 "${CHROME_BIN}" \
   --test-type \
   --user-data-dir="${USER_DATA_DIR}" \
-  --origin-to-force-quic-on=127.0.0.1:4433,localhost:4433,127.0.0.1:4434,localhost:4434 \
+  --origin-to-force-quic-on=127.0.0.1:4433,localhost:4433,127.0.0.1:4434,localhost:4434,${RELAY_A_AUTHORITY},${RELAY_B_AUTHORITY} \
   --ignore-certificate-errors-spki-list="${CERT_SPKI_BASE64}" \
-  --use-fake-device-for-media-stream
+  --ignore-certificate-errors \
+  --use-fake-device-for-media-stream \
+  --use-fake-ui-for-media-stream \
+  --autoplay-policy=no-user-gesture-required \
+  "${BROWSER_APP_URL_WITH_RELAYS}"

--- a/scripts/ensure-relay-certs.mjs
+++ b/scripts/ensure-relay-certs.mjs
@@ -13,6 +13,13 @@ import {
   serverKeysDir,
 } from "./media-e2e-helpers.mjs";
 
+const requiredSubjectAltNames = [
+  "DNS:localhost",
+  "DNS:relay-a",
+  "DNS:relay-b",
+  "IP Address:127.0.0.1",
+];
+
 export async function ensureRelayCertificates() {
   ensureLinuxEnvironment();
   await assertOpenSsl();
@@ -23,42 +30,36 @@ export async function ensureRelayCertificates() {
   }
 
   mkdirSync(serverKeysDir, { recursive: true });
-  await runCommand(
-    resolveCommandName("openssl"),
-    [
-      "req",
-      "-newkey",
-      "rsa:2048",
-      "-nodes",
-      "-keyout",
-      keyPath,
-      "-x509",
-      "-out",
-      certPath,
-      "-days",
-      "365",
-      "-subj",
-      "/CN=Test Certificate",
-      "-addext",
-      "subjectAltName = DNS:localhost,IP:127.0.0.1",
-    ],
-    { cwd: repoRoot },
-  );
+  await generateRelayCertificate();
   ensureCertificatePermissions();
 }
 
-
 async function hasValidCertificates() {
   try {
-    await runCommand(resolveCommandName("openssl"), ["x509", "-in", certPath, "-noout"], {
-      cwd: repoRoot,
-      quiet: true,
-    });
-    await runCommand(resolveCommandName("openssl"), ["rsa", "-in", keyPath, "-check", "-noout"], {
-      cwd: repoRoot,
-      quiet: true,
-    });
-    return true;
+    await runCommand(
+      resolveCommandName("openssl"),
+      ["x509", "-in", certPath, "-noout"],
+      {
+        cwd: repoRoot,
+        quiet: true,
+      },
+    );
+    await runCommand(
+      resolveCommandName("openssl"),
+      ["rsa", "-in", keyPath, "-check", "-noout"],
+      {
+        cwd: repoRoot,
+        quiet: true,
+      },
+    );
+    const subjectAltName = await readCommand(
+      resolveCommandName("openssl"),
+      ["x509", "-in", certPath, "-noout", "-ext", "subjectAltName"],
+      { cwd: repoRoot },
+    );
+    return requiredSubjectAltNames.every((entry) =>
+      subjectAltName.includes(entry),
+    );
   } catch (_error) {
     return false;
   }
@@ -77,6 +78,30 @@ function ensureCertificatePermissions() {
   // disposable E2E keys read-only, so make them world-readable for tests.
   chmodSync(certPath, 0o644);
   chmodSync(keyPath, 0o644);
+}
+
+async function generateRelayCertificate() {
+  await runCommand(
+    resolveCommandName("openssl"),
+    [
+      "req",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-keyout",
+      keyPath,
+      "-x509",
+      "-out",
+      certPath,
+      "-days",
+      "365",
+      "-subj",
+      "/CN=Test Certificate",
+      "-addext",
+      "subjectAltName = DNS:localhost,DNS:relay-a,DNS:relay-b,IP:127.0.0.1",
+    ],
+    { cwd: repoRoot },
+  );
 }
 
 async function runCommand(command, args, options) {
@@ -116,7 +141,49 @@ async function runCommand(command, args, options) {
   });
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+async function readCommand(command, args, options) {
+  const { cwd, errorHint } = options;
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      rejectPromise(
+        new Error(
+          `${command} failed to start: ${getErrorMessage(error)} ${errorHint ?? ""}`.trim(),
+        ),
+      );
+    });
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolvePromise(stdout);
+        return;
+      }
+      rejectPromise(
+        new Error(
+          `${command} ${args.join(" ")} exited with code ${code}. ${errorHint ?? ""} ${stderr.trim()}`.trim(),
+        ),
+      );
+    });
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   ensureRelayCertificates().catch((error) => {
     console.error(getErrorMessage(error));
     process.exitCode = 1;

--- a/scripts/fetch-e2e.sh
+++ b/scripts/fetch-e2e.sh
@@ -36,7 +36,9 @@ fi
 docker compose up -d redis relay-a
 docker compose logs -f --no-color relay-a &
 LOGS_PID=$!
+RELAY_URL="$(node scripts/resolve-local-relay-url.mjs moqt://127.0.0.1:4433)"
+echo "Using relay URL: $RELAY_URL"
 
 # The clients assert the fetched object sets and panic on mismatch, so a
 # non-zero exit is the only failure signal needed.
-cargo run -p fetch-e2e
+MOQT_E2E_RELAY_URL="$RELAY_URL" cargo run -p fetch-e2e

--- a/scripts/multiple-publishers-e2e.sh
+++ b/scripts/multiple-publishers-e2e.sh
@@ -37,7 +37,9 @@ fi
 docker compose up -d redis relay-a
 docker compose logs -f --no-color relay-a &
 LOGS_PID=$!
+RELAY_URL="$(node scripts/resolve-local-relay-url.mjs moqt://127.0.0.1:4433)"
+echo "Using relay URL: $RELAY_URL"
 
 # Bob asserts the first-writer-wins guard and panics on violation, so a non-zero
 # exit is the only failure signal needed.
-cargo run -p multiple-publishers-e2e
+MOQT_E2E_RELAY_URL="$RELAY_URL" cargo run -p multiple-publishers-e2e

--- a/scripts/object-dedup-e2e.sh
+++ b/scripts/object-dedup-e2e.sh
@@ -37,7 +37,9 @@ fi
 docker compose up -d redis relay-a
 docker compose logs -f --no-color relay-a &
 LOGS_PID=$!
+RELAY_URL="$(node scripts/resolve-local-relay-url.mjs moqt://127.0.0.1:4433)"
+echo "Using relay URL: $RELAY_URL"
 
 # bob asserts group 0 deduplicates to o0..o4 and panics on a duplicate, so a
 # non-zero exit is the only failure signal needed.
-cargo run -p object-dedup-e2e
+MOQT_E2E_RELAY_URL="$RELAY_URL" cargo run -p object-dedup-e2e

--- a/scripts/resolve-local-relay-url.mjs
+++ b/scripts/resolve-local-relay-url.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { repoRoot, resolveCommandName } from "./media-e2e-helpers.mjs";
+
+const defaultMoqtUrl = "https://127.0.0.1:4433";
+const dockerRelayHostEnvNames = ["MOQT_DOCKER_RELAY_HOST", "LOCAL_RELAY_HOST"];
+
+function main() {
+  const moqtUrl = process.argv[2] || process.env.MOQT_URL || defaultMoqtUrl;
+  const resolvedUrl = resolveLocalRelayUrl(moqtUrl);
+  console.log(formatUrl(resolvedUrl));
+}
+
+export function resolveLocalRelayUrl(moqtUrl) {
+  const url = new URL(moqtUrl || defaultMoqtUrl);
+  const overrideHost = findOverrideHost();
+  if (overrideHost) {
+    url.hostname = overrideHost;
+    return url;
+  }
+
+  if (!isLoopbackHost(url.hostname) || !isDockerComposeRelayRunning()) {
+    return url;
+  }
+
+  const dockerDesktopHost = detectDockerDesktopBridgeHost();
+  if (dockerDesktopHost) {
+    url.hostname = dockerDesktopHost;
+  }
+  return url;
+}
+
+function findOverrideHost() {
+  for (const name of dockerRelayHostEnvNames) {
+    const value = process.env[name]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function isLoopbackHost(hostname) {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+}
+
+function isDockerComposeRelayRunning() {
+  try {
+    const output = execFileSync(
+      resolveCommandName("docker"),
+      ["compose", "ps", "--status", "running", "--services", "relay-a"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    return output.split(/\s+/).includes("relay-a");
+  } catch (_error) {
+    return false;
+  }
+}
+
+function detectDockerDesktopBridgeHost() {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+
+  try {
+    const routeTable = execFileSync("netstat", ["-rn", "-f", "inet"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return selectBridgeHost(routeTable);
+  } catch (_error) {
+    return null;
+  }
+}
+
+function selectBridgeHost(routeTable) {
+  const candidates = routeTable
+    .split("\n")
+    .map((line) => line.trim().split(/\s+/))
+    .filter((columns) => columns.length >= 4)
+    .filter((columns) => /^bridge\d+$/.test(columns[3]))
+    .map((columns) => columns[0])
+    .filter(isPrivateIpv4Host);
+
+  return (
+    candidates.find((host) => host.endsWith(".2")) ?? candidates[0] ?? null
+  );
+}
+
+function isPrivateIpv4Host(host) {
+  const octets = host.split(".").map((part) => Number(part));
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return false;
+  }
+
+  const [first, second] = octets;
+  return (
+    first === 10 ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+function formatUrl(url) {
+  const formatted = url.toString();
+  if (url.pathname === "/" && !url.search && !url.hash) {
+    return formatted.slice(0, -1);
+  }
+  return formatted;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/run-call-e2e.mjs
+++ b/scripts/run-call-e2e.mjs
@@ -21,8 +21,11 @@ import {
   resolveCommandName,
   waitForHttpOk,
 } from "./media-e2e-helpers.mjs";
+import { resolveLocalRelayUrl } from "./resolve-local-relay-url.mjs";
 
 const callIndexPath = "/moq-wasm/examples/call/index.html";
+const defaultRelayAUrl = "https://127.0.0.1:4433";
+const defaultRelayBUrl = "https://127.0.0.1:4434";
 
 const childProcesses = [];
 const playwrightArgs = process.argv.slice(2);
@@ -134,6 +137,10 @@ async function main() {
       waitForHttpOk(`${baseUrl}${callIndexPath}`, 120_000),
     ]);
 
+    const relayAUrl = getCallRelayUrl("CALL_E2E_RELAY_A_URL", defaultRelayAUrl);
+    const relayBUrl = getCallRelayUrl("CALL_E2E_RELAY_B_URL", defaultRelayBUrl);
+    console.error(`[setup] Using call relay URLs: ${relayAUrl}, ${relayBUrl}`);
+
     await runCommand(
       resolveCommandName("npm"),
       playwrightArgs.length > 0
@@ -144,12 +151,24 @@ async function main() {
         env: {
           ...process.env,
           MEDIA_E2E_BASE_URL: baseUrl,
+          CALL_E2E_RELAY_A_URL: relayAUrl,
+          CALL_E2E_RELAY_B_URL: relayBUrl,
         },
       },
     );
   } finally {
     await cleanup();
   }
+}
+
+function getCallRelayUrl(envName, defaultUrl) {
+  const configuredUrl = process.env[envName];
+  const url = configuredUrl ?? resolveLocalRelayUrl(defaultUrl).toString();
+  return stripTrailingSlash(url);
+}
+
+function stripTrailingSlash(url) {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
 }
 
 // Return true if the relay image used by docker compose is already available

--- a/tests/cache-eviction-e2e/src/main.rs
+++ b/tests/cache-eviction-e2e/src/main.rs
@@ -29,9 +29,7 @@
 //!
 //! The client sleeps below assume TTL=5s / interval=1s.
 
-use std::net::ToSocketAddrs;
-use std::str::FromStr;
-use std::time::Duration;
+use std::{env, net::ToSocketAddrs, str::FromStr, time::Duration};
 
 use moqt::{
     ClientConfig, ContentExists, Endpoint, ExtensionHeaders, Fetch, FetchDataReceiver, FetchOption,
@@ -39,7 +37,7 @@ use moqt::{
     SubgroupObject, SubscribeOption,
 };
 
-const RELAY_URL: &str = "moqt://localhost:4433";
+const DEFAULT_RELAY_URL: &str = "moqt://127.0.0.1:4433";
 const NAMESPACE_A: &str = "evict/a";
 const NAMESPACE_B: &str = "evict/b";
 const TRACK_NAME: &str = "data";
@@ -47,7 +45,9 @@ const PUBLISHER_PRIORITY: u8 = 128;
 const OBJECTS_PER_GROUP: u64 = 5;
 
 async fn new_session() -> anyhow::Result<Session<QUIC>> {
-    let url = url::Url::from_str(RELAY_URL).unwrap();
+    let relay_url =
+        env::var("MOQT_E2E_RELAY_URL").unwrap_or_else(|_| DEFAULT_RELAY_URL.to_string());
+    let url = url::Url::from_str(&relay_url).unwrap();
     let host = url.host_str().unwrap();
     let remote = (host, url.port().unwrap_or(4433))
         .to_socket_addrs()?

--- a/tests/fetch-e2e/src/main.rs
+++ b/tests/fetch-e2e/src/main.rs
@@ -15,6 +15,7 @@
 //! Run a relay on localhost:4433, then `cargo run -p fetch-e2e` from the repo
 //! root. Any range that resolves to the wrong object set fails an assertion.
 
+use std::env;
 use std::net::ToSocketAddrs;
 use std::str::FromStr;
 
@@ -25,7 +26,7 @@ use moqt::{
     SubscribeOption,
 };
 
-const RELAY_URL: &str = "moqt://localhost:4433";
+const DEFAULT_RELAY_URL: &str = "moqt://127.0.0.1:4433";
 const NAMESPACE: &str = "room/alice";
 const TRACK_NAME: &str = "data";
 const PUBLISHER_PRIORITY: u8 = 128;
@@ -33,7 +34,9 @@ const GROUPS: u64 = 3;
 const OBJECTS_PER_GROUP: u64 = 5;
 
 async fn new_session() -> anyhow::Result<Session<QUIC>> {
-    let url = url::Url::from_str(RELAY_URL).unwrap();
+    let relay_url =
+        env::var("MOQT_E2E_RELAY_URL").unwrap_or_else(|_| DEFAULT_RELAY_URL.to_string());
+    let url = url::Url::from_str(&relay_url).unwrap();
     let host = url.host_str().unwrap();
     let remote = (host, url.port().unwrap_or(4433))
         .to_socket_addrs()?

--- a/tests/multiple-publishers-e2e/src/main.rs
+++ b/tests/multiple-publishers-e2e/src/main.rs
@@ -13,6 +13,7 @@
 //! from the repo root. Bob asserts `carol == 0`, that Alice keeps flowing after
 //! Carol leaves, and prints a summary.
 
+use std::env;
 use std::net::ToSocketAddrs;
 use std::str::FromStr;
 use std::time::Duration;
@@ -24,7 +25,7 @@ use moqt::{
 };
 use tokio::sync::oneshot;
 
-const RELAY_URL: &str = "moqt://localhost:4433";
+const DEFAULT_RELAY_URL: &str = "moqt://127.0.0.1:4433";
 const NAMESPACE: &str = "room/main";
 const TRACK_NAME: &str = "data";
 const PUBLISHER_PRIORITY: u8 = 128;
@@ -36,7 +37,9 @@ const OBJECTS_PER_GROUP: u64 = 5;
 const LATE_GROUP: u64 = 4;
 
 async fn new_session() -> anyhow::Result<Session<QUIC>> {
-    let url = url::Url::from_str(RELAY_URL).unwrap();
+    let relay_url =
+        env::var("MOQT_E2E_RELAY_URL").unwrap_or_else(|_| DEFAULT_RELAY_URL.to_string());
+    let url = url::Url::from_str(&relay_url).unwrap();
     let host = url.host_str().unwrap();
     let remote = (host, url.port().unwrap_or(4433))
         .to_socket_addrs()?

--- a/tests/object-dedup-e2e/src/main.rs
+++ b/tests/object-dedup-e2e/src/main.rs
@@ -9,6 +9,7 @@
 //!
 //! Run a relay on localhost:4433, then `cargo run -p object-dedup-e2e`.
 
+use std::env;
 use std::net::ToSocketAddrs;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -18,14 +19,16 @@ use moqt::{
     Location, PublishOption, QUIC, Session, StreamDataSenderFactory, SubgroupId, SubgroupObject,
 };
 
-const RELAY_URL: &str = "moqt://localhost:4433";
+const DEFAULT_RELAY_URL: &str = "moqt://127.0.0.1:4433";
 const NAMESPACE: &str = "room/main";
 const PUBLISHER_PRIORITY: u8 = 128;
 const GROUP_ID: u64 = 0;
 const OBJECTS_PER_GROUP: u64 = 5;
 
 async fn new_session() -> anyhow::Result<Session<QUIC>> {
-    let url = url::Url::from_str(RELAY_URL).unwrap();
+    let relay_url =
+        env::var("MOQT_E2E_RELAY_URL").unwrap_or_else(|_| DEFAULT_RELAY_URL.to_string());
+    let url = url::Url::from_str(&relay_url).unwrap();
     let host = url.host_str().unwrap();
     let remote = (host, url.port().unwrap_or(4433))
         .to_socket_addrs()?


### PR DESCRIPTION
## 何を対応するか
ローカルの Docker Compose relay を、browser examples / Rust manual-client / ONVIF / live-ingest / E2E から一貫して使えるようにします。

## 変更内容
- Docker relay の loopback URL を macOS では Docker Desktop bridge host に解決する `scripts/resolve-local-relay-url.mjs` を追加しました。
- browser examples の relay preset を共通化し、一覧ページから各 example へ relay query parameter を引き継ぐようにしました。
- `make chrome` は example 一覧を `localhost:5173` で開き、WebTransport 用の QUIC 強制・証明書許可フラグを付けるようにしました。
- call / media / message / ONVIF / remote-monitoring examples で local Docker relay preset を選べるようにしました。
- Rust manual-client で `MOQT_URL` / `MOQT_TRANSPORT` / `MOQT_INSECURE_SKIP_TLS_VERIFY` を指定できるようにしました。
- WebTransport client の rustls CryptoProvider 初期化と TLS 検証無効化経路を整理し、QUIC client bind を IPv4 に寄せました。
- ONVIF / live-ingest / Rust E2E が resolver 経由の local relay URL を使うようにしました。

## なぜ
ブラウザの call app は Docker relay に接続できていた一方で、ONVIF や manual-client などは `127.0.0.1:4433` 固定や証明書/QUIC 起動条件の差で WebTransport 接続が完了しないケースがありました。手動操作・各 example・E2E の relay 指定方法を揃え、ローカル検証時の接続先を明確にするためです。

## 確認
- `cargo check -p moqt -p relay -p moqt-bridge-onvif -p moqt-bridge-live-ingest -p manual-client`
- `npm --prefix examples/browser run lint`
- `npm --prefix examples/browser run build`
- `node scripts/run-call-e2e.mjs`
- `node scripts/run-media-e2e.mjs`
- `./scripts/fetch-e2e.sh`
- `./scripts/multiple-publishers-e2e.sh`
- `./scripts/object-dedup-e2e.sh`
- `./scripts/cascading-relay-e2e.sh`
- `CHROME_BIN=/bin/echo scripts/chrome_mac.sh`
- `make -n live-ingest`