### PR TITLE
docs: moqt / relay クレートの設計ドキュメントをADRディレクトリに追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ Application and integration components (draft reference is normally not required
 
 - `moqt` is the central crate — all other crates depend on it. Changes to `moqt` affect the entire workspace.
 
+### Architecture Documentation
+- Design overviews and the intent behind the module structure are recorded under `architecture_decision_record/`:
+  - `architecture_decision_record/moqt/architecture.md` — `moqt` crate design (transport abstraction, session/runtime model, control/data plane split).
+  - `architecture_decision_record/relay/architecture.md` — `relay` crate design (event pipeline, ingress/egress/cache, multi-relay routing).
+- Read the relevant architecture document before making structural changes (adding modules, moving responsibilities, changing task/channel topology) to `moqt` or `relay`, and update it when a change alters the documented design.
+
 ## 3. Specifications
 - MoQT-related specifications are stored in the `spec` directory.
 - For library components listed in the draft-governed table above, use only the draft listed in `Related Draft` as the authoritative specification. Do not consult other drafts unless the task explicitly requires them.

--- a/architecture_decision_record/moqt/architecture.md
+++ b/architecture_decision_record/moqt/architecture.md
@@ -1,0 +1,164 @@
+# Architecture: `moqt` crate
+
+## Status
+Accepted (documents the design as of `master`, 2026-07)
+
+## Purpose
+`moqt` is the core implementation of Media over QUIC Transport
+(draft-ietf-moq-transport-14). It provides both the client and server
+endpoint roles and is the crate every other workspace member depends on
+(`relay`, `bindings/wasm`, `bridges/*`, `examples/`).
+
+The crate has two consumption modes:
+
+1. **Full async endpoint** (native targets) — `Endpoint` / `Session` /
+   `Publisher` / `Subscriber` running on tokio.
+2. **Wire-format library** (`moqt::wire`, also compiled for `wasm32`) —
+   message encode/decode only, no runtime. This is what `bindings/wasm`
+   uses; everything runtime-related is gated behind
+   `#[cfg(not(target_arch = "wasm32"))]`.
+
+## Layer Map
+
+```
+moqt/src/modules/
+├── transport/          Transport abstraction (QUIC / WebTransport / Dual)
+│   ├── quic/           quinn-based raw QUIC (ALPN "moq-00")
+│   ├── webtransport/   web_transport_quinn-based (browsers, ALPN h3)
+│   └── dual/           One server endpoint accepting BOTH protocols
+├── moqt/
+│   ├── control_plane/  Control messages (encode/decode) + incoming-request handlers
+│   ├── data_plane/     Object wire formats, stream/datagram senders & receivers, codecs
+│   ├── domains/        Public API surface: Endpoint, Connecting, Session,
+│   │                   Publisher, Subscriber, SessionContext
+│   └── runtime/        Background receive tasks + object dispatch
+└── extensions/         Buf{Get,Put}Ext (varint etc.), ResultExt
+```
+
+Dependency direction is strictly downward: `domains`/`runtime` →
+`control_plane`/`data_plane` → `transport`. `transport` knows nothing
+about MoQT semantics.
+
+## Key Design Decisions
+
+### 1. Transport selection via generics, not trait objects
+`TransportProtocol` (`modules/moqt/protocol.rs`) is a marker trait with
+associated types (`ConnectionCreator`, `Connection`, `SendStream`,
+`ReceiveStream`). Concrete protocols are zero-sized types: `QUIC`,
+`WEBTRANSPORT`, `DUAL`. All public types are generic over it
+(`Endpoint<T>`, `Session<T>`, …).
+
+- Rationale: no dynamic dispatch on the per-object hot path; the
+  compiler monomorphizes each transport.
+- Consequence: a `Session<QUIC>` and a `Session<WEBTRANSPORT>` are
+  different types. Code that must hold sessions of mixed transports
+  (the relay) erases the generic behind its own `dyn` traits — that is
+  deliberately the *caller's* job, not this crate's.
+
+### 2. `DUAL`: one UDP port, two protocols
+`DUAL` is a server-only protocol whose creator registers two ALPNs
+(`h3` for WebTransport, `moq-00` for raw QUIC) on a single quinn
+endpoint and wraps the accepted connection in `DualConnection`. This
+lets a server (typically the relay) serve browsers and native clients
+on the same port. Client mode intentionally fails: a client always
+knows which protocol it speaks.
+
+### 3. Session establishment: `Endpoint` → `Connecting` → `Session`
+`Endpoint::connect()/accept()` returns `Connecting<T>`, a boxed future
+that performs the MoQT setup handshake (CLIENT_SETUP / SERVER_SETUP on
+the bidirectional control stream) and resolves to a ready `Session<T>`.
+This mirrors quinn's connect-then-await shape and keeps handshake logic
+out of `Session`.
+
+### 4. `Session` = thin façade over shared `SessionContext`
+`Session<T>` owns the background task handles and an event receiver;
+all shared mutable state lives in `Arc<SessionContext<T>>`
+(`domains/session_context.rs`). `Publisher`/`Subscriber` are cheap
+handles cloned from the same `Arc` (`session.publisher()`,
+`session.subscriber()`), so one session can be used from both roles
+concurrently. Dropping `Session` aborts all of its tasks.
+
+`SessionContext` centralizes:
+- **Request/response correlation** — `sender_map: RequestId →
+  oneshot::Sender<ResponseMessage>`. Requesters register a sender, send
+  the control message, and `await_response()` with a 10 s timeout
+  (draft-14 §12.2); timeout closes the session with
+  `ControlMessageTimeout`. `RegisteredSender` is a drop guard that
+  removes the map entry even when the request future is cancelled.
+- **ID allocation** — atomics for Request ID (step 2, per draft parity
+  rule) and Track Alias.
+- **Object routing** — see decision 6.
+
+### 5. Background work as owned tasks (actor pattern)
+Runtime behavior lives in four task structs under `runtime/tasks/`
+(`ControlMessageReceiveTask`, `UniStreamReceiveTask`,
+`DatagramReceiveTask`, `DisconnectWatchTask`), each following the
+repo-wide convention: `run()` spawns and returns the struct owning the
+`JoinHandle`. The control-message task holds only a
+`Weak<SessionContext>` so a dropped `Session` can actually deallocate.
+
+Incoming control messages are split into two kinds:
+- **Responses** (SUBSCRIBE_OK, REQUEST_ERROR, …) are routed to the
+  waiting requester through `sender_map`. A response for an unknown
+  Request ID is a protocol violation and closes the session.
+- **Requests** from the peer (SUBSCRIBE, PUBLISH_NAMESPACE, FETCH, …)
+  become `SessionEvent`s delivered to the application via
+  `Session::receive_event()`.
+
+### 6. Incoming requests are surfaced as handler objects
+Each `SessionEvent` variant carries a handler
+(`control_plane/handler/*_handler.rs`, e.g. `SubscribeHandler`) that
+exposes the request's fields plus explicit `ok(...)` / `error(...)`
+methods that send the response. The application decides; the library
+never auto-accepts. This is the seam the relay builds on (it wraps
+these handlers in its own `dyn` traits).
+
+### 7. Object delivery: buffer-until-receiver, then live channel
+Objects can arrive on unidirectional streams *before* the local
+SUBSCRIBE_OK plumbing registered a receiver for the track alias.
+`SessionContext::object_sinks` holds, per track alias, either a
+`Buffer(VecDeque)` (pre-registration, bounded by `max_pending_objects`,
+drop-oldest) or a `Receiver(mpsc sender)` (live). Registration
+atomically drains the buffer into the new channel under the same lock.
+Duplicate registration for a track alias is rejected as
+`DuplicateTrackAlias`.
+
+### 8. Control plane / data plane split mirrors the draft
+- `control_plane/control_messages/` — one file per draft message with
+  `encode()`/`decode()` and unit tests; shared parameter types under
+  `messages/parameters/`. Message framing (type varint + 16-bit length,
+  draft-14) lives in `wire.rs`.
+- `data_plane/object/` — data wire formats (subgroup headers/objects,
+  datagrams, fetch objects, extension headers).
+- `data_plane/stream/`, `data_plane/datagram/` — typed senders and
+  receivers over transport streams; `data_plane/codec/` — incremental
+  decoders driving them.
+
+### 9. Typestate for stream senders
+`StreamDataSender<T, S>` uses a typestate parameter
+(`Uninitialized` → `HeaderSent`): `send_header()` consumes the sender
+and returns the object-sending state, so "subgroup header is sent
+exactly once, before any object" is a compile-time invariant instead of
+a runtime check.
+
+### 10. Public API is curated in `lib.rs`
+Everything under `modules/` is `pub(crate)`; `lib.rs` re-exports the
+intended surface explicitly (and `wire.rs` re-exports the encode/decode
+surface). Adding a `pub` item to a module does not leak it — it must
+also be re-exported, which keeps the API reviewable.
+
+## Consequences
+- New control messages follow a fixed recipe: message struct +
+  `ControlMessageType` entry (+ handler and `SessionEvent` variant if it
+  is a request), and dispatch in the control-message receive task.
+- Transport-generic code stays monomorphic and fast, but any component
+  that mixes transports at runtime must do its own type erasure (see
+  `relay`'s `core` module, documented in
+  `../relay/architecture.md`).
+- The wasm boundary must be maintained by hand: runtime/domain code
+  needs the `#[cfg(not(target_arch = "wasm32"))]` gate, wire-format code
+  must stay runtime-free.
+
+## References
+- `spec/draft-ietf-moq-transport-14.txt` (authoritative draft for this crate)
+- `../relay/architecture.md` — how the relay consumes this crate

--- a/architecture_decision_record/relay/architecture.md
+++ b/architecture_decision_record/relay/architecture.md
@@ -1,0 +1,185 @@
+# Architecture: `relay` crate
+
+## Status
+Accepted (documents the design as of `master`, 2026-07)
+
+## Purpose
+`relay` is the MoQT relay server. It terminates MoQT sessions from
+publishers and subscribers (end clients and other relays), maintains a
+local pub/sub directory, caches objects per track, and fans data out to
+downstream subscribers. It extends the `moqt` crate with the
+relay-specific behavior described in the relay sections of
+draft-ietf-moq-transport-14.
+
+A single relay process listens on two endpoints (see `main.rs`):
+
+- **Client-facing** `DUAL` endpoint (`RELAY_PORT`, default 4433) —
+  accepts both WebTransport (browsers) and raw QUIC clients on one port.
+- **Inner** `QUIC` endpoint (`RELAY_INNER_PORT`, default port+1) —
+  accepts connections from *other relays* for cascading.
+
+## Layer Map
+
+```
+relay/src/
+├── main.rs / config.rs / logging.rs    Process entry, env config, tracing setup
+├── relay_server/                       Composition root
+│   ├── server.rs    RelayServer: builds runtime, spawns the two endpoints
+│   ├── runtime.rs   RelayRuntime: wires ingress/egress/event handler/eviction
+│   └── store.rs     RelayStore: shared state (TrackCacheStore, ObjectNotifyProducerMap)
+└── modules/
+    ├── core/            Transport erasure over `moqt` (dyn Session/Publisher/
+    │                    Subscriber, dyn *Handler, data senders/receivers)
+    ├── event_resolver/  moqt::SessionEvent → relay SessionEvent (adds SessionId)
+    ├── session_handler.rs      Accept loop per endpoint
+    ├── session_repository.rs   SessionId → session registry (+ spans, peer kind)
+    ├── event_handler.rs        Reader + per-session worker event dispatch
+    ├── sequences/       Per-control-message orchestration (subscribe, publish,
+    │                    namespaces, fetch, …) + LocalPubSubDirectory tables
+    ├── relay/
+    │   ├── ingress/     Pull objects from upstream into the cache
+    │   ├── egress/      Push cached/live objects to downstream subscribers
+    │   ├── cache/       TrackCacheStore → TrackCache → GroupCache (+ TTL eviction)
+    │   └── notifications/  Per-track broadcast of "object arrived" events
+    ├── route_registry/  Namespace routing for multi-relay (Noop | Redis)
+    ├── inter_relay.rs   Outbound QUIC connections to other relays
+    ├── upstream_publisher_resolver.rs  Local publisher vs. remote relay lookup
+    └── control_message_forwarder.rs    Send control messages to other sessions
+```
+
+## Key Design Decisions
+
+### 1. Transport erasure at the relay boundary (`core/`)
+`moqt` exposes sessions as generics (`Session<QUIC>`,
+`Session<DUAL>`, …), but the relay must hold sessions of *mixed*
+transports in one `SessionRepository`. `core/` defines object-safe
+traits (`Session`, `Publisher`, `Subscriber`, per-message `*Handler`
+traits) with blanket impls for every `moqt::TransportProtocol`, so all
+relay logic downstream of the accept loop works on `Box<dyn …>` and is
+transport-agnostic. This is the single place where the generics are
+erased.
+
+### 2. Client vs. relay peers are first-class (`SessionPeer`)
+Every accepted session is tagged `SessionPeer::Client` or
+`SessionPeer::Relay { relay_id }` depending on which endpoint accepted
+it. The distinction matters for cleanup and routing: only *client*
+publishers/subscribers own route-registry entries, so the directory
+tracks peer kind to detect when the last client leaves a namespace
+(then the Redis route may be dropped), and relay-learned namespaces are
+purged rather than trusted after their subscribers disappear.
+
+### 3. Event pipeline: one reader, one worker per session
+All session events funnel into a single unbounded channel consumed by
+`EventHandler` (`event_handler.rs`), which implements a
+**reader/worker** structure:
+
+- The **reader** never awaits peer responses; it only routes each event
+  to a per-session unbounded channel (lazily creating a worker task per
+  `SessionId`, tracked in a `JoinSet`). Cross-session deadlock is
+  therefore structurally impossible.
+- Each **session worker** processes its events strictly in FIFO order,
+  fully awaiting each sequence handler (including upstream round
+  trips) before the next event. Ordering per session, concurrency
+  across sessions; a slow session cannot head-of-line block others.
+- Terminal events (`Disconnected`, `ProtocolViolation`) run idempotent
+  `cleanup_session` and end the worker; the reader reaps it via
+  `JoinSet` and removes the channel.
+
+### 4. Control-plane orchestration lives in `sequences/`
+Each MoQT request type has a sequence struct (`Subscribe`, `Publish`,
+`PublishNamespace`, `Fetch`, …) whose `handle()` implements the relay
+behavior for that message: update the `LocalPubSubDirectory`, respond
+via the handler, forward control messages to other sessions
+(`ControlMessageForwarder`), start/stop ingress and egress, and cascade
+to other relays (`CascadingRelayContext`). `event_handler.rs` is pure
+dispatch; the protocol logic is in `sequences/*`.
+
+Supporting pieces:
+- `sequences/tables/` — `LocalPubSubDirectory` trait + in-memory
+  implementation: who publishes/subscribes what on this relay, upstream
+  subscription refcounts (`downstream_subscriber_count`), and what must
+  be torn down when a session is removed
+  (`RemovedSessionSubscriptions`).
+- `sequences/upstream_serializer.rs` — serializes concurrent upstream
+  subscription creation so two SUBSCRIBEs for the same track create one
+  upstream, not two.
+
+### 5. Data plane is decoupled from the control plane via cache + broadcast
+Object flow is **write-once, read-per-subscriber**:
+
+1. **Ingress** (`relay/ingress/`): one ingress per (track, publisher
+   session) reads upstream subgroup streams / datagrams, appends every
+   object into the `TrackCache`, and publishes a `TrackEvent` on the
+   track's broadcast channel (`ObjectNotifyProducerMap`).
+2. **Egress** (`relay/egress/`): one runner per (subscriber session,
+   subscribe ID) reads objects out of the cache — catching up from its
+   start location, then following live notifications — and writes them
+   to its downstream session. Fetch is served the same way, straight
+   from the cache range.
+
+Consequences: a new subscriber never perturbs the publisher path or
+other subscribers; slow subscribers fall behind independently; FETCH
+and late joins are cache reads, not upstream round trips.
+
+### 6. Cache structure and eviction
+`TrackCacheStore` (DashMap keyed by `TrackKey` = namespace + name) →
+`TrackCache` (BTreeMaps of groups, separately for stream subgroups and
+datagrams) → `GroupCache` (objects). A periodic eviction job
+(`cache/eviction_job.rs`) TTL-evicts old groups and removes a track
+entry only when nobody else holds its `Arc` (`strong_count == 1`),
+avoiding races with concurrently joining ingress/egress. The cache also
+answers `largest_location()`, used to fill SUBSCRIBE_OK — taking the
+max of cache and upstream SUBSCRIBE_OK so a publisher rejoin does not
+resurrect stale locations (`sequences/subscribe.rs`).
+
+### 7. Multi-relay: route registry + inter-relay connections
+Horizontal scaling is namespace-based:
+
+- `route_registry/` — `RelayRouteRegistry` trait mapping
+  `track_namespace` → publishing relay (`RelayInfo`) and namespace
+  prefixes → subscribing relays. Two implementations: `Noop`
+  (standalone relay, everything local) and `Redis` (shared registry;
+  enabled when `REDIS_URL` is set). Registration is conflict-checked:
+  one active publisher route per namespace.
+- `inter_relay.rs` — `InterRelayConnectionManager` lazily dials the
+  owning relay's *inner* QUIC endpoint and registers the session as a
+  `Relay` peer, reusing one session per remote relay.
+- `upstream_publisher_resolver.rs` — on SUBSCRIBE, decides whether the
+  upstream is a local publisher session or a remote relay reached
+  through the registry + connection manager.
+- Namespace announcements (PUBLISH_NAMESPACE etc.) cascade to
+  interested relays via `CascadingRelayContext`.
+
+### 8. Shared state is minimal and explicit (`RelayStore`)
+Only two things are shared across the whole runtime: the
+`TrackCacheStore` and the `ObjectNotifyProducerMap`. Everything else is
+owned by a coordinator task and driven by commands
+(`IngressCommand`/`EgressCommand` over bounded mpsc channels), keeping
+locking narrow. `SessionRepository` sits behind a `tokio::sync::Mutex`
+and is the main cross-cutting lock; handlers take it briefly and never
+across upstream awaits where avoidable.
+
+### 9. Observability is structured around session spans
+Every session gets a root tracing span (`relay.session`) carrying
+session id, peer kind, relay id and hostname; every event, sequence,
+ingress and egress span is parented to (or linked with, for
+cross-session flows like ingress) that span. OpenTelemetry export is
+wired in `logging.rs`. When adding relay logic, keep new spans inside
+this hierarchy.
+
+## Consequences
+- Adding relay behavior for a new control message means: a handler
+  trait in `core/handler/`, a `SessionEvent` variant + resolver arm, a
+  sequence struct in `sequences/`, and a dispatch arm in
+  `event_handler.rs`.
+- Per-session FIFO makes reasoning simple but means one session's slow
+  upstream round trip delays that session's later events by design.
+- The cache is the source of truth for late joiners and FETCH; bugs in
+  eviction or `largest_location` surface as wrong SUBSCRIBE_OK content
+  or stale replays, so changes there need E2E coverage
+  (`scripts/run-media-e2e.mjs`, cache-eviction E2E).
+
+## References
+- `spec/draft-ietf-moq-transport-14.txt` (relay-related sections)
+- `../moqt/architecture.md` — the underlying protocol crate
+- `docker-compose.yml` — two-relay + Redis local topology


### PR DESCRIPTION
## 対応内容

`moqt` / `relay` 両クレートの設計意図を整理したアーキテクチャドキュメントを追加し、AGENTS.md から参照できるようにしました。

## 変更点

- `architecture_decision_record/moqt/architecture.md` を新規作成
  - レイヤ構成（transport / control_plane / data_plane / domains / runtime）の整理
  - 主要な設計判断の記録: `TransportProtocol` によるジェネリクスベースのトランスポート抽象、`DUAL`（1ポートで WebTransport + raw QUIC）、`SessionContext` によるリクエスト/レスポンス相関とタイムアウト、SUBSCRIBE_OK 前のオブジェクトバッファリング、typestate によるヘッダ先行送信の保証、wasm 向け `wire` モジュール分離など
- `architecture_decision_record/relay/architecture.md` を新規作成
  - レイヤ構成（relay_server / core / sequences / relay(ingress・egress・cache) / route_registry / inter_relay など）の整理
  - 主要な設計判断の記録: `core/` でのトランスポート消去、単一リーダー + セッションごとワーカーのイベントパイプライン（セッション内 FIFO・セッション間並行）、cache + broadcast によるデータプレーンの分離、TTL エビクション、Redis ルートレジストリによるマルチリレー構成など
- `AGENTS.md` の §2 Project Scope に「Architecture Documentation」節を追加
  - 両ドキュメントへの参照と、構造的な変更の前に該当ドキュメントを読み、設計が変わった場合は更新するルールを明記

## 意図

コードから読み取りにくい設計判断（なぜジェネリクスか、なぜ per-session worker か、など）を明文化することで、人間・AI エージェント双方が構造変更時に設計意図を踏まえて作業できるようにするためです。AGENTS.md から参照させることで、エージェントが `moqt` / `relay` に手を入れる際に必ず設計ドキュメントへ辿り着けるようにしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)