### PR TITLE
test(relay): cover unsubscribe sequence, stream ingress, and upstream resolver

### DIFF
--- a/relay/src/modules/relay/ingress/stream_reader.rs
+++ b/relay/src/modules/relay/ingress/stream_reader.rs
@@ -163,3 +163,270 @@ impl Drop for StreamReader {
         self.join_handle.abort();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use moqt::{
+        ExtensionHeaders, SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField,
+        wire::ObjectStatus,
+    };
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    struct ScriptedStreamReceiver {
+        objects: VecDeque<DataObject>,
+        // Fired once all scripted objects were consumed; lets tests order a
+        // stop signal after ingestion without racing the read loop.
+        exhausted_sender: Option<oneshot::Sender<()>>,
+        hang_when_exhausted: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl StreamReceiver for ScriptedStreamReceiver {
+        async fn receive_object(&mut self) -> anyhow::Result<DataObject> {
+            if let Some(object) = self.objects.pop_front() {
+                return Ok(object);
+            }
+            if let Some(sender) = self.exhausted_sender.take() {
+                let _ = sender.send(());
+            }
+            if self.hang_when_exhausted {
+                std::future::pending::<()>().await;
+            }
+            anyhow::bail!("stream closed")
+        }
+    }
+
+    fn make_header(group_id: u64) -> DataObject {
+        DataObject::SubgroupHeader(SubgroupHeader::new(
+            0,
+            group_id,
+            SubgroupId::Value(0),
+            0,
+            false,
+            false,
+        ))
+    }
+
+    fn empty_extension_headers() -> ExtensionHeaders {
+        ExtensionHeaders {
+            prior_group_id_gap: vec![],
+            prior_object_id_gap: vec![],
+            immutable_extensions: vec![],
+        }
+    }
+
+    fn make_payload_object(object_id_delta: u64) -> DataObject {
+        let message_type =
+            SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false).message_type;
+        DataObject::SubgroupObject(SubgroupObjectField {
+            message_type,
+            object_id_delta,
+            extension_headers: empty_extension_headers(),
+            subgroup_object: SubgroupObject::new_payload(Bytes::from(vec![1])),
+        })
+    }
+
+    fn make_end_of_group_object() -> DataObject {
+        let message_type =
+            SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false).message_type;
+        DataObject::SubgroupObject(SubgroupObjectField {
+            message_type,
+            object_id_delta: 0,
+            extension_headers: empty_extension_headers(),
+            subgroup_object: SubgroupObject::new_status(ObjectStatus::EndOfGroup as u64),
+        })
+    }
+
+    struct TestEnv {
+        track_key: TrackKey,
+        cache_store: Arc<TrackCacheStore>,
+        notify_map: Arc<ObjectNotifyProducerMap>,
+        event_receiver: tokio::sync::broadcast::Receiver<TrackEvent>,
+        stop_sender: watch::Sender<bool>,
+        stop_receiver: watch::Receiver<bool>,
+    }
+
+    fn make_env() -> TestEnv {
+        let track_key = TrackKey::new("ns", "track");
+        let cache_store = Arc::new(TrackCacheStore::new());
+        let notify_map = Arc::new(ObjectNotifyProducerMap::new());
+        let event_receiver = notify_map.get_or_create(&track_key).subscribe();
+        let (stop_sender, stop_receiver) = watch::channel(false);
+        TestEnv {
+            track_key,
+            cache_store,
+            notify_map,
+            event_receiver,
+            stop_sender,
+            stop_receiver,
+        }
+    }
+
+    async fn assert_subgroup_closed_after(env: &TestEnv, group_id: u64, last_object_id: u64) {
+        let cache = env.cache_store.get_or_create(&env.track_key);
+        let subgroup = StreamSubgroupId::Value(0);
+        let closed = tokio::time::timeout(
+            Duration::from_secs(1),
+            cache.stream_object_from_or_wait(group_id, &subgroup, last_object_id + 1),
+        )
+        .await
+        .expect("subgroup should be closed, not waiting for more objects");
+        assert!(closed.is_none());
+    }
+
+    #[tokio::test]
+    async fn end_of_group_status_closes_subgroup_and_notifies() {
+        let mut env = make_env();
+        let receiver = ScriptedStreamReceiver {
+            objects: VecDeque::from([
+                make_header(0),
+                make_payload_object(0),
+                make_end_of_group_object(),
+            ]),
+            exhausted_sender: None,
+            hang_when_exhausted: false,
+        };
+
+        StreamReader::read_loop(
+            env.track_key.clone(),
+            Box::new(receiver),
+            env.stop_receiver.clone(),
+            env.cache_store.clone(),
+            env.notify_map.clone(),
+        )
+        .await;
+
+        assert!(matches!(
+            env.event_receiver.try_recv(),
+            Ok(TrackEvent::StreamOpened { group_id: 0, .. })
+        ));
+        assert!(matches!(
+            env.event_receiver.try_recv(),
+            Ok(TrackEvent::EndOfGroup)
+        ));
+
+        let cache = env.cache_store.get_or_create(&env.track_key);
+        let subgroup = StreamSubgroupId::Value(0);
+        let (payload_id, _) = cache
+            .stream_object_from_or_wait(0, &subgroup, 0)
+            .await
+            .expect("payload object should be cached");
+        assert_eq!(payload_id, 0);
+        let (status_id, _) = cache
+            .stream_object_from_or_wait(0, &subgroup, 1)
+            .await
+            .expect("end-of-group status object should be cached");
+        assert_eq!(status_id, 1);
+        assert_subgroup_closed_after(&env, 0, 1).await;
+    }
+
+    #[tokio::test]
+    async fn receiver_error_closes_open_subgroup() {
+        let mut env = make_env();
+        let receiver = ScriptedStreamReceiver {
+            objects: VecDeque::from([make_header(0), make_payload_object(0)]),
+            exhausted_sender: None,
+            hang_when_exhausted: false,
+        };
+
+        StreamReader::read_loop(
+            env.track_key.clone(),
+            Box::new(receiver),
+            env.stop_receiver.clone(),
+            env.cache_store.clone(),
+            env.notify_map.clone(),
+        )
+        .await;
+
+        assert!(matches!(
+            env.event_receiver.try_recv(),
+            Ok(TrackEvent::StreamOpened { group_id: 0, .. })
+        ));
+        assert!(matches!(
+            env.event_receiver.try_recv(),
+            Ok(TrackEvent::EndOfGroup)
+        ));
+        assert_subgroup_closed_after(&env, 0, 0).await;
+    }
+
+    #[tokio::test]
+    async fn stop_signal_closes_open_subgroup() {
+        let mut env = make_env();
+        let (exhausted_sender, exhausted_receiver) = oneshot::channel();
+        let receiver = ScriptedStreamReceiver {
+            objects: VecDeque::from([make_header(0), make_payload_object(0)]),
+            exhausted_sender: Some(exhausted_sender),
+            hang_when_exhausted: true,
+        };
+
+        let read_task = tokio::spawn(StreamReader::read_loop(
+            env.track_key.clone(),
+            Box::new(receiver),
+            env.stop_receiver.clone(),
+            env.cache_store.clone(),
+            env.notify_map.clone(),
+        ));
+
+        exhausted_receiver
+            .await
+            .expect("reader should consume all scripted objects");
+        env.stop_sender.send(true).expect("stop signal should send");
+        tokio::time::timeout(Duration::from_secs(1), read_task)
+            .await
+            .expect("read loop should stop on signal")
+            .expect("read loop should not panic");
+
+        assert!(matches!(
+            env.event_receiver.try_recv(),
+            Ok(TrackEvent::StreamOpened { group_id: 0, .. })
+        ));
+        assert!(matches!(
+            env.event_receiver.try_recv(),
+            Ok(TrackEvent::EndOfGroup)
+        ));
+        assert_subgroup_closed_after(&env, 0, 0).await;
+    }
+
+    #[tokio::test]
+    async fn resolves_absolute_object_ids_from_deltas() {
+        let mut env = make_env();
+        let receiver = ScriptedStreamReceiver {
+            // deltas 0, 0, 1 resolve to absolute ids 0, 1, 3
+            objects: VecDeque::from([
+                make_header(0),
+                make_payload_object(0),
+                make_payload_object(0),
+                make_payload_object(1),
+            ]),
+            exhausted_sender: None,
+            hang_when_exhausted: false,
+        };
+
+        StreamReader::read_loop(
+            env.track_key.clone(),
+            Box::new(receiver),
+            env.stop_receiver.clone(),
+            env.cache_store.clone(),
+            env.notify_map.clone(),
+        )
+        .await;
+        // silence unused warnings for the fields this test does not exercise
+        let _ = (&env.stop_sender, &mut env.event_receiver);
+
+        let cache = env.cache_store.get_or_create(&env.track_key);
+        let subgroup = StreamSubgroupId::Value(0);
+        let mut object_ids = Vec::new();
+        let mut cursor = 0;
+        while let Some((id, _)) = cache.stream_object_from_or_wait(0, &subgroup, cursor).await {
+            object_ids.push(id);
+            cursor = id + 1;
+        }
+        assert_eq!(object_ids, vec![0, 1, 3]);
+    }
+}

--- a/relay/src/modules/sequences/unsubscribe.rs
+++ b/relay/src/modules/sequences/unsubscribe.rs
@@ -105,3 +105,258 @@ impl Unsubscribe {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::modules::{
+        core::{
+            data_receiver::receiver::DataReceiver, handler::publish::SubscribeOption,
+            publisher::Publisher, session::Session, session_event::MoqtSessionEvent,
+            subscriber::Subscriber, subscription::UpstreamSubscription,
+        },
+        enums::ContentExists,
+        sequences::tables::{
+            hashmap_table::InMemoryLocalPubSubDirectory,
+            table::{ActiveUpstreamSubscription, UpstreamSubscriptionKey},
+        },
+        session_repository::SessionRepository,
+        types::TrackKey,
+    };
+
+    const PUBLISHER_SESSION: SessionId = 1;
+    const UPSTREAM_REQUEST_ID: u64 = 42;
+
+    struct MockUnsubscribeHandler {
+        subscribe_id: u64,
+    }
+
+    impl UnsubscribeHandler for MockUnsubscribeHandler {
+        fn subscribe_id(&self) -> u64 {
+            self.subscribe_id
+        }
+    }
+
+    struct MockSubscriber {
+        unsubscribed_request_ids: Arc<Mutex<Vec<u64>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Subscriber for MockSubscriber {
+        async fn _send_subscribe_namespace(&self, _namespace: String) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn send_subscribe(
+            &mut self,
+            _track_namespace: String,
+            _track_name: String,
+            _option: SubscribeOption,
+        ) -> anyhow::Result<UpstreamSubscription> {
+            unimplemented!("not used in unsubscribe tests")
+        }
+
+        async fn send_unsubscribe(&self, subscribe_id: u64) -> anyhow::Result<()> {
+            self.unsubscribed_request_ids
+                .lock()
+                .unwrap()
+                .push(subscribe_id);
+            Ok(())
+        }
+
+        async fn send_unsubscribe_namespace(&self, _namespace: String) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn create_data_receiver(
+            &mut self,
+            _subscription: &UpstreamSubscription,
+        ) -> anyhow::Result<DataReceiver> {
+            unimplemented!("not used in unsubscribe tests")
+        }
+    }
+
+    struct MockSession {
+        unsubscribed_request_ids: Arc<Mutex<Vec<u64>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Session for MockSession {
+        fn as_publisher(&self) -> Box<dyn Publisher> {
+            unimplemented!("not used in unsubscribe tests")
+        }
+
+        fn as_subscriber(&self) -> Box<dyn Subscriber> {
+            Box::new(MockSubscriber {
+                unsubscribed_request_ids: self.unsubscribed_request_ids.clone(),
+            })
+        }
+
+        async fn receive_moqt_session_event(&self) -> anyhow::Result<MoqtSessionEvent> {
+            std::future::pending().await
+        }
+    }
+
+    struct TestContext {
+        table: InMemoryLocalPubSubDirectory,
+        forwarder: ControlMessageForwarder,
+        ingress_sender: mpsc::Sender<IngressCommand>,
+        ingress_receiver: mpsc::Receiver<IngressCommand>,
+        egress_sender: mpsc::Sender<EgressCommand>,
+        egress_receiver: mpsc::Receiver<EgressCommand>,
+        unsubscribed_request_ids: Arc<Mutex<Vec<u64>>>,
+    }
+
+    async fn setup(
+        origin: UpstreamSubscriptionOrigin,
+        downstream_subscriptions: &[(SessionId, u64)],
+    ) -> TestContext {
+        let table = InMemoryLocalPubSubDirectory::new();
+        let upstream_key = UpstreamSubscriptionKey {
+            publisher_session_id: PUBLISHER_SESSION,
+            track_namespace: "ns".to_string(),
+            track_name: "track".to_string(),
+        };
+        table.register_upstream_subscription(
+            upstream_key.clone(),
+            ActiveUpstreamSubscription {
+                upstream_request_id: UPSTREAM_REQUEST_ID,
+                track_key: TrackKey::new("ns", "track"),
+                expires: None,
+                content_exists: ContentExists::False,
+                downstream_subscriber_count: 0,
+                origin,
+            },
+        );
+        for (session_id, subscribe_id) in downstream_subscriptions {
+            assert!(table.register_downstream_subscription(
+                *session_id,
+                *subscribe_id,
+                upstream_key.clone(),
+                None,
+            ));
+        }
+
+        let unsubscribed_request_ids = Arc::new(Mutex::new(Vec::new()));
+        let mut repository = SessionRepository::new();
+        let (session_event_sender, _session_event_receiver) = mpsc::unbounded_channel();
+        repository
+            .add_client(
+                PUBLISHER_SESSION,
+                Box::new(MockSession {
+                    unsubscribed_request_ids: unsubscribed_request_ids.clone(),
+                }),
+                session_event_sender,
+                tracing::Span::none(),
+            )
+            .await;
+        let forwarder = ControlMessageForwarder {
+            repository: Arc::new(tokio::sync::Mutex::new(repository)),
+        };
+
+        let (ingress_sender, ingress_receiver) = mpsc::channel(8);
+        let (egress_sender, egress_receiver) = mpsc::channel(8);
+        TestContext {
+            table,
+            forwarder,
+            ingress_sender,
+            ingress_receiver,
+            egress_sender,
+            egress_receiver,
+            unsubscribed_request_ids,
+        }
+    }
+
+    async fn run_unsubscribe(ctx: &TestContext, session_id: SessionId, subscribe_id: u64) {
+        Unsubscribe
+            .handle(
+                session_id,
+                &tracing::Span::none(),
+                &ctx.table,
+                &ctx.forwarder,
+                &ctx.ingress_sender,
+                &ctx.egress_sender,
+                Box::new(MockUnsubscribeHandler { subscribe_id }),
+            )
+            .await;
+    }
+
+    #[tokio::test]
+    async fn last_subscriber_forwards_upstream_unsubscribe_and_stops_ingress() {
+        let mut ctx = setup(UpstreamSubscriptionOrigin::Subscribe, &[(100, 10)]).await;
+
+        run_unsubscribe(&ctx, 100, 10).await;
+
+        match ctx.egress_receiver.try_recv() {
+            Ok(EgressCommand::StopReader {
+                subscriber_session_id,
+                downstream_subscribe_id,
+            }) => {
+                assert_eq!(subscriber_session_id, 100);
+                assert_eq!(downstream_subscribe_id, 10);
+            }
+            other => panic!("Expected StopReader, got {:?}", other.is_ok()),
+        }
+        assert_eq!(
+            *ctx.unsubscribed_request_ids.lock().unwrap(),
+            vec![UPSTREAM_REQUEST_ID]
+        );
+        match ctx.ingress_receiver.try_recv() {
+            Ok(IngressCommand::StopTrack {
+                track_key,
+                publisher_session_id,
+            }) => {
+                assert_eq!(track_key, TrackKey::new("ns", "track"));
+                assert_eq!(publisher_session_id, PUBLISHER_SESSION);
+            }
+            other => panic!("Expected StopTrack, got {:?}", other.is_ok()),
+        }
+    }
+
+    #[tokio::test]
+    async fn remaining_subscribers_keep_upstream_subscription() {
+        let mut ctx = setup(
+            UpstreamSubscriptionOrigin::Subscribe,
+            &[(100, 10), (101, 11)],
+        )
+        .await;
+
+        run_unsubscribe(&ctx, 100, 10).await;
+
+        assert!(matches!(
+            ctx.egress_receiver.try_recv(),
+            Ok(EgressCommand::StopReader { .. })
+        ));
+        assert!(ctx.unsubscribed_request_ids.lock().unwrap().is_empty());
+        assert!(ctx.ingress_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn publish_origin_keeps_upstream_subscription() {
+        let mut ctx = setup(UpstreamSubscriptionOrigin::Publish, &[(100, 10)]).await;
+
+        run_unsubscribe(&ctx, 100, 10).await;
+
+        assert!(matches!(
+            ctx.egress_receiver.try_recv(),
+            Ok(EgressCommand::StopReader { .. })
+        ));
+        assert!(ctx.unsubscribed_request_ids.lock().unwrap().is_empty());
+        assert!(ctx.ingress_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn unknown_subscription_sends_no_commands() {
+        let mut ctx = setup(UpstreamSubscriptionOrigin::Subscribe, &[]).await;
+
+        run_unsubscribe(&ctx, 100, 10).await;
+
+        assert!(ctx.egress_receiver.try_recv().is_err());
+        assert!(ctx.unsubscribed_request_ids.lock().unwrap().is_empty());
+        assert!(ctx.ingress_receiver.try_recv().is_err());
+    }
+}

--- a/relay/src/modules/upstream_publisher_resolver.rs
+++ b/relay/src/modules/upstream_publisher_resolver.rs
@@ -45,6 +45,13 @@ impl UpstreamPublisherResolver {
             .await
     }
 
+    // TODO(draft-14 8.4.2 Graceful Publisher Relay Switchover): min session_id
+    // implements first-writer-wins, which conflicts with GOAWAY migration —
+    // during the switchover overlap the NEWER session is the correct target
+    // for new subscriptions, while the old one keeps serving established
+    // ones. Introduce a per-session Active/Draining status (mirroring
+    // route_registry::RouteStatus) and prefer Active publishers here,
+    // keeping min session_id only as the deterministic tie-break.
     async fn find_local_publisher(
         &self,
         table: &dyn LocalPubSubDirectory,
@@ -199,6 +206,10 @@ mod tests {
         )
     }
 
+    // Pins the current first-writer-wins policy (min session_id = oldest).
+    // Expected to change to "Active first, min session_id as tie-break" once
+    // GOAWAY migration adds per-session Active/Draining status (see the
+    // find_local_publisher TODO).
     #[tokio::test]
     async fn prefers_local_publisher_and_picks_min_session_id() {
         let table = InMemoryLocalPubSubDirectory::new();

--- a/relay/src/modules/upstream_publisher_resolver.rs
+++ b/relay/src/modules/upstream_publisher_resolver.rs
@@ -103,3 +103,140 @@ impl UpstreamPublisherResolver {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::{
+        route_registry::{
+            NamespaceRoute, RegisterNamespacePublisherError, RegisterNamespaceSubscriberError,
+            RelayInfo, RouteStatus,
+        },
+        sequences::tables::{hashmap_table::InMemoryLocalPubSubDirectory, table::PeerKind},
+        session_repository::SessionRepository,
+    };
+
+    enum PublisherLookup {
+        NotFound,
+        Fails,
+        MustNotBeCalled,
+    }
+
+    struct StubRouteRegistry {
+        lookup: PublisherLookup,
+    }
+
+    #[async_trait::async_trait]
+    impl RelayRouteRegistry for StubRouteRegistry {
+        async fn register_namespace_publisher(
+            &self,
+            _track_namespace: &str,
+            _status: RouteStatus,
+        ) -> Result<(), RegisterNamespacePublisherError> {
+            unimplemented!("not used in resolver tests")
+        }
+
+        async fn register_namespace_subscriber(
+            &self,
+            _track_namespace_prefix: &str,
+            _status: RouteStatus,
+        ) -> Result<(), RegisterNamespaceSubscriberError> {
+            unimplemented!("not used in resolver tests")
+        }
+
+        async fn find_active_namespace_publisher(
+            &self,
+            _track_namespace: &str,
+        ) -> anyhow::Result<Option<RelayInfo>> {
+            match self.lookup {
+                PublisherLookup::NotFound => Ok(None),
+                PublisherLookup::Fails => Err(anyhow::anyhow!("route registry down")),
+                PublisherLookup::MustNotBeCalled => {
+                    panic!("route registry must not be consulted when a local publisher exists")
+                }
+            }
+        }
+
+        async fn find_namespace_publishers_by_prefix(
+            &self,
+            _track_namespace_prefix: &str,
+        ) -> anyhow::Result<Vec<NamespaceRoute>> {
+            unimplemented!("not used in resolver tests")
+        }
+
+        async fn unregister_namespace_publisher(
+            &self,
+            _track_namespace: &str,
+        ) -> anyhow::Result<()> {
+            unimplemented!("not used in resolver tests")
+        }
+
+        async fn unregister_namespace_subscriber(
+            &self,
+            _track_namespace_prefix: &str,
+        ) -> anyhow::Result<()> {
+            unimplemented!("not used in resolver tests")
+        }
+
+        async fn find_namespace_subscribers(
+            &self,
+            _track_namespace: &str,
+        ) -> anyhow::Result<Vec<RelayInfo>> {
+            unimplemented!("not used in resolver tests")
+        }
+    }
+
+    fn make_resolver(lookup: PublisherLookup) -> UpstreamPublisherResolver {
+        let repository = Arc::new(tokio::sync::Mutex::new(SessionRepository::new()));
+        let (session_event_sender, _session_event_receiver) =
+            tokio::sync::mpsc::unbounded_channel();
+        UpstreamPublisherResolver::new(
+            Arc::new(StubRouteRegistry { lookup }),
+            Arc::new(InterRelayConnectionManager::new(
+                repository,
+                session_event_sender,
+            )),
+        )
+    }
+
+    #[tokio::test]
+    async fn prefers_local_publisher_and_picks_min_session_id() {
+        let table = InMemoryLocalPubSubDirectory::new();
+        table.register_publish_namespace(5, "ns".to_string(), PeerKind::Client);
+        table.register_publish_namespace(3, "ns".to_string(), PeerKind::Client);
+        let resolver = make_resolver(PublisherLookup::MustNotBeCalled);
+
+        let resolved = resolver
+            .resolve(&table, "ns", "track")
+            .await
+            .expect("resolve should succeed")
+            .expect("local publisher should be found");
+
+        assert_eq!(resolved.publisher_session_id, 3);
+        assert_eq!(resolved.track_namespace, "ns");
+        assert_eq!(resolved.track_name, "track");
+    }
+
+    #[tokio::test]
+    async fn returns_none_when_no_publisher_anywhere() {
+        let table = InMemoryLocalPubSubDirectory::new();
+        let resolver = make_resolver(PublisherLookup::NotFound);
+
+        let resolved = resolver
+            .resolve(&table, "ns", "track")
+            .await
+            .expect("resolve should succeed");
+
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn propagates_route_registry_error() {
+        let table = InMemoryLocalPubSubDirectory::new();
+        let resolver = make_resolver(PublisherLookup::Fails);
+
+        let result = resolver.resolve(&table, "ns", "track").await;
+
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## 概要

これまでユニットテストがなかった relay の3箇所に、計11件のテストを追加します。テストのみの変更で、プロダクションコードには手を入れていません。

それぞれ「どういう状況で・何が起きるのが正常か」を以下に整理します。

## 1. `sequences/unsubscribe.rs` — UNSUBSCRIBE 受信時の上流購読の解体判断(4件)

リレーは1つの上流購読を複数の downstream 購読者で共有します。UNSUBSCRIBE を受けたとき「上流ごと解体してよいか」を参照カウントと購読の起源(origin)で判断する分岐を検証します。

| テストケース | 状況 | 正常とする挙動 |
| --- | --- | --- |
| `last_subscriber_forwards_upstream_unsubscribe_and_stops_ingress` | 上流購読(origin=Subscribe)の購読者が1人だけで、その1人が UNSUBSCRIBE | 本人への配信停止(`EgressCommand::StopReader`)に加えて、上流へ `UNSUBSCRIBE` を転送し、`IngressCommand::StopTrack` で取り込みも止める |
| `remaining_subscribers_keep_upstream_subscription` | 2人が同じ上流購読を共有し、うち1人が UNSUBSCRIBE | 解除した本人の `StopReader` のみ。上流 `UNSUBSCRIBE` も `StopTrack` も送らず、残る購読者への配信を維持する |
| `publish_origin_keeps_upstream_subscription` | 上流購読の origin が Publish(publisher 主導)で、最後の購読者が UNSUBSCRIBE | `StopReader` のみ。publisher 主導で始まった上流購読はリレー側から解除しない |
| `unknown_subscription_sends_no_commands` | テーブルに存在しない `(session_id, subscribe_id)` への UNSUBSCRIBE(二重解除・切断処理とのレースなど) | 警告ログのみで何のコマンドも送らない。存在しない購読の解除で共有リソースを壊さない |

検証方法: モックの `Session`/`Subscriber` を実物の `SessionRepository` に登録し、上流へ転送された `UNSUBSCRIBE` の request_id を記録して assert しています。ingress / egress へのコマンドは mpsc チャネルの受信側で観測します。

## 2. `relay/ingress/stream_reader.rs` — オブジェクト取り込みループの終端処理(4件)

`read_loop` は publisher からのストリームを読んでキャッシュに書き込みます。終端時に `close_stream_subgroup` を取りこぼすと、キャッシュを待つ egress 側の `*_or_wait` が永久に待ち続け、downstream のストリームが終わらなくなります。3つの終端経路すべてで close されることを検証します。

| テストケース | 状況 | 正常とする挙動 |
| --- | --- | --- |
| `end_of_group_status_closes_subgroup_and_notifies` | ヘッダ+オブジェクトの後に EndOfGroup ステータスオブジェクトを受信 | ステータスも含めてキャッシュに保存した上で subgroup を close し、`TrackEvent::EndOfGroup` を通知して読み取りを終了する |
| `receiver_error_closes_open_subgroup` | subgroup が開いたままレシーバーが `Err` を返す(ストリーム終端 FIN・切断・デコード失敗) | 開いている subgroup を close し、`EndOfGroup` を通知して終了する |
| `stop_signal_closes_open_subgroup` | subgroup が開いた状態で stop シグナルを受信(上流購読の解体時など) | 同上 |
| `resolves_absolute_object_ids_from_deltas` | オブジェクトの id がワイヤ上は delta 形式で届く(delta 0, 0, 1) | 絶対 object_id 0, 1, 3 に解決されてキャッシュに載る |

検証方法: 事前に決めた列を順に返すスクリプト式のモックレシーバーを使用。stop のテストは「全オブジェクト消費後」を oneshot で通知してから stop を送ることで、`select!` のレースによる flaky 化を避けています。

## 3. `upstream_publisher_resolver.rs` — publisher の解決先の優先順位(3件)

SUBSCRIBE されたトラックの publisher を「ローカル接続 → route registry(リモートリレー)」の順で探す解決ロジックを検証します。

| テストケース | 状況 | 正常とする挙動 |
| --- | --- | --- |
| `prefers_local_publisher_and_picks_min_session_id` | ローカルに publisher が2セッション(id 5 と 3)存在 | route registry には一切問い合わせず(スタブは呼ばれたら panic)、最小の session_id 3 を決定的に選ぶ |
| `returns_none_when_no_publisher_anywhere` | ローカルにも route registry にも publisher がいない | `Ok(None)` を返す(呼び出し側が SUBSCRIBE_ERROR を返せる) |
| `propagates_route_registry_error` | route registry への問い合わせ自体が失敗(Redis 障害など) | `Err` として伝播する。「publisher がいない」と「確認できなかった」を混同しない |

### 将来の変更予定について

`prefers_local_publisher_and_picks_min_session_id` が固定しているのは現行の first-writer-wins ポリシー(最小 session_id = 最古セッション)の**決定性**であり、選択ルール自体を仕様として確定させる意図ではありません。

draft-14 §8.4.2(Graceful Publisher Relay Switchover)では、GOAWAY を受けた publisher は新セッションで PUBLISH した後も**旧セッションへの送信をただちには止めない**ため、移行中は新旧2セッションが同じトラックの publisher として同居します。このとき新規 SUBSCRIBE の正しい解決先は「新しい方」なので、GOAWAY / session migration 対応の際には、ローカルにも route registry の `RouteStatus` と対称な **Active / Draining ステータス**を導入し、選択ルールを「Active 優先 + min session_id はタイブレーク」へ変更する予定です。その時点でこのテストの期待値も書き換わります(コード上の該当箇所とテストに TODO / NOTE コメントを残しています)。

## テスト

- `cargo test -p relay`(72件パス、うち11件追加)
- `cargo fmt --check`、`cargo clippy -p relay --all-targets` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
