### PR TITLE
fix(deps): resolve cargo audit vulnerabilities for quick-xml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+[advisories]
+ignore = [
+    # quick-xml 0.39.4 DoS advisories (fixed in >=0.41.0). The only remaining
+    # dependent is wayland-scanner, a proc-macro that parses Wayland protocol
+    # XML bundled at build time, so no untrusted input reaches quick-xml.
+    # No wayland-scanner release accepts quick-xml 0.41 yet (master pins 0.40);
+    # remove these once wayland-scanner ships with quick-xml >=0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arboard"
@@ -4198,7 +4198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -7178,9 +7177,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.2"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
 dependencies = [
  "serde",
  "winnow",
@@ -7189,12 +7188,12 @@ dependencies = [
 
 [[package]]
 name = "zbus_xml"
-version = "5.1.1"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
+checksum = "59ab0513c0a66a60a8718d5ad712a5094845a20d95b5c1c81e2bd8e904a52b4f"
 dependencies = [
- "quick-xml",
  "serde",
+ "winnow",
  "zbus_names",
  "zvariant",
 ]
@@ -7302,9 +7301,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.12.0"
+version = "5.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
 dependencies = [
  "endi",
  "enumflags2",
@@ -7316,9 +7315,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.12.0"
+version = "5.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7329,9 +7328,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

`cargo audit` was failing with two high-severity advisories against **quick-xml 0.39.4**:

- [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195): Unbounded namespace-declaration allocation in `NsReader` (DoS)
- [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194): Quadratic run time when checking duplicate attribute names

Both are fixed in quick-xml >= 0.41.0. quick-xml entered the tree via two paths:

| Path | Resolution |
|---|---|
| `zbus_xml 5.1.1` (runtime D-Bus introspection XML, via accesskit/atspi) | **Fixed**: updated to `zbus_xml 5.2.0`, which drops quick-xml entirely (replaced with winnow). Pulls in `zvariant 5.13.0` / `zbus_names 4.3.3` / `zvariant_utils 3.5.0`. |
| `wayland-scanner 0.31.10` (build-time proc-macro) | **Ignored with justification** in `.cargo/audit.toml`: no wayland-scanner release accepts quick-xml >= 0.41 (upstream master still pins 0.40). It only parses Wayland protocol XML bundled at build time, so no untrusted input reaches quick-xml. The ignore should be removed once wayland-scanner ships with quick-xml >= 0.41. |

Additionally updated `anyhow` 1.0.102 → 1.0.103, which clears the [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) unsound warning (`Error::downcast_mut()`).

All updates are semver-compatible; no manifest changes were needed. `cargo audit` now exits 0 (one remaining allowed warning: `ttf-parser` unmaintained, transitive via eframe, no fix available).

## Test plan

All run locally against the updated `Cargo.lock` (relay Docker image rebuilt from this lock):

- [x] `cargo audit` passes
- [x] `make test` (workspace unit + doc tests)
- [x] `scripts/fetch-e2e.sh`
- [x] `scripts/cascading-relay-e2e.sh`
- [x] `scripts/cache-eviction-e2e.sh`
- [x] `scripts/multiple-publishers-e2e.sh`
- [x] `scripts/object-dedup-e2e.sh`
- [x] `make browser-e2e-media` (1 passed)
- [x] `make browser-e2e-call` (6 passed)

Note: fetch-e2e and object-dedup-e2e each failed once on first run with a fetch-before-cache race ("No cached track for fetch" / partial fetch range) and passed on rerun; the flake is unrelated to this dependency bump (the updated crates are Linux GUI-only deps plus an anyhow patch release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)