### PR TITLE
docs(moqt): document moqt and relay architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ Application and integration components (draft reference is normally not required
 
 - `moqt` is the central crate — all other crates depend on it. Changes to `moqt` affect the entire workspace.
 
+### Architecture Documents
+- Architecture documents live under `architecture_decision_record/${package_name}/architecture.md`:
+  - `architecture_decision_record/moqt/architecture.md` — `moqt` crate architecture
+  - `architecture_decision_record/relay/architecture.md` — `relay` crate architecture
+- Before making structural changes to a component (module layout, layering, task/channel topology), read its architecture document first.
+- When a change alters the design intent, module boundaries, runtime flow, or key invariants described in an architecture document, update that document in the same change.
+
 ## 3. Specifications
 - MoQT-related specifications are stored in the `spec` directory.
 - For library components listed in the draft-governed table above, use only the draft listed in `Related Draft` as the authoritative specification. Do not consult other drafts unless the task explicitly requires them.

--- a/architecture_decision_record/moqt/architecture.md
+++ b/architecture_decision_record/moqt/architecture.md
@@ -1,0 +1,180 @@
+# `moqt` Architecture
+
+## Status
+Living document. Update this file in the same change whenever the design intent,
+module boundaries, runtime flow, or invariants described here change.
+
+## Scope
+The `moqt` crate is the core implementation of Media over QUIC Transport
+(draft-ietf-moq-transport-14). Every other crate in the workspace depends on it:
+`relay` builds a server on top of it, `bindings/wasm` reuses its message codecs,
+and the bridges/examples use its client API.
+
+## Layering
+
+```
+lib.rs (public re-exports)        wire.rs (raw message codecs, wasm-safe)
+        │
+        ▼
+modules/moqt/domains      ← public API objects (Endpoint, Session, Publisher, …)
+modules/moqt/runtime      ← background tasks + incoming-object dispatch
+modules/moqt/control_plane← control messages, handlers, session events
+modules/moqt/data_plane   ← object formats, stream/datagram send/receive, codecs
+modules/moqt/protocol.rs  ← TransportProtocol trait + QUIC/WEBTRANSPORT/DUAL markers
+        │
+        ▼
+modules/transport         ← transport abstraction + quinn/web-transport-quinn impls
+```
+
+- `lib.rs` re-exports the session-level API. Everything except the message
+  codecs is `#[cfg(not(target_arch = "wasm32"))]`; on wasm32 only
+  `control_plane` and `data_plane` compile, which is what `bindings/wasm`
+  consumes.
+- `wire.rs` re-exports raw control-message structs, framing helpers
+  (`encode_control_message` / `take_control_message`), and data-plane object
+  types for consumers that need direct wire access (the relay uses
+  `moqt::wire::FetchType`, the wasm bindings use the codecs).
+
+## Transport layer (`modules/transport`)
+
+`protocol.rs` defines the `TransportProtocol` trait with four associated types:
+
+```rust
+trait TransportProtocol {
+    type ConnectionCreator: TransportConnectionCreator;
+    type Connection: TransportConnection;
+    type SendStream: TransportSendStream;
+    type ReceiveStream: TransportReceiveStream;
+}
+```
+
+Three zero-sized markers implement it:
+
+| Marker | Implementation | Notes |
+| --- | --- | --- |
+| `QUIC` | quinn, ALPN `moq-00` | raw QUIC; used for inter-relay links and native clients |
+| `WEBTRANSPORT` | web-transport-quinn, ALPN `h3` | browser-facing |
+| `DUAL` | quinn endpoint dispatching on negotiated ALPN | **server-only**; accepts both `h3` (WebTransport handshake) and `moq-00` (raw QUIC) on one port. Client-side constructors `bail!`. |
+
+The whole session stack is generic over `T: TransportProtocol`, so protocol
+selection is a compile-time type parameter (e.g. `Endpoint::<moqt::DUAL>`),
+not a runtime branch — except inside `DualConnection`, which wraps either
+variant behind one connection type.
+
+## Session establishment (`modules/moqt/domains`)
+
+Flow: `Endpoint` → `Connecting` (a boxed `Future`) → `Session`.
+
+- `Endpoint::create_client(&ClientConfig)` / `create_server(&ServerConfig)`
+  build a `SessionCreator` around the transport's `ConnectionCreator`.
+- `connect()` / `accept()` return `Connecting<T>`, whose future performs the
+  transport handshake, opens/accepts the bidirectional control stream, and runs
+  the SETUP exchange in `SessionContextFactory` (CLIENT_SETUP/SERVER_SETUP,
+  version `0xff00000e` = draft-14).
+- On success a `Session<T>` is created.
+
+### `Session` and its background tasks
+
+`Session::new` spawns four tasks (all named via `tokio::task::Builder`, all
+aborted in `Drop`):
+
+| Task | Role |
+| --- | --- |
+| `ControlMessageReceiveTask` | reads the control stream, decodes messages, routes them (see below). Holds only a `Weak<SessionContext>` so it cannot keep the session alive. |
+| `UniStreamReceiveTask` | accepts incoming unidirectional streams; the first frame must be a subgroup header (→ `SubscriptionNotifier`) or fetch header (→ `FetchNotifier`). |
+| `DatagramReceiveTask` | receives datagrams, decodes `ObjectDatagram`, dispatches via `SubscriptionNotifier`. |
+| `DisconnectWatchTask` | awaits transport close, then emits `SessionEvent::Disconnected`. |
+
+`Session::publisher()` / `subscriber()` return lightweight `Publisher<T>` /
+`Subscriber<T>` facades sharing the same `Arc<SessionContext<T>>`. Application
+code consumes inbound control messages through
+`Session::receive_event() -> SessionEvent<T>`.
+
+### `SessionContext` — shared session state
+
+One struct owns all cross-task state:
+
+- `request_id: AtomicU64` — starts at 1, incremented by 2 per request.
+- `track_alias: AtomicU64` — server-side track alias allocation
+  (`SubscribeHandler::allocate_track_alias`). `Publisher::publish` uses a
+  separate process-global `NEXT_TRACK_ALIAS` counter.
+- `sender_map: HashMap<RequestId, oneshot::Sender<ResponseMessage>>` —
+  request/response correlation. Registration returns a `RegisteredSender`
+  drop-guard that removes the entry on drop, so cancelled requests never leak
+  senders.
+- `object_sinks: HashMap<track_alias, ObjectSink>` — see buffering invariant
+  below.
+- `fetch_notification_map` / `fetch_receiver_map` — keyed by request id, used
+  for FETCH data streams.
+
+## Control plane (`modules/moqt/control_plane`)
+
+- `control_messages/messages/*` — one struct per draft-14 control message with
+  `encode`/`decode`. Framing (varint type + **16-bit fixed length**, a draft-14
+  change) lives in `wire.rs`.
+- `handler/*` — received-message facades handed to the application inside
+  `SessionEvent` (e.g. `SubscribeHandler::ok(...)`, `::error(...)`). They keep
+  an `Arc<SessionContext>` so responding does not require the `Session`.
+- `enums.rs` — `SessionEvent<T>` (inbound requests + `Disconnected` /
+  `ProtocolViolation`) and the crate-private `ResponseMessage`.
+- `constants.rs` — protocol version and `TerminationErrorCode` (draft-14
+  §13.1.1).
+
+`ControlMessageReceiveTask` splits every decoded message into one of two paths:
+
+1. **Requests** (SUBSCRIBE, PUBLISH, FETCH, namespace messages, …) become
+   `SessionEvent` variants delivered to `Session::receive_event()`.
+2. **Responses** (`*_OK` / `*_ERROR`) are matched against `sender_map` by
+   request id and complete the pending `oneshot`.
+
+## Data plane (`modules/moqt/data_plane`)
+
+- `object/*` — wire formats: `SubgroupHeader` (types `0x10..=0x1D` encoding
+  subgroup-id mode / extensions / end-of-group), `SubgroupObject`,
+  `ObjectDatagram`, `FetchObject`, `ExtensionHeaders`, `ObjectStatus`.
+- `codec/*` — incremental decoders (`ControlMessageDecoder`,
+  `UniStreamDecoder`, `SubgroupDecoder`, `FetchDecoder`) over a shared
+  `tokio_reader`.
+- `stream/*` — send/receive wrappers:
+  - `StreamDataSenderFactory::next()` opens one uni stream per subgroup and
+    returns a `StreamDataSender`.
+  - `StreamDataSender` uses a **typestate** (`Uninitialized` → `send_header()`
+    → `HeaderSent`) so "header before objects" is enforced at compile time.
+  - `StreamDataReceiverFactory` / `StreamDataReceiver`, `DatagramSender` /
+    `DatagramReceiver`, `FetchDataSender` / `FetchDataReceiver` mirror this on
+    the other side.
+
+## Runtime dispatch (`modules/moqt/runtime/dispatch`)
+
+- `SubscriptionNotifier` routes incoming objects by track alias into
+  `SessionContext::object_sinks`.
+- `FetchNotifier` routes FETCH streams by request id.
+- `IncomingObject<T>` is the internal envelope (`StreamHeader` / `Datagram` /
+  `Fetch`).
+
+## Key invariants
+
+- **Buffer-before-subscribe**: objects can arrive before the application
+  registers a receiver (data races SUBSCRIBE_OK). `object_sinks` buffers up to
+  256 objects per track alias (`SubscriptionNotifier::MAX_PENDING_OBJECTS_PER_TRACK_ALIAS`),
+  dropping the oldest on overflow. `register_data_receiver` drains the buffer
+  into the new channel atomically under the sinks lock.
+- **Duplicate track alias**: if SUBSCRIBE_OK carries a track alias that already
+  has a registered receiver, the subscriber closes the session with
+  `DuplicateTrackAlias` (draft-14 §9.8).
+- **Unknown response request id**: a response that matches no `sender_map`
+  entry is a protocol violation; the session is closed with
+  `ProtocolViolation`.
+- **Control response timeout**: `SessionContext::await_response` bounds every
+  request/response wait to 10 s; on timeout the session is closed with
+  `ControlMessageTimeout` (draft-14 §12.2).
+- **Header-first subgroup streams**: enforced by the sender typestate; on the
+  receive side a uni stream whose first frame is not a header is rejected.
+- **Session teardown**: dropping `Session` aborts all four background tasks;
+  the control task's `Weak` reference guarantees it never keeps the context
+  alive.
+
+## Testing conventions
+Unit tests live in `#[cfg(test)] mod tests` inside the module under test
+(Arrange/Act/Assert, see `wire.rs` framing round-trip tests). Cross-crate
+behaviour is covered by the workspace-level E2E suites under `tests/`.

--- a/architecture_decision_record/relay/architecture.md
+++ b/architecture_decision_record/relay/architecture.md
@@ -1,0 +1,202 @@
+# `relay` Architecture
+
+## Status
+Living document. Update this file in the same change whenever the design intent,
+module boundaries, runtime flow, or invariants described here change.
+
+## Scope
+The `relay` crate is a MoQT relay server (draft-ietf-moq-transport-14, relay
+sections) built on the `moqt` crate. It fans publisher tracks out to
+subscribers, caches objects per track, serves FETCH from that cache, and
+optionally cascades across relays via a Redis-backed route registry.
+
+## Startup path
+
+`main.rs`:
+1. `init_logging` (tracing + OpenTelemetry OTLP export).
+2. Generate self-signed certs under `relay/keys/` if missing.
+3. `RelayConfig::from_env()` — `RELAY_ID`, `RELAY_ADVERTISE_HOST`,
+   `RELAY_PORT` (default 4433), `RELAY_INNER_PORT` (default port+1),
+   `REDIS_URL` (optional).
+4. `RelayServer::new_with_config(...)` then:
+   - `spawn_client_transport::<moqt::DUAL>(port)` — client-facing endpoint
+     accepting both WebTransport and raw QUIC on one port.
+   - `spawn_inner_transport::<moqt::QUIC>(inner_port)` — inter-relay endpoint.
+
+`RelayServer` (in `relay_server/`) wires three long-lived pieces:
+
+- `SessionRepository` (shared `Arc<Mutex<_>>`).
+- `RelayStore` — `TrackCacheStore` + `ObjectNotifyProducerMap`, the shared
+  data-plane state.
+- `RelayRuntime` — constructs `InterRelayConnectionManager`,
+  `UpstreamPublisherResolver`, `IngressCoordinator`, `EgressCoordinator`,
+  `EventHandler`, and the cache-eviction job, and returns the relay-wide
+  `SessionEvent` sender.
+
+## Control plane
+
+### Session intake
+`SessionHandler` runs one accept loop per endpoint. Each accepted `moqt`
+session is boxed as `dyn core::session::Session` and added to
+`SessionRepository` tagged with a `SessionPeer` (`Client` or
+`Relay { relay_id }`) — the peer kind of the endpoint it arrived on.
+
+### `modules/core` — transport-erased `moqt` facade
+The relay never handles `moqt::Session<T>` generically beyond intake. `core`
+defines object-safe traits (`Session`, `Publisher`, `Subscriber`, one
+`handler::*` trait per control message, `subscription`, `data_receiver`,
+`data_sender`) implemented for every `T: TransportProtocol`. Everything past
+the repository works with `Box<dyn …>`.
+
+### Event pipeline
+
+```
+moqt session ──receive_event()──► Session Event Forwarder (one task per session)
+      │  MoqtSessionEvent → RelaySessionEventResolver → SessionEvent(session_id, handler)
+      ▼
+EventHandler reader (single task, never awaits handlers)
+      │  per-session unbounded channel (lazily created)
+      ▼
+session worker (one task per session, FIFO)
+      │
+      ▼
+sequences::{PublishNamespace, Subscribe, Fetch, …}.handle(...)
+```
+
+- `SessionRepository::start_session_event_forwarding` spawns a forwarder task
+  per session that pumps `moqt` events into the relay-wide unbounded channel,
+  stopping after `Disconnected` / `ProtocolViolation`.
+- `EventHandler` implements a **reader/worker** structure: the single reader
+  only dispatches to per-session unbounded channels, so a slow or blocked
+  session can never head-of-line-block another (unit tests in
+  `event_handler.rs` pin this). Workers process one event at a time, fully
+  awaiting each sequence (including upstream round-trips) — events within a
+  session are strictly ordered.
+- Terminal events (`Disconnected` / `ProtocolViolation`) trigger
+  `cleanup_session` (idempotent) and end the worker. Cleanup: remove the
+  session from the pub/sub directory, stop affected egress readers, forward
+  upstream UNSUBSCRIBE / stop ingress when the last downstream subscriber
+  left, withdraw namespace routes for client sessions, then drop the session
+  from the repository.
+
+### `modules/sequences` — one struct per control message
+Each sequence owns the relay-side protocol logic for one message
+(`publish`, `subscribe`, `fetch`, `publish_namespace`,
+`publish_namespace_done`, `subscribe_namespace`, `unsubscribe`,
+`unsubscribe_namespace`). Shared collaborators:
+
+- `ControlMessageForwarder` — sends control messages on *other* sessions via
+  the repository (e.g. forwarding SUBSCRIBE upstream, PUBLISH_NAMESPACE to
+  interested subscribers).
+- `LocalPubSubDirectory` (trait; `InMemoryLocalPubSubDirectory` impl in
+  `tables/`) — the relay's in-memory registry of publish/subscribe namespaces
+  (with `PeerKind` so client-owned Redis routes are cleaned up when the last
+  *client* leaves), active upstream subscriptions, and downstream
+  subscriptions. `remove_session` returns everything cleanup needs.
+- `UpstreamCreationSerializer` — per-(namespace, track) async lock.
+
+### SUBSCRIBE sequence (the central flow)
+1. **Find-or-create upstream subscription.** Fast path: an
+   `ActiveUpstreamSubscription` already exists in the directory. Miss: take
+   the per-track serializer lock, re-check (a sibling may have created it),
+   otherwise resolve a publisher and send upstream SUBSCRIBE, start ingress,
+   and register the upstream subscription — so concurrent subscribers to the
+   same track produce exactly one upstream subscription.
+2. **Publisher resolution** (`UpstreamPublisherResolver`): local directory
+   first (lowest publisher session id wins), then the route registry for a
+   remote relay, dialled via `InterRelayConnectionManager`.
+3. **Largest Object resolution**: max of the upstream SUBSCRIBE_OK location
+   and the local cache's largest location (`resolve_subscribe_largest`). The
+   cache is consulted even for a fresh upstream: a publisher that rejoined
+   under the same track must not make the relay advertise
+   `contentExists=false` and replay stale cache from {0,0}.
+4. **Downstream registration + egress start**: register the downstream
+   subscription, send `EgressCommand::StartReader` and wait for the runner's
+   readiness `oneshot`, then send SUBSCRIBE_OK with the allocated track alias
+   and resolved largest location — SUBSCRIBE_OK and egress start always agree.
+
+### FETCH sequence
+Resolve the track and object range (Standalone from the message; Relative
+Joining from the downstream subscription's start location), reply FETCH_OK,
+then delegate to `EgressCommand::StartFetch`, which serves the range entirely
+from `TrackCache` over a new uni stream.
+
+## Data plane
+
+### Shared state (`RelayStore`)
+- `TrackCacheStore` — `DashMap<TrackKey, Arc<TrackCache>>`.
+- `ObjectNotifyProducerMap` — `DashMap<TrackKey, broadcast::Sender<TrackEvent>>`
+  (capacity 256); ingress announces new objects, egress schedulers listen.
+
+### Ingress (`modules/relay/ingress`)
+`IngressCoordinator` consumes `IngressCommand::{Start, StopTrack}`:
+
+- On `Start`, it obtains the upstream session's `Subscriber`, creates the data
+  receiver (cancellable via a per-track `watch` stop channel), and hands it to
+  `StreamIngressTask` (subgroup streams) or `DatagramReader` (datagrams).
+- `StreamIngressTask` runs a per-track factory loop accepting subgroup
+  streams. **First-publisher-wins**: a second publisher on an active track is
+  ignored (draft-14 §8.2 multiple-publisher dedup is a known TODO), and only
+  the owning publisher's `Stop` tears the reader down.
+- Readers append every object into `TrackCache` and broadcast a `TrackEvent`.
+
+### Cache (`modules/relay/cache`)
+- `TrackCache`: `group_id → subgroup_id → GroupCache` for streams plus a
+  parallel `group_id → GroupCache` map for datagrams; answers
+  `largest_location()` and `get_fetch_objects(range)`.
+- Eviction job (`eviction_job.rs`): every `RELAY_CACHE_EVICT_INTERVAL_SECS`
+  (5 s) evict groups older than `RELAY_CACHE_TTL_SECS` (30 s); a `TrackCache`
+  entry is removed from the store only when its `Arc::strong_count == 1`,
+  i.e. no ingress/egress holds it — avoiding races with new joiners.
+
+### Egress (`modules/relay/egress`)
+`EgressCoordinator` consumes `StartReader` / `StopReader` / `StartFetch` and
+keeps one runner per `(subscriber_session_id, downstream_subscribe_id)`
+(restart replaces the old runner). `EgressRunner` splits into:
+
+- `EgressScheduler` — listens on the track's broadcast channel and the cache,
+  computes the delivery start per draft-14 filter type (`NextGroupStart`,
+  `LargestObject`, `AbsoluteStart`, `AbsoluteRange`; an absolute start at or
+  below Largest is clamped to Largest+1), and emits `GroupSendTask`s.
+- `GroupSender` — opens downstream subgroup streams / datagrams via the
+  session's `Publisher` and transmits cached objects in order.
+
+## Cascading relays (`route_registry`, `inter_relay`)
+
+- `RelayRouteRegistry` trait: `NoopRelayRouteRegistry` (single-relay, no
+  `REDIS_URL`) or `RedisRelayRouteRegistry` (relay info hash with 15 s TTL
+  refreshed by a 5 s heartbeat; namespace-publisher and namespace-subscriber
+  routes with the same TTL scheme).
+- Only **client-origin** namespaces register routes: `PublishNamespace`
+  registers the publisher route and notifies remote subscriber relays;
+  `SubscribeNamespace` registers the subscriber route when the first client
+  subscriber for a prefix appears.
+- `InterRelayConnectionManager` lazily dials the remote relay's inner endpoint
+  over raw QUIC (`moqt::QUIC`, certificate verification disabled) and
+  registers the session as `SessionPeer::Relay`, reusing it afterwards. From
+  then on the remote relay behaves like any upstream publisher session.
+
+## Key invariants
+
+- **Reader never awaits**: the `EventHandler` reader only routes; all awaiting
+  happens in per-session workers. Cross-session deadlock is structurally
+  impossible; per-session ordering is FIFO.
+- **One upstream subscription per track**: enforced by the
+  `UpstreamCreationSerializer` per-track lock with a double-check.
+- **SUBSCRIBE_OK matches egress**: the largest location advertised downstream
+  is the same value the egress scheduler starts from.
+- **First-publisher-wins ingress**: one active reader per track; stop is
+  owner-checked.
+- **Cache lifetime**: a track cache lives while referenced or until TTL
+  eviction with `strong_count == 1`.
+- **Client-owned routes**: Redis namespace routes are registered/withdrawn
+  only for client-origin sessions; relay-learned namespaces are purged locally
+  when the last client subscriber for the prefix leaves.
+
+## Testing conventions
+Unit tests are colocated (`#[cfg(test)]`) and pin structural invariants —
+e.g. reader/worker non-blocking and terminal-event handling in
+`event_handler.rs`, largest-location resolution in `sequences/subscribe.rs`,
+eviction refcount rules in `cache/store.rs`. Multi-process behaviour
+(cascading relays, cache eviction, fetch, multiple publishers, dedup) lives in
+the workspace-level `tests/*-e2e` suites driven by `scripts/run-*.mjs`.


### PR DESCRIPTION
## 対応内容

`moqt` と `relay` のアーキテクチャドキュメントを新規作成し、`AGENTS.md` から参照できるようにしました。

## 変更点

- `architecture_decision_record/moqt/architecture.md` を新規作成
  - レイヤ構成(transport / control_plane / data_plane / domains / runtime)
  - `TransportProtocol` トレイトと QUIC / WEBTRANSPORT / DUAL(サーバ専用・ALPN 分岐)の関係
  - `Endpoint → Connecting → Session` の確立フローと Session が抱える4つの常駐タスク
  - `SessionContext` による request/response 相関(sender_map + drop-guard、10秒タイムアウト)
  - 主要 invariant(track alias ごとの先行オブジェクトバッファ、DuplicateTrackAlias / ProtocolViolation でのセッション close、typestate による header-first 強制など)
- `architecture_decision_record/relay/architecture.md` を新規作成
  - 起動経路(client 面 DUAL + inner 面 QUIC)と `RelayServer` / `RelayRuntime` の構成
  - `modules/core` によるトランスポート消去、EventHandler の reader/worker 構造(セッション単位 FIFO・セッション間並行)
  - SUBSCRIBE シーケンス(per-track serializer による upstream 一意化、cache と SUBSCRIBE_OK の max を取る largest-location 解決)
  - ingress の first-publisher-wins、cache の TTL + strong_count 削除、Redis route registry と inter-relay カスケード
- `AGENTS.md` にアーキテクチャドキュメントのセクションを追加
  - ドキュメント一覧
  - 構造的な変更前に該当ドキュメントを読むこと
  - 設計意図・モジュール境界・runtime flow・invariant が変わる変更では同一変更でドキュメントも更新すること

## 変更の意図

現状、`moqt` / `relay` の設計意図(モジュール境界、タスク・チャネル構成、invariant)がコードにしか存在せず、構造的な変更時に把握コストが高い状態でした。実装を直接調査した内容をドキュメント化し、AGENTS.md から参照させることで、今後の変更時に設計と実装の乖離を防ぎます。

## レビュー時の補足

- ドキュメントは現在の実装(master 159eda57 時点)を調査して書き起こしたもので、コード変更は含みません。
- ドキュメント内に記載した既知ギャップ: 複数パブリッシャの per-object dedup(draft-14 §8.2 の SHOULD)は未実装で、first-publisher-wins が暫定挙動です(`relay/src/modules/relay/ingress/stream_ingress_task.rs` の FIXME)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)