### PR TITLE
fix(relay): FETCHがingest中のグループ・切断直後のキャッシュを取りこぼす競合を修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -1727,13 +1727,13 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand 0.9.4",
+ "portable-atomic",
  "siphasher",
 ]
 
@@ -2039,11 +2039,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2053,11 +2051,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4202,9 +4202,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4222,21 +4222,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -4246,16 +4247,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4354,6 +4355,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "range-alloc"
@@ -4563,7 +4573,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4733,6 +4743,27 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -6609,15 +6640,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6649,28 +6671,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6695,12 +6700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6711,12 +6710,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6731,22 +6724,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6761,12 +6742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6777,12 +6752,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6797,12 +6766,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6813,12 +6776,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -118,8 +118,8 @@ impl GroupCache {
     }
 
     /// Returns all cached objects in object_id order. The subgroup header is not included.
-    /// Production reads go through `object_from_or_wait`; a snapshot can miss
-    /// objects still in flight.
+    /// Test-only: production reads use `object_from_or_wait` since a snapshot can miss
+    /// in-flight objects.
     #[cfg(test)]
     pub(crate) async fn objects_snapshot(&self) -> Vec<(u64, Arc<DataObject>)> {
         self.objects

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -118,6 +118,9 @@ impl GroupCache {
     }
 
     /// Returns all cached objects in object_id order. The subgroup header is not included.
+    /// Production reads go through `object_from_or_wait`; a snapshot can miss
+    /// objects still in flight.
+    #[cfg(test)]
     pub(crate) async fn objects_snapshot(&self) -> Vec<(u64, Arc<DataObject>)> {
         self.objects
             .read()

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -44,12 +44,14 @@ impl TrackCacheStore {
             }
         }
         // Only TTL-drained (empty) tracks may be removed: an unreferenced track
-        // must keep serving FETCH until then. strong_count==1 only guards
-        // against a writer re-attaching between the emptiness check and
-        // remove_if (appending requires holding a track Arc).
+        // must keep serving FETCH until then. Both conditions are re-checked
+        // under the shard lock because a writer may attach — or attach, write,
+        // and detach — after the emptiness loop above. With strong_count == 1
+        // no other Arc exists, so try_read inside is_empty_sync cannot fail.
         for key in empty_keys {
-            self.caches
-                .remove_if(&key, |_, track| Arc::strong_count(track) == 1);
+            self.caches.remove_if(&key, |_, track| {
+                Arc::strong_count(track) == 1 && track.is_empty_sync()
+            });
         }
     }
 }

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -37,9 +37,21 @@ impl TrackCacheStore {
         for (_, track) in &entries {
             track.evict(ttl).await;
         }
+        // A track is removed only once its groups have all drained through the
+        // TTL above; strong_count alone must not delete it — a track whose
+        // publisher already disconnected still has to serve FETCH until the
+        // TTL expires. Appending requires holding a track Arc (strong_count
+        // >= 2), so the emptiness observed here cannot be invalidated by the
+        // time remove_if re-checks the count under the shard lock.
+        let mut empty_keys = Vec::new();
+        for (key, track) in &entries {
+            if track.is_empty().await {
+                empty_keys.push(key.clone());
+            }
+        }
         // Drop the snapshot Arcs before the strong_count check so it counts only real holders.
-        let keys: Vec<TrackKey> = entries.into_iter().map(|(key, _)| key).collect();
-        for key in keys {
+        drop(entries);
+        for key in empty_keys {
             self.caches
                 .remove_if(&key, |_, track| Arc::strong_count(track) == 1);
         }
@@ -60,6 +72,57 @@ mod tests {
         // Act
         store.evict(Duration::from_secs(10)).await;
         // Assert: strong_count == 1, so the track is reclaimed
+        assert!(store.get(&key).is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_keeps_unreferenced_track_with_fresh_objects() {
+        use crate::modules::{core::data_object::DataObject, relay::types::StreamSubgroupId};
+        use moqt::{
+            ExtensionHeaders, SubgroupHeader, SubgroupId, SubgroupObject, SubgroupObjectField,
+        };
+
+        // Arrange: a publisher ingested one closed group and disconnected, so
+        // only the store holds the track (strong_count == 1).
+        let ttl = Duration::from_secs(30);
+        let store = TrackCacheStore::new();
+        let key = TrackKey::new("ns", "track");
+        let subgroup = StreamSubgroupId::Value(0);
+        {
+            let track = store.get_or_create(&key);
+            let header = SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false);
+            let message_type = header.message_type;
+            track
+                .append_stream_object(0, &subgroup, None, DataObject::SubgroupHeader(header))
+                .await;
+            track
+                .append_stream_object(
+                    0,
+                    &subgroup,
+                    Some(0),
+                    DataObject::SubgroupObject(SubgroupObjectField {
+                        message_type,
+                        object_id_delta: 0,
+                        extension_headers: ExtensionHeaders {
+                            prior_group_id_gap: vec![],
+                            prior_object_id_gap: vec![],
+                            immutable_extensions: vec![],
+                        },
+                        subgroup_object: SubgroupObject::new_payload(bytes::Bytes::new()),
+                    }),
+                )
+                .await;
+            track.close_stream_subgroup(0, &subgroup).await;
+        }
+
+        // Act / Assert: within the TTL the track must survive to serve FETCH.
+        tokio::time::advance(Duration::from_secs(1)).await;
+        store.evict(ttl).await;
+        assert!(store.get(&key).is_some());
+
+        // Act / Assert: once the groups drain past the TTL, the track is reclaimed.
+        tokio::time::advance(Duration::from_secs(31)).await;
+        store.evict(ttl).await;
         assert!(store.get(&key).is_none());
     }
 

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -44,10 +44,14 @@ impl TrackCacheStore {
             }
         }
         // Only TTL-drained (empty) tracks may be removed: an unreferenced track
-        // must keep serving FETCH until then. Both conditions are re-checked
-        // under the shard lock because a writer may attach — or attach, write,
-        // and detach — after the emptiness loop above. With strong_count == 1
-        // no other Arc exists, so try_read inside is_empty_sync cannot fail.
+        // must keep serving FETCH until then. Two guards close the gap between
+        // the emptiness loop above and the removal here:
+        // - strong_count == 1: a session attached right now (e.g. an ingress
+        //   that acquired the cache but has not appended yet) will write to
+        //   this handle; removing the track under it would orphan those writes.
+        // - is_empty_sync: a writer may attach, write, and detach entirely
+        //   within the gap, leaving fresh objects behind at count == 1;
+        //   re-checking content under the shard lock keeps them.
         for key in empty_keys {
             self.caches.remove_if(&key, |_, track| {
                 Arc::strong_count(track) == 1 && track.is_empty_sync()

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -34,21 +34,19 @@ impl TrackCacheStore {
             .iter()
             .map(|entry| (entry.key().clone(), entry.value().clone()))
             .collect();
-        for (_, track) in &entries {
-            track.evict(ttl).await;
-        }
-        // Only TTL-drained (empty) tracks may be removed: an unreferenced track
-        // must keep serving FETCH until then. strong_count==1 below only guards
-        // against a writer re-attaching between this check and remove_if
-        // (appending requires holding a track Arc).
+        // Consuming the snapshot drops each Arc with its iteration, so the
+        // strong_count check below sees only real holders.
         let mut empty_keys = Vec::new();
-        for (key, track) in &entries {
+        for (key, track) in entries {
+            track.evict(ttl).await;
             if track.is_empty().await {
-                empty_keys.push(key.clone());
+                empty_keys.push(key);
             }
         }
-        // Drop the snapshot Arcs before the strong_count check so it counts only real holders.
-        drop(entries);
+        // Only TTL-drained (empty) tracks may be removed: an unreferenced track
+        // must keep serving FETCH until then. strong_count==1 only guards
+        // against a writer re-attaching between the emptiness check and
+        // remove_if (appending requires holding a track Arc).
         for key in empty_keys {
             self.caches
                 .remove_if(&key, |_, track| Arc::strong_count(track) == 1);

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -46,9 +46,10 @@ impl TrackCacheStore {
         // Only TTL-drained (empty) tracks may be removed: an unreferenced track
         // must keep serving FETCH until then. Two guards close the gap between
         // the emptiness loop above and the removal here:
-        // - strong_count == 1: a session attached right now (e.g. an ingress
-        //   that acquired the cache but has not appended yet) will write to
-        //   this handle; removing the track under it would orphan those writes.
+        // - strong_count == 1: even though the track is empty, a session
+        //   holding its Arc (e.g. an ingress that acquired the cache but has
+        //   not appended yet) may still write through that handle; removing
+        //   the track under it would orphan those writes.
         // - is_empty_sync: a writer may attach, write, and detach entirely
         //   within the gap, leaving fresh objects behind at count == 1;
         //   re-checking content under the shard lock keeps them.

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -37,12 +37,10 @@ impl TrackCacheStore {
         for (_, track) in &entries {
             track.evict(ttl).await;
         }
-        // A track is removed only once its groups have all drained through the
-        // TTL above; strong_count alone must not delete it — a track whose
-        // publisher already disconnected still has to serve FETCH until the
-        // TTL expires. Appending requires holding a track Arc (strong_count
-        // >= 2), so the emptiness observed here cannot be invalidated by the
-        // time remove_if re-checks the count under the shard lock.
+        // Only TTL-drained (empty) tracks may be removed: an unreferenced track
+        // must keep serving FETCH until then. strong_count==1 below only guards
+        // against a writer re-attaching between this check and remove_if
+        // (appending requires holding a track Arc).
         let mut empty_keys = Vec::new();
         for (key, track) in &entries {
             if track.is_empty().await {

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -255,17 +255,13 @@ impl TrackCache {
         //   group=1: skip object_id 0,1,2 -> include 3,4,...
         //   group=2: include object_id 0,1,2,3,4 -> stop before 5 (exclusive)
         //
-        // QUIC gives no cross-stream ordering, so a later group's stream can
-        // complete while an earlier group is still in flight (e.g. its packet
-        // was lost and awaits retransmission). A snapshot taken at that moment
-        // would silently drop the in-flight objects from the response, so wait
-        // for each open group instead; ingress closes every group when its
-        // stream ends, errs, or the publisher leaves, which bounds the wait.
+        // QUIC gives no cross-stream ordering, so groups in range may still be
+        // in flight; wait on open groups instead of snapshotting (ingress
+        // always closes them, bounding the wait).
         let mut fetch_objects = Vec::new();
         for (group_id, cache) in caches_in_range {
             let Some(header) = cache.header_or_wait().await else {
-                // Closed before a header arrived; nothing to deliver.
-                continue;
+                continue; // closed before a header arrived
             };
             let (publisher_priority, subgroup_id) = match header.as_ref() {
                 DataObject::SubgroupHeader(h) => (h.publisher_priority, h.subgroup_id.resolve()),
@@ -281,9 +277,8 @@ impl TrackCache {
                 0
             };
             loop {
-                // End Location is exclusive; end.object_id == 0 is a special case
-                // meaning "the entire group". Checked before waiting so a fetch
-                // ending inside a live group does not block on objects past it.
+                // End Location is exclusive (object_id == 0 = entire group);
+                // checked before waiting so we never block on objects past it.
                 if group_id == end.group_id && end.object_id != 0 && next_object_id >= end.object_id
                 {
                     break;
@@ -489,8 +484,8 @@ mod tests {
         fill_group_with_ids(cache, group_id, &object_ids).await;
     }
 
-    // Fills a group and closes it, like ingress does when the stream ends.
-    // get_fetch_objects waits on open groups, so fetch tests need closed ones.
+    // get_fetch_objects waits on open groups, so fetch tests use closed ones
+    // (like ingress leaves them once the stream ends).
     async fn fill_closed_group_with_ids(cache: &TrackCache, group_id: u64, object_ids: &[u64]) {
         fill_group_with_ids(cache, group_id, object_ids).await;
         cache

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -155,9 +155,13 @@ impl TrackCache {
         self.stream_groups.read().await.is_empty() && self.datagram_groups.read().await.is_empty()
     }
 
-    /// Non-blocking emptiness check for sync contexts (the eviction `remove_if`
-    /// closure). Lock contention means someone is using the track, so report
-    /// non-empty to keep it.
+    /// Non-blocking `is_empty` for the eviction `remove_if` closure, which is
+    /// sync and runs under the DashMap shard lock: it re-validates emptiness at
+    /// the moment of removal (a writer may have attached, written, and
+    /// detached since the async pre-check). With strong_count == 1 checked
+    /// first no other Arc exists, so try_read cannot actually be contended;
+    /// treating contention as non-empty is a defensive fallback that errs
+    /// toward keeping the track.
     pub(crate) fn is_empty_sync(&self) -> bool {
         self.stream_groups
             .try_read()

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -155,6 +155,21 @@ impl TrackCache {
         self.stream_groups.read().await.is_empty() && self.datagram_groups.read().await.is_empty()
     }
 
+    /// Non-blocking emptiness check for sync contexts (the eviction `remove_if`
+    /// closure). Lock contention means someone is using the track, so report
+    /// non-empty to keep it.
+    pub(crate) fn is_empty_sync(&self) -> bool {
+        self.stream_groups
+            .try_read()
+            .map(|groups| groups.is_empty())
+            .unwrap_or(false)
+            && self
+                .datagram_groups
+                .try_read()
+                .map(|groups| groups.is_empty())
+                .unwrap_or(false)
+    }
+
     /// Returns the Largest Location as defined in the MoQT spec.
     pub(crate) async fn largest_location(&self) -> Option<moqt::Location> {
         let (group_id, cache) = {

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -151,6 +151,10 @@ impl TrackCache {
         }
     }
 
+    pub(crate) async fn is_empty(&self) -> bool {
+        self.stream_groups.read().await.is_empty() && self.datagram_groups.read().await.is_empty()
+    }
+
     /// Returns the Largest Location as defined in the MoQT spec.
     pub(crate) async fn largest_location(&self) -> Option<moqt::Location> {
         let (group_id, cache) = {
@@ -250,10 +254,17 @@ impl TrackCache {
         // Example for start={group=1, object=3}, end={group=2, object=5}:
         //   group=1: skip object_id 0,1,2 -> include 3,4,...
         //   group=2: include object_id 0,1,2,3,4 -> stop before 5 (exclusive)
+        //
+        // QUIC gives no cross-stream ordering, so a later group's stream can
+        // complete while an earlier group is still in flight (e.g. its packet
+        // was lost and awaits retransmission). A snapshot taken at that moment
+        // would silently drop the in-flight objects from the response, so wait
+        // for each open group instead; ingress closes every group when its
+        // stream ends, errs, or the publisher leaves, which bounds the wait.
         let mut fetch_objects = Vec::new();
         for (group_id, cache) in caches_in_range {
-            let Some(header) = cache.header().await else {
-                tracing::error!("unexpected: GroupCache has no subgroup header");
+            let Some(header) = cache.header_or_wait().await else {
+                // Closed before a header arrived; nothing to deliver.
                 continue;
             };
             let (publisher_priority, subgroup_id) = match header.as_ref() {
@@ -264,24 +275,38 @@ impl TrackCache {
                 }
             };
 
-            for (current_object_id, object) in cache.objects_snapshot().await {
-                let field = match object.as_ref() {
-                    DataObject::SubgroupObject(f) => f,
-                    _ => continue,
-                };
-
-                // Apply range filter for first and last groups
-                if group_id == start.group_id && current_object_id < start.object_id {
-                    continue;
+            let mut next_object_id = if group_id == start.group_id {
+                start.object_id
+            } else {
+                0
+            };
+            loop {
+                // End Location is exclusive; end.object_id == 0 is a special case
+                // meaning "the entire group". Checked before waiting so a fetch
+                // ending inside a live group does not block on objects past it.
+                if group_id == end.group_id && end.object_id != 0 && next_object_id >= end.object_id
+                {
+                    break;
                 }
-                // End Location is exclusive; `>=` excludes the object at end.object_id.
-                // end.object_id == 0 is a special case meaning "the entire group".
+                let Some((current_object_id, object)) =
+                    cache.object_from_or_wait(next_object_id).await
+                else {
+                    break;
+                };
+                next_object_id = current_object_id + 1;
+
+                // A gap can jump past the exclusive End Location.
                 if group_id == end.group_id
                     && end.object_id != 0
                     && current_object_id >= end.object_id
                 {
                     break;
                 }
+
+                let field = match object.as_ref() {
+                    DataObject::SubgroupObject(f) => f,
+                    _ => continue,
+                };
 
                 // Convert to FetchObjectField and append to fetch_objects
                 let fetch_object = match &field.subgroup_object {
@@ -464,6 +489,20 @@ mod tests {
         fill_group_with_ids(cache, group_id, &object_ids).await;
     }
 
+    // Fills a group and closes it, like ingress does when the stream ends.
+    // get_fetch_objects waits on open groups, so fetch tests need closed ones.
+    async fn fill_closed_group_with_ids(cache: &TrackCache, group_id: u64, object_ids: &[u64]) {
+        fill_group_with_ids(cache, group_id, object_ids).await;
+        cache
+            .close_stream_subgroup(group_id, &StreamSubgroupId::Value(0))
+            .await;
+    }
+
+    async fn fill_closed_group(cache: &TrackCache, group_id: u64, count: u64) {
+        let object_ids: Vec<u64> = (0..count).collect();
+        fill_closed_group_with_ids(cache, group_id, &object_ids).await;
+    }
+
     // Fills a group with objects at the given (non-sequential) absolute object_ids.
     async fn fill_group_with_ids(cache: &TrackCache, group_id: u64, object_ids: &[u64]) {
         let subgroup = StreamSubgroupId::Value(0);
@@ -485,7 +524,7 @@ mod tests {
     async fn get_fetch_objects_excludes_end_object() {
         // Arrange: group 0 with object_ids 0..=4
         let cache = TrackCache::new();
-        fill_group(&cache, 0, 5).await;
+        fill_closed_group(&cache, 0, 5).await;
         // Act: fetch [{0,0}, {0,3}) -> end object 3 is excluded
         let objects = cache
             .get_fetch_objects(
@@ -507,7 +546,7 @@ mod tests {
     async fn get_fetch_objects_end_object_zero_returns_entire_group() {
         // Arrange: group 0 with object_ids 0..=4
         let cache = TrackCache::new();
-        fill_group(&cache, 0, 5).await;
+        fill_closed_group(&cache, 0, 5).await;
         // Act: end.object_id == 0 means the entire end group
         let objects = cache
             .get_fetch_objects(
@@ -532,7 +571,7 @@ mod tests {
     async fn get_fetch_objects_filters_range_with_gaps() {
         // Arrange: group 0 with gapped object_ids 0, 3, 5, 8
         let cache = TrackCache::new();
-        fill_group_with_ids(&cache, 0, &[0, 3, 5, 8]).await;
+        fill_closed_group_with_ids(&cache, 0, &[0, 3, 5, 8]).await;
         // Act: fetch [{0,3}, {0,8}) -> start 3 inclusive, end 8 exclusive
         let objects = cache
             .get_fetch_objects(
@@ -554,8 +593,8 @@ mod tests {
     async fn get_fetch_objects_spans_groups_with_exclusive_end() {
         // Arrange: group 0 and group 1, each with object_ids 0..=4
         let cache = TrackCache::new();
-        fill_group(&cache, 0, 5).await;
-        fill_group(&cache, 1, 5).await;
+        fill_closed_group(&cache, 0, 5).await;
+        fill_closed_group(&cache, 1, 5).await;
         // Act: fetch [{0,2}, {1,3}) -> start object 2 (inclusive), end object 3 (exclusive)
         let objects = cache
             .get_fetch_objects(
@@ -573,6 +612,55 @@ mod tests {
         assert_eq!(
             object_ids(&objects),
             vec![(0, 2), (0, 3), (0, 4), (1, 0), (1, 1), (1, 2)]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_fetch_objects_waits_for_in_flight_group() {
+        // Arrange: group 0 is still in flight (header only, open) while group 1
+        // has already completed — the cross-stream reordering QUIC allows.
+        let cache = Arc::new(TrackCache::new());
+        let subgroup = StreamSubgroupId::Value(0);
+        cache
+            .append_stream_object(0, &subgroup, None, make_header(0))
+            .await;
+        fill_closed_group(&cache, 1, 5).await;
+
+        // Act: fetch [{0,0}, {1,3}) while group 0's objects have not arrived yet.
+        let fetch = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                cache
+                    .get_fetch_objects(
+                        moqt::Location {
+                            group_id: 0,
+                            object_id: 0,
+                        },
+                        moqt::Location {
+                            group_id: 1,
+                            object_id: 3,
+                        },
+                    )
+                    .await
+            }
+        });
+        // Group 0's objects arrive after the fetch started, then the stream ends.
+        tokio::task::yield_now().await;
+        for id in 0..3u64 {
+            cache
+                .append_stream_object(0, &subgroup, Some(id), make_object(0))
+                .await;
+        }
+        cache.close_stream_subgroup(0, &subgroup).await;
+
+        let objects = tokio::time::timeout(Duration::from_secs(5), fetch)
+            .await
+            .expect("fetch must complete once the in-flight group closes")
+            .unwrap();
+        // Assert: the late group 0 objects are delivered, not silently dropped.
+        assert_eq!(
+            object_ids(&objects),
+            vec![(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]
         );
     }
 }

--- a/tests/cache-eviction-e2e/src/main.rs
+++ b/tests/cache-eviction-e2e/src/main.rs
@@ -1,4 +1,4 @@
-//! E2E for the relay's cache eviction (TTL object drain + strong_count track reclaim).
+//! E2E for the relay's cache eviction (TTL object drain + post-drain track reclaim).
 //!
 //! Two independent tracks exercise the two eviction mechanisms. FETCH reads the
 //! relay's object cache directly, so "present vs gone" is observed by fetching.
@@ -12,14 +12,16 @@
 //!         succeeds because the track (held by Carol) is alive; only the
 //!         closed, drained group was reclaimed.
 //!
-//!   Phase B (strong_count track reclaim):
+//!   Phase B (track reclaim after TTL drain, no holders):
 //!     A publisher sends one closed group on track B. A subscriber (Bob) triggers
 //!     the publish and holds the track during the baseline fetch, then leaves.
 //!       - fetch B/g0 while Bob holds it  -> 5 objects
 //!       - after Bob leaves, wait > interval but < TTL
-//!       - fetch B/g0                     -> FETCH error (TrackNotFound): the
-//!         whole track was reclaimed while its objects were still within TTL,
-//!         which only strong_count reclaim (not object TTL) can explain.
+//!       - fetch B/g0                     -> 5 objects: a track with fresh
+//!         objects must keep serving FETCH even with no session holding it
+//!         (reclaiming it here loses data, see the object-dedup E2E)
+//!       - after TTL+interval             -> FETCH error (TrackNotFound): the
+//!         objects drained via TTL, the emptied track was reclaimed.
 //!
 //! Run a relay on localhost:4433 with a short TTL, then `cargo run -p
 //! cache-eviction-e2e` from the repo root:
@@ -206,7 +208,7 @@ async fn run_scenario() -> anyhow::Result<()> {
 
     drop(carol); // release the track for good measure
 
-    // ---- Phase B: strong_count track reclaim (no holders, before TTL) ----
+    // ---- Phase B: track reclaim after TTL drain (no holders) ----
     let bob = subscribe_live(NAMESPACE_B).await?;
     tokio::time::sleep(Duration::from_millis(800)).await; // let group 0 publish
 
@@ -221,22 +223,28 @@ async fn run_scenario() -> anyhow::Result<()> {
     drop(bob); // now nobody holds the track (strong_count -> 1)
     tokio::time::sleep(Duration::from_secs(3)).await; // > interval, still < TTL
 
+    let unheld = fetch_group(NAMESPACE_B, 0).await?;
+    assert_eq!(
+        unheld,
+        full_group(0),
+        "[B] a fresh track must keep serving FETCH after all holders left"
+    );
+    tracing::info!("[B] after Bob left, before TTL: still 5 objects — OK");
+
+    tokio::time::sleep(Duration::from_secs(4)).await; // objects now past TTL + interval
     match fetch_group(NAMESPACE_B, 0).await {
         Err(e) => {
-            tracing::info!(
-                "[B] after Bob left: fetch errored ({}) — track reclaimed, OK",
-                e
-            );
+            tracing::info!("[B] after TTL: fetch errored ({}) — track reclaimed, OK", e);
         }
         Ok(objects) => {
             anyhow::bail!(
-                "[B] track should have been reclaimed by strong_count, but fetch returned {:?}",
+                "[B] track should have drained via TTL and been reclaimed, but fetch returned {:?}",
                 objects
             );
         }
     }
 
-    tracing::info!("ALL OK: object TTL and strong_count reclaim both verified");
+    tracing::info!("ALL OK: object TTL drain and post-drain track reclaim both verified");
     Ok(())
 }
 


### PR DESCRIPTION
## 概要

Fetch 系 E2E(fetch_e2e / object_dedup_e2e)がタイミング依存で間欠的に失敗する問題を修正します。原因は relay 側の2つの競合で、負荷の高い CI ランナーではパケット到着や eviction tick のタイミング次第で顕在化していました。

## 修正内容

### 1. FETCH が ingest 途中のグループを黙って取りこぼす

QUIC はストリーム間の到着順序を保証しないため、publisher が順に送った group が relay には前後して届き得ます(失敗時の CI ログでは g2, g1 が先に完了し、g0 が約 30ms 遅れて到着)。`TrackCache::get_fetch_objects` はキャッシュのスナップショットを返していたため、この間に FETCH が来ると in-flight のグループが応答から丸ごと欠落していました(fetch_e2e の assert 失敗: group 0 欠落)。

**修正**: スナップショットをやめ、live egress と同じ `header_or_wait` / `object_from_or_wait` で範囲内の open なグループを待つように変更。ingress はストリーム終端・エラー・publisher 離脱で必ずグループを close するため待ちは有界です。End Location(排他)は待つ前に判定し、live グループ途中まで の FETCH(joining fetch 等)が余計にブロックしないようにしています。

### 2. publisher 切断直後にトラックキャッシュごと削除される

`TrackCacheStore::evict` が TTL を無視して `Arc::strong_count == 1`(= セッションが誰も保持していない)だけでトラックを削除していました。キャッシュは「書き手がいなくなった後に来る読み手に応える」ためのものなので、参照ゼロは削除条件になり得ません。publisher 切断直後の evict tick で ingest 数秒後のキャッシュが消え、FETCH が `TrackDoesNotExist` になっていました(object_dedup_e2e の失敗)。

**修正**: グループが TTL で drain されて空になったトラックのみ削除。`strong_count == 1` は「消す瞬間に書き込み中の人がいない」ことの安全ガードとして維持(書き込みには Arc 取得が必要なため、remove_if のロック内再チェックで競合を弾けます)。

### 3. cache-eviction E2E の期待値更新

Phase B は「参照ゼロのトラックは TTL 内でも即回収」という旧挙動をアサートしており、object-dedup E2E(切断直後の FETCH が成功すること)と矛盾していました。両者は evict tick のタイミング運でしか両立していなかったため、Phase B を「TTL 内は参照ゼロでも FETCH 可能 → drain 後に回収」に更新しています。

## テスト

- 回帰テスト追加:
  - `get_fetch_objects_waits_for_in_flight_group`(in-flight グループを待って返す)
  - `evict_keeps_unreferenced_track_with_fresh_objects`(TTL 内は参照ゼロでも保持、TTL 経過後に回収)
- ローカル E2E: fetch-e2e ×5、object-dedup-e2e ×3、さらに `RELAY_CACHE_EVICT_INTERVAL_SECS=1`(修正前ならほぼ毎回失敗する条件)で object-dedup-e2e ×3 — すべて成功
- CI の E2E workflow を3回実行し、本修正対象の fetch_e2e / object_dedup_e2e / cache_eviction_e2e は 3/3 で green
- `cargo test -p relay --lib` / `cargo clippy` / `cargo fmt --check` green

## 備考

- lockfile で quinn を 0.11.11 に更新しています(暫定ピンの解除)。
- cascading_relay_e2e に別系統のタイミング競合が残っています(subscribe 処理と同時に publish された object が LargestObject の start=largest+1 計算でスキップされ、header-only ストリームになる)。本 PR とは独立のバグのため別途対応予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)