### PR TITLE
feat(examples): 映像送受信 CLI (moq-cli) の追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,6 +3042,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moq-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap",
+ "media-streaming-format",
+ "moqt",
+ "packages",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "moqt"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     'moqt',
     'relay',
     'examples/rust/manual-client',
+    'examples/rust/moq-cli',
     'tests/cache-eviction-e2e',
     'tests/cascading-relay-e2e',
     'tests/fetch-e2e',

--- a/bindings/wasm/src/messages.rs
+++ b/bindings/wasm/src/messages.rs
@@ -833,6 +833,7 @@ pub struct FetchObjectMessage {
     group_id: u64,
     object_id: u64,
     object_payload: Vec<u8>,
+    loc_header: LocHeader,
 }
 
 #[wasm_bindgen]
@@ -856,6 +857,12 @@ impl FetchObjectMessage {
     pub fn object_payload(&self) -> Vec<u8> {
         self.object_payload.clone()
     }
+
+    #[wasm_bindgen(getter, js_name = locHeader)]
+    pub fn loc_header(&self) -> Result<JsValue, JsValue> {
+        crate::loc::encode_loc_header(&self.loc_header)
+            .map_err(|error| JsValue::from_str(&error.to_string()))
+    }
 }
 
 impl FetchObjectMessage {
@@ -869,6 +876,7 @@ impl FetchObjectMessage {
             group_id: field.group_id,
             object_id: field.object_id,
             object_payload: payload,
+            loc_header: crate::loc::extension_headers_to_loc_header(&field.extension_headers),
         }
     }
 }

--- a/examples/browser/examples/remote-monitoring/src/components/MonitoringRoom.tsx
+++ b/examples/browser/examples/remote-monitoring/src/components/MonitoringRoom.tsx
@@ -10,7 +10,7 @@ import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { Label } from './ui/label'
 import { MonitorSession } from '../monitor/monitorSession'
-import { CameraSubscriber } from '../monitor/cameraSubscriber'
+import { CameraSubscriber, type ReviewFrame } from '../monitor/cameraSubscriber'
 import { useUrlSync } from '../hooks/useUrlSync'
 
 interface Props {
@@ -43,7 +43,7 @@ export function MonitoringRoom({ location: defaultLocation, relayUrl: defaultRel
   const stageIdRef = useRef<CameraId>(stageId)
 
   // Review
-  const reviewBufferRef = useRef<Map<bigint, Uint8Array>>(new Map())
+  const reviewBufferRef = useRef<Map<bigint, ReviewFrame>>(new Map())
   const activeFetchIdRef = useRef<bigint | null>(null)
   const fetchGenRef = useRef(0)
 
@@ -159,7 +159,7 @@ export function MonitoringRoom({ location: defaultLocation, relayUrl: defaultRel
 
       const targetGroup = seekGroup
       const needSequential = targetObjectId !== undefined && targetObjectId > 0n
-      const seqBuffer = new Map<bigint, Uint8Array>()
+      const seqBuffer = new Map<bigint, ReviewFrame>()
       let seqDecoded = false
 
       try {
@@ -169,21 +169,21 @@ export function MonitoringRoom({ location: defaultLocation, relayUrl: defaultRel
 
           // Always store I-frames for step navigation
           if (msg.objectId === 0n) {
-            reviewBufferRef.current.set(msg.groupId, payload)
+            reviewBufferRef.current.set(msg.groupId, { payload, locHeader: msg.locHeader })
           }
 
           if (msg.groupId === targetGroup) {
             if (needSequential) {
               // Collect all frames up to targetObjectId for sequential decode
               if (msg.objectId <= targetObjectId!) {
-                seqBuffer.set(msg.objectId, payload)
+                seqBuffer.set(msg.objectId, { payload, locHeader: msg.locHeader })
               }
               if (msg.objectId === targetObjectId && !seqDecoded) {
                 seqDecoded = true
                 subscriber.decodeFrameSequential(seqBuffer, targetObjectId!)
               }
             } else if (msg.objectId === 0n) {
-              subscriber.decodeFrame(msg.groupId, payload)
+              subscriber.decodeFrame(msg.groupId, payload, msg.locHeader)
             }
           }
         })
@@ -236,9 +236,9 @@ export function MonitoringRoom({ location: defaultLocation, relayUrl: defaultRel
       return
     }
     setCurrentGroupId(next)
-    const payload = reviewBufferRef.current.get(next)
+    const entry = reviewBufferRef.current.get(next)
     const subscriber = subscribersRef.current.get(stageId)
-    if (payload && subscriber) subscriber.decodeFrame(next, payload)
+    if (entry && subscriber) subscriber.decodeFrame(next, entry.payload, entry.locHeader)
   }
 
   const handleStepForward = () => {
@@ -250,9 +250,9 @@ export function MonitoringRoom({ location: defaultLocation, relayUrl: defaultRel
       return
     }
     setCurrentGroupId(next)
-    const payload = reviewBufferRef.current.get(next)
+    const entry = reviewBufferRef.current.get(next)
     const subscriber = subscribersRef.current.get(stageId)
-    if (payload && subscriber) subscriber.decodeFrame(next, payload)
+    if (entry && subscriber) subscriber.decodeFrame(next, entry.payload, entry.locHeader)
   }
 
   const handleJump = (seekGroup: bigint) => {

--- a/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
+++ b/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
@@ -1,6 +1,9 @@
 import type { SubgroupObjectMessage } from '../../../../pkg/moqt_client_wasm'
 import type { CameraId } from '../types/monitoring'
-import { tryDeserializeChunk } from '../../../../utils/media/chunk'
+import { tryDeserializeChunk, type DeserializedChunk } from '../../../../utils/media/chunk'
+import { readLocHeader, bytesToBase64, type LocHeader } from '../../../../utils/media/loc'
+
+export type ReviewFrame = { payload: Uint8Array; locHeader: unknown }
 
 const log = (...args: unknown[]) => console.log('[mon][decoder]', ...args)
 
@@ -195,8 +198,32 @@ export class CameraSubscriber {
     this.paused = false
   }
 
-  decodeFrame(groupId: bigint, payload: Uint8Array): void {
+  // Parse a review object: the browser publisher wraps metadata in the payload
+  // (serializeChunk envelope), whereas moq-cli publishes raw LOC objects (coded frame in
+  // the payload, metadata in the LOC extension header). Try the envelope first, then LOC.
+  private deserializeOrLoc(payload: Uint8Array, locHeader: unknown, objectId: bigint): DeserializedChunk | null {
     const parsed = tryDeserializeChunk(payload)
+    if (parsed) return parsed
+    const loc = readLocHeader(locHeader as LocHeader | undefined)
+    const timestamp =
+      typeof loc.captureTimestampMicros === 'number' && Number.isFinite(loc.captureTimestampMicros)
+        ? loc.captureTimestampMicros
+        : Number(objectId)
+    return {
+      metadata: {
+        type: objectId === 0n ? 'key' : 'delta',
+        timestamp,
+        duration: null,
+        codec: 'avc3.640028',
+        avcFormat: 'annexb',
+        descriptionBase64: loc.videoConfig ? bytesToBase64(loc.videoConfig) : undefined
+      },
+      data: payload
+    }
+  }
+
+  decodeFrame(groupId: bigint, payload: Uint8Array, locHeader?: unknown): void {
+    const parsed = this.deserializeOrLoc(payload, locHeader, 0n)
     if (!parsed) {
       log('decodeFrame: failed to parse payload', { camId: this.camId, groupId })
       return
@@ -246,21 +273,21 @@ export class CameraSubscriber {
   }
 
   // Decode I-frame through target P-frame sequentially, displaying only the target frame.
-  decodeFrameSequential(frames: Map<bigint, Uint8Array>, targetObjectId: bigint): void {
-    const iFramePayload = frames.get(0n)
-    if (!iFramePayload) return
+  decodeFrameSequential(frames: Map<bigint, ReviewFrame>, targetObjectId: bigint): void {
+    const iFrame = frames.get(0n)
+    if (!iFrame) return
 
     // If target is the I-frame itself, fall through to decodeFrame
     if (targetObjectId === 0n) {
-      this.decodeFrame(0n, iFramePayload)
+      this.decodeFrame(0n, iFrame.payload, iFrame.locHeader)
       return
     }
 
-    const iFrameParsed = tryDeserializeChunk(iFramePayload)
+    const iFrameParsed = this.deserializeOrLoc(iFrame.payload, iFrame.locHeader, 0n)
     if (!iFrameParsed) return
 
-    const targetPayload = frames.get(targetObjectId)
-    const targetParsed = targetPayload ? tryDeserializeChunk(targetPayload) : null
+    const target = frames.get(targetObjectId)
+    const targetParsed = target ? this.deserializeOrLoc(target.payload, target.locHeader, targetObjectId) : null
     // Use timestamp to identify the target frame in the output callback
     const targetTimestamp = targetParsed?.metadata.timestamp ?? null
 
@@ -304,12 +331,12 @@ export class CameraSubscriber {
     this.reviewDecoder.configure(config)
 
     for (let objId = 0n; objId <= targetObjectId; objId++) {
-      const payload = frames.get(objId)
-      if (!payload) {
+      const entry = frames.get(objId)
+      if (!entry) {
         log('decodeFrameSequential: missing frame, stopping', { camId: this.camId, objId, targetObjectId })
         break
       }
-      const parsed = tryDeserializeChunk(payload)
+      const parsed = this.deserializeOrLoc(entry.payload, entry.locHeader, objId)
       if (!parsed) break
       try {
         this.reviewDecoder.decode(

--- a/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
+++ b/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
@@ -45,8 +45,8 @@ export class CameraSubscriber {
     this.worker = new Worker(new URL('../../../../utils/media/decoders/videoDecoder.ts', import.meta.url), {
       type: 'module'
     })
-    // bypass jitter buffer for low-latency monitoring
-    this.worker.postMessage({ type: 'config', config: { bypassJitterBuffer: true, telemetryEnabled: false } })
+    // enable jitter buffer + capture-timestamp pacing (was bypassed for lowest latency)
+    this.worker.postMessage({ type: 'config', config: { bypassJitterBuffer: false, telemetryEnabled: false } })
     this.worker.postMessage({ type: 'catalog', codec: 'avc1.640028', framerate: 30 })
 
     this.worker.onmessage = (e) => {

--- a/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
+++ b/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
@@ -47,7 +47,7 @@ export class CameraSubscriber {
     })
     // enable jitter buffer + capture-timestamp pacing (was bypassed for lowest latency)
     this.worker.postMessage({ type: 'config', config: { bypassJitterBuffer: false, telemetryEnabled: false } })
-    this.worker.postMessage({ type: 'catalog', codec: 'avc1.640028', framerate: 30 })
+    this.worker.postMessage({ type: 'catalog', codec: 'avc3.640028', framerate: 30 })
 
     this.worker.onmessage = (e) => {
       if (e.data.type === 'frame') {

--- a/examples/browser/examples/remote-monitoring/src/publisher/cameraPublisher.ts
+++ b/examples/browser/examples/remote-monitoring/src/publisher/cameraPublisher.ts
@@ -11,7 +11,7 @@ const KEYFRAME_INTERVAL_FRAMES = 30 // 30fps × 1s = 1 GoP per second
 const BITRATE_LOG_INTERVAL_CHUNKS = 900 // ~30 seconds at 30fps
 const OBJECT_STATUS_END_OF_GROUP = 3
 const VIDEO_CONFIG = {
-  codec: 'avc1.640028', // H.264 High Profile Level 4.0
+  codec: 'avc3.640028', // H.264 High Profile Level 4.0 (in-band SPS/PPS; encoder emits annex-b)
   width: 1280,
   height: 720,
   bitrate: 1_000_000,

--- a/examples/browser/utils/relayPresets.ts
+++ b/examples/browser/utils/relayPresets.ts
@@ -47,7 +47,7 @@ type RelayUrlControlsOptions = {
 
 export function getLocalRelayUrls(): { relayAUrl: string; relayBUrl: string } {
   return {
-    relayAUrl: readRelayUrlSearchParam(['relayAUrl', ...DEFAULT_RELAY_URL_PARAM_NAMES]) ?? DEFAULT_LOCAL_RELAY_A_URL,
+    relayAUrl: readRelayUrlSearchParam(['relayAUrl']) ?? DEFAULT_LOCAL_RELAY_A_URL,
     relayBUrl: readRelayUrlSearchParam(['relayBUrl']) ?? DEFAULT_LOCAL_RELAY_B_URL
   }
 }

--- a/examples/rust/moq-cli/Cargo.toml
+++ b/examples/rust/moq-cli/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "moq-cli"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "moq-cli"
+path = "src/main.rs"
+
+[dependencies]
+moqt = { path = "../../../moqt" }
+media-streaming-format = { path = "../../../shared/media-streaming-format" }
+packages = { path = "../../../shared/packages" }
+serde_json = "1"
+tokio = { version = "1.52.3", features = ["full"] }
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+anyhow = { version = "1.0.102", features = ["backtrace"] }
+bytes = "1"
+url = "2.5.8"
+clap = { version = "4.6.1", features = ["derive"] }

--- a/examples/rust/moq-cli/README.md
+++ b/examples/rust/moq-cli/README.md
@@ -1,0 +1,89 @@
+# moq-cli
+
+エンコード済みの映像を MoQ relay に publish / subscribe する CLI。
+
+## 使い方
+
+```sh
+# 配信
+ffmpeg ... | moq-cli publish --relay <relay> --track <track> --codec <codec>
+
+# 購読
+moq-cli subscribe --relay <relay> --track <track> | ffplay -
+```
+
+## オプション
+
+| フラグ | publish | subscribe | 説明 |
+|---|:-:|:-:|---|
+| `--relay` | ● | ● | 接続先 relay。例 `moqt://localhost:4433` |
+| `--track` | ● | ● | full track name。例 `tokyo/cam01/video` |
+| `--codec` | ● | | `--container loc` のとき必須。`avc3`。cmaf では不要 |
+| `--container` | ● | | `loc`（既定）か `cmaf` |
+| `--insecure` | ● | ● | 証明書検証を無効化。自己署名 relay 用 |
+
+subscribe は codec と container を catalog から読むので指定しない。timestamp は wall-clock で自動付与。入力・出力は stdin/stdout 固定。
+
+## コンテナ
+
+publish する側が、視聴側の再生方法に合わせて `--container` を選ぶ。
+
+| container | 入力 | moq-cli の仕事 | codec 知識 |
+|---|---|---|---|
+| `loc`（既定） | 生 elementary stream（annex-b） | フレーム分割・keyframe 判定・1frame=1object | 必要 |
+| `cmaf` | CMAF（moof+mdat, ffmpeg `-f mp4 -movflags frag...`） | 箱境界で Object 化するだけ | 不要 |
+
+## 例
+
+```sh
+# ローカル loopback
+cat sample.h264 | moq-cli publish --relay moqt://localhost:4433 --track live/video --codec avc3 --insecure
+moq-cli subscribe --relay moqt://localhost:4433 --track live/video --insecure | ffplay -
+
+# Mac カメラ
+ffmpeg -f avfoundation -framerate 30 -video_size 1280x720 -pix_fmt nv12 -i "0" \
+  -c:v libx264 -pix_fmt yuv420p -preset ultrafast -tune zerolatency -g 30 -f h264 - \
+  | moq-cli publish --relay moqt://localhost:4433 --track live/video --codec avc3 --insecure
+
+# mp4 から（ffmpeg で annex-b にして渡す）
+ffmpeg -i movie.mp4 -c:v copy -bsf:v h264_mp4toannexb -f h264 - \
+  | moq-cli publish --relay moqt://localhost:4433 --track live/video --codec avc3 --insecure
+```
+
+## Raspberry Pi
+
+Mac から cargo-zigbuild で静的バイナリを作って scp する。
+
+```sh
+cargo zigbuild --release --target aarch64-unknown-linux-musl -p moq-cli
+scp target/aarch64-unknown-linux-musl/release/moq-cli pi@pi-cam.local:~/
+
+# ライブカメラ
+rpicam-vid -t 0 --codec h264 --inline --width 1280 --height 720 --framerate 30 -o - \
+  | ./moq-cli publish --relay moqt://<relay>:443 --track live/video --codec avc3
+```
+
+## ビルド・テスト
+
+```sh
+cargo build --release -p moq-cli
+cargo test -p moq-cli
+```
+
+## 設計メモ
+
+- **catalog 取得**: 後から join した subscriber に届けるため publisher が各キーフレーム（group 境界）で catalog を再送している。正しい形は「一度だけ publish、subscriber は joining fetch（`Subscriber::fetch_relative_joining`）で取得」。
+- **LOC payload**: payload=生 annex-b。Object Header Extension に Capture Timestamp を 0xB（ImmutableExtensions）で `"loc:"+JSON(packages::loc::LocHeader)` として入れている 。spec §2.3.1.1 は本来 Capture Timestamp を ID=2 の bare varint で送る。moqt crate の `ExtensionHeaders` が3種（`0x3c`/`0x3e`/`0xb`）ハードコードで任意 ID を送れないため 0xB 相乗り。
+- spec: `spec/draft-ietf-moq-loc-01.txt`(LOC) / `draft-ietf-moq-msf-00.txt`(MSF) / `draft-ietf-moq-transport-14.txt`(MoQT)
+
+## 実装状況
+
+- [x] publish / subscribe（H.264/avc3 の LOC 配信）
+- [x] ブラウザ再生（WebCodecs）・Pi 実機配信
+- [x] catalog の publish / subscribe（subscribe で取得。publisher は各キーフレームで再送する暫定実装）
+- [x] CLI 整理（`--container` 追加、`--fps`/`--input` 撤廃、timestamp を wall-clock 化）
+- [ ] catalog を joining fetch で取得し、publisher は catalog を一度だけ publish
+- [ ] VP8 / VP9（LOC 経路の codec splitter）
+- [ ] `--container cmaf`（CMAF パススルー・MSE 再生）
+- [x] payload JSON 廃止 → 生 annex-b ＋ Capture Timestamp を 0xB 拡張ヘッダに（browser 互換の `"loc:"+JSON` 相乗り）
+- [ ] spec-true LOC 化（Capture Timestamp を Object Header Extension ID=2 varint で送る。moqt の任意 ID 拡張対応が前提）

--- a/examples/rust/moq-cli/src/catalog.rs
+++ b/examples/rust/moq-cli/src/catalog.rs
@@ -1,0 +1,93 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use media_streaming_format::{
+    Catalog, KnownPackaging, KnownTrackRole, Packaging, Track, TrackRole,
+};
+
+/// Track name carrying the catalog on every namespace.
+pub const TRACK: &str = "catalog";
+
+pub fn build_video_catalog(namespace: &str, media_track: &str, codec: &str) -> Catalog {
+    let track = Track {
+        namespace: Some(namespace.to_string()),
+        name: media_track.to_string(),
+        packaging: Packaging::Known(KnownPackaging::Loc),
+        role: Some(TrackRole::Known(KnownTrackRole::Video)),
+        is_live: true,
+        codec: Some(codec.to_string()),
+        event_type: None,
+        target_latency: None,
+        label: None,
+        render_group: None,
+        alt_group: None,
+        init_data: None,
+        depends: None,
+        temporal_id: None,
+        spatial_id: None,
+        mime_type: None,
+        framerate: None,
+        timescale: None,
+        bitrate: None,
+        width: None,
+        height: None,
+        sample_rate: None,
+        channel_config: None,
+        display_width: None,
+        display_height: None,
+        lang: None,
+        parent_name: None,
+        track_duration: None,
+    };
+    Catalog {
+        version: Some(1),
+        generated_at: Some(now_millis()),
+        is_complete: Some(true),
+        tracks: Some(vec![track]),
+        delta_update: None,
+        add_tracks: None,
+        remove_tracks: None,
+        clone_tracks: None,
+    }
+}
+
+pub fn serialize(catalog: &Catalog) -> Result<Vec<u8>> {
+    serde_json::to_vec(catalog).context("serialize catalog json")
+}
+
+pub fn parse(bytes: &[u8]) -> Result<Catalog> {
+    serde_json::from_slice(bytes).context("parse catalog json")
+}
+
+pub fn packaging_str(packaging: &Packaging) -> String {
+    match packaging {
+        Packaging::Known(KnownPackaging::Loc) => "loc".to_string(),
+        Packaging::Known(KnownPackaging::MediaTimeline) => "media-timeline".to_string(),
+        Packaging::Known(KnownPackaging::EventTimeline) => "event-timeline".to_string(),
+        Packaging::Other(s) => s.clone(),
+    }
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_video_catalog() {
+        let catalog = build_video_catalog("tokyo/cam01", "video", "avc3.640028");
+        let bytes = serialize(&catalog).unwrap();
+        let parsed = parse(&bytes).unwrap();
+
+        let track = &parsed.tracks.unwrap()[0];
+        assert_eq!(track.name, "video");
+        assert_eq!(track.codec.as_deref(), Some("avc3.640028"));
+        assert_eq!(packaging_str(&track.packaging), "loc");
+    }
+}

--- a/examples/rust/moq-cli/src/cli.rs
+++ b/examples/rust/moq-cli/src/cli.rs
@@ -1,0 +1,49 @@
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+use crate::relay_url::RelayUrl;
+use crate::track::FullTrackName;
+
+#[derive(Parser, Debug)]
+#[command(about = "MoQT CLI: publish/subscribe media over MoQT")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    Publish(PublishArgs),
+    Subscribe(SubscribeArgs),
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[value(rename_all = "lower")]
+pub enum Container {
+    #[default]
+    Loc,
+    Cmaf,
+}
+
+#[derive(Args, Debug)]
+pub struct PublishArgs {
+    #[arg(long)]
+    pub relay: RelayUrl,
+    #[arg(long)]
+    pub track: FullTrackName,
+    #[arg(long)]
+    pub insecure: bool,
+    #[arg(long, default_value = "avc3")]
+    pub codec: String,
+    #[arg(long, value_enum, default_value_t = Container::Loc)]
+    pub container: Container,
+}
+
+#[derive(Args, Debug)]
+pub struct SubscribeArgs {
+    #[arg(long)]
+    pub relay: RelayUrl,
+    #[arg(long)]
+    pub track: FullTrackName,
+    #[arg(long)]
+    pub insecure: bool,
+}

--- a/examples/rust/moq-cli/src/loc.rs
+++ b/examples/rust/moq-cli/src/loc.rs
@@ -1,0 +1,41 @@
+use bytes::Bytes;
+use packages::loc::{CaptureTimestamp, LocHeader, LocHeaderExtension};
+
+/// Prefix marking a LOC header JSON blob inside a MOQ immutable extension (0xB).
+/// Matches the browser publisher/receiver so the two interoperate.
+const LOC_HEADER_SENTINEL: &[u8] = b"loc:";
+
+/// Build the 0xB immutable-extension payload carrying the capture timestamp.
+///
+/// draft-ietf-moq-loc-01 §2.3.1.1 defines Capture Timestamp as header extension
+/// ID 2 (a bare varint), but the moqt crate can only emit the 0x3c/0x3e/0xb
+/// extension IDs, so we ride on 0xB with the `"loc:"+JSON` encoding the browser
+/// uses. Spec-wise this is malformed, but it round-trips within this system.
+pub fn capture_timestamp_ext(micros_since_unix_epoch: u64) -> Bytes {
+    let header = LocHeader {
+        extensions: vec![LocHeaderExtension::CaptureTimestamp(CaptureTimestamp {
+            micros_since_unix_epoch,
+        })],
+    };
+    let mut encoded = Vec::from(LOC_HEADER_SENTINEL);
+    encoded.extend_from_slice(&serde_json::to_vec(&header).expect("LocHeader serializes"));
+    Bytes::from(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_capture_timestamp_as_sentinel_prefixed_json() {
+        let ext = capture_timestamp_ext(1_700_000_000_000_000);
+
+        let json = ext
+            .strip_prefix(LOC_HEADER_SENTINEL)
+            .expect("sentinel prefix");
+        assert_eq!(
+            std::str::from_utf8(json).unwrap(),
+            r#"{"extensions":[{"type":"captureTimestamp","value":{"microsSinceUnixEpoch":1700000000000000}}]}"#
+        );
+    }
+}

--- a/examples/rust/moq-cli/src/main.rs
+++ b/examples/rust/moq-cli/src/main.rs
@@ -1,0 +1,34 @@
+mod catalog;
+mod cli;
+mod loc;
+mod media;
+mod publish;
+mod relay_url;
+mod subscribe;
+mod track;
+mod transport;
+
+use anyhow::Result;
+use clap::Parser;
+
+use cli::{Cli, Command};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    run(Cli::parse()).await
+}
+
+async fn run(cli: Cli) -> Result<()> {
+    match cli.command {
+        Command::Publish(args) => publish::run(args).await,
+        Command::Subscribe(args) => subscribe::run(args).await,
+    }
+}

--- a/examples/rust/moq-cli/src/media/h264.rs
+++ b/examples/rust/moq-cli/src/media/h264.rs
@@ -1,0 +1,352 @@
+use anyhow::{Result, bail};
+use bytes::{Bytes, BytesMut};
+use std::time::Instant;
+
+use super::{Frame, Timestamp};
+
+const MAX_BUFFERED_BYTES: usize = 16 * 1024 * 1024;
+
+/// Assembles an Annex-B H.264 byte stream into a sequence of [`Frame`]s.
+pub struct AnnexBFramer {
+    codec_base: String,
+    tail: BytesMut,      // bytes after the last start code (a possibly incomplete NAL)
+    current: AccessUnit, // access unit being assembled
+    sps: Vec<Bytes>,     // most recently seen SPS, for injection into bare keyframes
+    pps: Vec<Bytes>,     // most recently seen PPS
+    zero: Option<Instant>, // wall-clock origin for synthesized timestamps
+    pending: Vec<Frame>, // frames finished during the current feed/flush
+}
+
+/// An H.264 access unit under construction.
+#[derive(Default)]
+struct AccessUnit {
+    chunks: BytesMut,     // NAL units accumulated so far (with start codes)
+    contains_idr: bool,   // holds an IDR slice -> keyframe
+    contains_slice: bool, // holds a coded slice (rejects param/SEI-only units)
+    sps_seen: Vec<Bytes>, // SPS carried inline in this unit (skip re-injection)
+    pps_seen: Vec<Bytes>, // PPS carried inline in this unit
+}
+
+impl AnnexBFramer {
+    pub fn new(codec_base: String) -> Self {
+        Self {
+            codec_base,
+            tail: BytesMut::new(),
+            current: AccessUnit::default(),
+            sps: Vec::new(),
+            pps: Vec::new(),
+            zero: None,
+            pending: Vec::new(),
+        }
+    }
+
+    pub fn feed(&mut self, data: &[u8]) -> Result<Vec<Frame>> {
+        self.tail.extend_from_slice(data);
+        let codes = start_code_positions(&self.tail);
+
+        let complete: Vec<Bytes> = (0..codes.len().saturating_sub(1))
+            .map(|i| Bytes::copy_from_slice(&self.tail[codes[i].1..codes[i + 1].0]))
+            .collect();
+        let drain_to = codes.last().map(|(code_start, _)| *code_start).unwrap_or(0);
+        let _ = self.tail.split_to(drain_to);
+        if self.tail.len() > MAX_BUFFERED_BYTES {
+            bail!("no NAL start code within {MAX_BUFFERED_BYTES} bytes; input is not annex-b?");
+        }
+
+        for nal in &complete {
+            self.classify_nal(nal)?;
+        }
+        Ok(std::mem::take(&mut self.pending))
+    }
+
+    pub fn flush(&mut self) -> Result<Vec<Frame>> {
+        if let Some((_, body_start)) = start_code_positions(&self.tail).first().copied() {
+            let nal = Bytes::copy_from_slice(&self.tail[body_start..]);
+            self.classify_nal(&nal)?;
+        }
+        self.tail.clear();
+        self.maybe_finish_frame()?;
+        Ok(std::mem::take(&mut self.pending))
+    }
+
+    /// The full codec string (e.g. `avc3.640028`), known once an SPS is seen.
+    pub fn codec_string(&self) -> Option<String> {
+        let sps = self.sps.first()?;
+        build_codec_string(&self.codec_base, sps).ok()
+    }
+
+    fn pts(&mut self) -> Timestamp {
+        let now = Instant::now();
+        let zero = *self.zero.get_or_insert(now);
+        Timestamp(now.saturating_duration_since(zero).as_micros() as i64)
+    }
+
+    fn classify_nal(&mut self, nal: &[u8]) -> Result<()> {
+        if self.current.contains_slice && starts_access_unit(nal) {
+            self.maybe_finish_frame()?;
+        }
+        self.current.chunks.extend_from_slice(&[0, 0, 0, 1]);
+        self.current.chunks.extend_from_slice(nal);
+
+        let nal_type = nal_type(nal);
+        if is_vcl(nal_type) {
+            self.current.contains_slice = true;
+        }
+        match nal_type {
+            // TODO: open-GOP/GDR (broadcast, MPEG-TS) has no IDR so late-join breaks. Handle recovery-point SEI then.
+            5 => self.current.contains_idr = true,
+            7 => {
+                let sps = Bytes::copy_from_slice(nal);
+                self.current.sps_seen.push(sps.clone());
+                self.sps = vec![sps];
+            }
+            8 => {
+                let pps = Bytes::copy_from_slice(nal);
+                self.current.pps_seen.push(pps.clone());
+                self.pps = vec![pps];
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn maybe_finish_frame(&mut self) -> Result<()> {
+        if !self.current.contains_slice {
+            self.current = AccessUnit::default();
+            return Ok(());
+        }
+        let au = std::mem::take(&mut self.current);
+        let payload = self.ensure_params(&au);
+        let timestamp = self.pts();
+        self.pending.push(Frame {
+            keyframe: au.contains_idr,
+            timestamp,
+            payload,
+        });
+        Ok(())
+    }
+
+    /// Prepend cached SPS/PPS to a keyframe that omits them, so it is self-contained.
+    fn ensure_params(&self, au: &AccessUnit) -> Bytes {
+        let mut out = BytesMut::new();
+        if au.contains_idr {
+            if au.sps_seen.is_empty() {
+                for sps in &self.sps {
+                    out.extend_from_slice(&[0, 0, 0, 1]);
+                    out.extend_from_slice(sps);
+                }
+            }
+            if au.pps_seen.is_empty() {
+                for pps in &self.pps {
+                    out.extend_from_slice(&[0, 0, 0, 1]);
+                    out.extend_from_slice(pps);
+                }
+            }
+        }
+        out.extend_from_slice(&au.chunks);
+        out.freeze()
+    }
+}
+
+/// Returns `(start_code_start, body_start)` for every Annex-B start code.
+fn start_code_positions(data: &[u8]) -> Vec<(usize, usize)> {
+    let mut positions = Vec::new();
+    let mut i = 0;
+    while i + 3 <= data.len() {
+        if data[i] == 0 && data[i + 1] == 0 && data[i + 2] == 1 {
+            let code_start = if i > 0 && data[i - 1] == 0 { i - 1 } else { i };
+            positions.push((code_start, i + 3));
+            i += 3;
+        } else {
+            i += 1;
+        }
+    }
+    positions
+}
+
+fn build_codec_string(base: &str, sps: &[u8]) -> Result<String> {
+    if nal_type(sps) != 7 {
+        bail!("expected SPS NAL (type 7), got type {}", nal_type(sps));
+    }
+    if sps.len() < 4 {
+        bail!("SPS NAL too short: {} bytes", sps.len());
+    }
+    Ok(format!("{base}.{:02x}{:02x}{:02x}", sps[1], sps[2], sps[3]))
+}
+
+fn nal_type(nal: &[u8]) -> u8 {
+    nal.first().map(|byte| byte & 0x1F).unwrap_or(0)
+}
+
+fn is_vcl(nal_type: u8) -> bool {
+    (1..=5).contains(&nal_type)
+}
+
+fn starts_access_unit(nal: &[u8]) -> bool {
+    let nal_type = nal_type(nal);
+    if is_vcl(nal_type) {
+        // first_mb_in_slice == 0 (a new picture's first slice) is Exp-Golomb `1`,
+        // i.e. the top bit of the slice header byte is set.
+        return nal.get(1).is_some_and(|byte| byte & 0x80 != 0);
+    }
+    matches!(nal_type, 6..=9)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const STREAM: [u8; 33] = [
+        0, 0, 0, 1, 0x67, 0x42, // SPS
+        0, 0, 0, 1, 0x68, 0xEE, // PPS
+        0, 0, 0, 1, 0x65, 0x88, 0x11, // IDR slice (first_mb=0)
+        0, 0, 0, 1, 0x41, 0x88, 0x22, // P slice
+        0, 0, 0, 1, 0x41, 0x88, 0x33, // P slice
+    ];
+
+    fn framer() -> AnnexBFramer {
+        AnnexBFramer::new("avc3".to_string())
+    }
+
+    #[test]
+    fn framer_splits_stream_into_frames() {
+        let mut framer = framer();
+
+        let mut frames = framer.feed(&STREAM).unwrap();
+        frames.extend(framer.flush().unwrap());
+
+        assert_eq!(frames.len(), 3);
+        assert!(frames[0].keyframe);
+        assert!(!frames[1].keyframe);
+        assert_eq!(
+            frames[0].payload.as_ref(),
+            &[
+                0, 0, 0, 1, 0x67, 0x42, 0, 0, 0, 1, 0x68, 0xEE, 0, 0, 0, 1, 0x65, 0x88, 0x11
+            ]
+        );
+        assert_eq!(frames[1].payload.as_ref(), &[0, 0, 0, 1, 0x41, 0x88, 0x22]);
+    }
+
+    #[test]
+    fn framer_is_independent_of_chunk_boundaries() {
+        let mut framer = framer();
+        let mut frames = Vec::new();
+
+        for byte in STREAM.iter() {
+            frames.extend(framer.feed(&[*byte]).unwrap());
+        }
+        frames.extend(framer.flush().unwrap());
+
+        assert_eq!(frames.len(), 3);
+        assert!(frames[0].keyframe);
+        assert!(!frames[2].keyframe);
+    }
+
+    #[test]
+    fn framer_groups_multi_slice_picture_into_one_frame() {
+        // A keyframe as two IDR slices, then a P frame as one slice.
+        let stream = [
+            0, 0, 0, 1, 0x67, 0x42, // SPS
+            0, 0, 0, 1, 0x68, 0xEE, // PPS
+            0, 0, 0, 1, 0x65, 0x88, 0x11, // IDR slice 0 (first_mb=0)
+            0, 0, 0, 1, 0x65, 0x10, 0x22, // IDR slice 1 (continuation)
+            0, 0, 0, 1, 0x41, 0x88, 0x33, // P slice 0 (first_mb=0)
+        ];
+        let mut framer = framer();
+
+        let mut frames = framer.feed(&stream).unwrap();
+        frames.extend(framer.flush().unwrap());
+
+        assert_eq!(frames.len(), 2);
+        assert!(frames[0].keyframe); // SPS+PPS+IDR0+IDR1 = one frame
+        assert!(!frames[1].keyframe);
+    }
+
+    #[test]
+    fn injects_cached_sps_pps_into_keyframe_that_omits_them() {
+        let stream = [
+            0, 0, 0, 1, 0x67, 0x42, // SPS
+            0, 0, 0, 1, 0x68, 0xEE, // PPS
+            0, 0, 0, 1, 0x65, 0x88, 0x11, // IDR slice (first_mb=0), GOP1 keyframe
+            0, 0, 0, 1, 0x41, 0x88, 0x22, // P slice
+            0, 0, 0, 1, 0x65, 0x90, 0x33, // IDR slice, GOP2 keyframe WITHOUT SPS/PPS
+            0, 0, 0, 1, 0x41, 0x88, 0x44, // P slice
+        ];
+        let mut framer = framer();
+
+        let mut frames = framer.feed(&stream).unwrap();
+        frames.extend(framer.flush().unwrap());
+
+        assert_eq!(frames.len(), 4);
+        assert!(frames[0].keyframe);
+        assert!(frames[2].keyframe);
+        assert_eq!(
+            frames[0].payload.as_ref(),
+            &[
+                0, 0, 0, 1, 0x67, 0x42, 0, 0, 0, 1, 0x68, 0xEE, 0, 0, 0, 1, 0x65, 0x88, 0x11
+            ]
+        );
+        assert_eq!(
+            frames[2].payload.as_ref(),
+            &[
+                0, 0, 0, 1, 0x67, 0x42, 0, 0, 0, 1, 0x68, 0xEE, 0, 0, 0, 1, 0x65, 0x90, 0x33
+            ]
+        );
+    }
+
+    #[test]
+    fn timestamps_are_monotonic_from_zero() {
+        let mut framer = framer();
+
+        let mut frames = framer.feed(&STREAM).unwrap();
+        frames.extend(framer.flush().unwrap());
+
+        assert_eq!(frames[0].timestamp.0, 0);
+        assert!(frames[1].timestamp.0 >= frames[0].timestamp.0);
+        assert!(frames[2].timestamp.0 >= frames[1].timestamp.0);
+    }
+
+    #[test]
+    fn codec_string_resolves_after_keyframe() {
+        let stream = [
+            0, 0, 0, 1, 0x67, 0x64, 0x00, 0x28, // SPS (type 7)
+            0, 0, 0, 1, 0x68, 0xEE, // PPS
+            0, 0, 0, 1, 0x65, 0x88, 0x11, // IDR slice
+            0, 0, 0, 1, 0x41, 0x88, 0x22, // P slice, forces the keyframe to finish
+        ];
+        let mut framer = framer();
+
+        assert!(framer.codec_string().is_none());
+        framer.feed(&stream).unwrap();
+
+        assert_eq!(framer.codec_string().as_deref(), Some("avc3.640028"));
+    }
+
+    #[test]
+    fn build_codec_string_from_sps() {
+        let sps = [0x67u8, 0x64, 0x00, 0x28, 0xFF, 0xFF];
+
+        assert_eq!(build_codec_string("avc3", &sps).unwrap(), "avc3.640028");
+    }
+
+    #[test]
+    fn build_codec_string_rejects_non_sps_nal() {
+        let not_sps = [0x65u8, 0x64, 0x00, 0x28]; // type 5, not SPS
+
+        assert!(build_codec_string("avc3", &not_sps).is_err());
+    }
+
+    #[test]
+    fn splits_on_4byte_and_3byte_start_codes() {
+        let data = [
+            0, 0, 0, 1, 0x67, 0xAA, // 4-byte start code
+            0, 0, 1, 0x65, 0xBB, 0xCC, // 3-byte start code
+        ];
+
+        let codes = start_code_positions(&data);
+
+        assert_eq!(codes.len(), 2);
+        assert_eq!(codes[0], (0, 4));
+        assert_eq!(codes[1], (6, 9));
+    }
+}

--- a/examples/rust/moq-cli/src/media/mod.rs
+++ b/examples/rust/moq-cli/src/media/mod.rs
@@ -1,0 +1,15 @@
+pub mod h264;
+
+use bytes::Bytes;
+
+/// Presentation timestamp in microseconds (WebCodecs convention).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Timestamp(pub i64);
+
+/// A completed frame emitted by a framer, independent of codec.
+pub struct Frame {
+    pub keyframe: bool,
+    pub timestamp: Timestamp,
+    /// One frame worth of coded bytes (a run of NAL units for H.264).
+    pub payload: Bytes,
+}

--- a/examples/rust/moq-cli/src/publish.rs
+++ b/examples/rust/moq-cli/src/publish.rs
@@ -1,0 +1,151 @@
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use moqt::PublishOption;
+use tokio::io::AsyncReadExt;
+use tracing::info;
+
+use crate::catalog;
+use crate::cli::{Container, PublishArgs};
+use crate::loc;
+use crate::media::{Frame, h264::AnnexBFramer};
+use crate::transport::{TrackWriter, connect_session};
+
+const READ_BUFFER_BYTES: usize = 64 * 1024;
+const DRAIN_BEFORE_CLOSE: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Wall-clock microseconds since the Unix epoch.
+fn unix_micros_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_micros() as i64)
+        .unwrap_or(0)
+}
+
+pub async fn run(args: PublishArgs) -> Result<()> {
+    if args.container == Container::Cmaf {
+        anyhow::bail!("--container cmaf is not implemented yet");
+    }
+
+    let track = &args.track;
+    let session = connect_session(&args.relay, args.insecure).await?;
+
+    let publisher = session.publisher();
+    let subscription = publisher
+        .publish(
+            track.namespace.clone(),
+            track.name.clone(),
+            PublishOption::default(),
+        )
+        .await
+        .context("failed to publish")?;
+    let catalog_subscription = publisher
+        .publish(
+            track.namespace.clone(),
+            catalog::TRACK.to_string(),
+            PublishOption::default(),
+        )
+        .await
+        .context("failed to publish catalog track")?;
+    info!(
+        namespace = track.namespace,
+        track = track.name,
+        "publish ok"
+    );
+
+    let mut media = TrackWriter::new(publisher.create_stream(&subscription));
+    let mut catalog = CatalogPublisher::new(
+        TrackWriter::new(publisher.create_stream(&catalog_subscription)),
+        track.namespace.clone(),
+        track.name.clone(),
+    );
+    let mut framer = AnnexBFramer::new(args.codec.clone());
+
+    let mut reader = tokio::io::stdin();
+    let mut read_buf = vec![0u8; READ_BUFFER_BYTES];
+    let mut frame_index: u64 = 0;
+    // Wall-clock time of the frame timeline's zero point, set on the first frame.
+    // Maps each frame's relative PTS onto a Unix-epoch capture timestamp.
+    let mut capture_origin: Option<i64> = None;
+
+    loop {
+        let read = tokio::select! {
+            result = reader.read(&mut read_buf) => result?,
+            _ = tokio::signal::ctrl_c() => {
+                info!("received ctrl-c, shutting down");
+                break;
+            }
+        };
+        let frames = if read == 0 {
+            framer.flush()?
+        } else {
+            framer.feed(&read_buf[..read])?
+        };
+
+        for frame in frames {
+            let codec = framer
+                .codec_string()
+                .context("first frame is not a keyframe (no SPS yet)")?;
+            catalog.maybe_publish(&frame, &codec).await?;
+            if frame.keyframe {
+                media.start_group().await?;
+            }
+            let origin =
+                *capture_origin.get_or_insert_with(|| unix_micros_now() - frame.timestamp.0);
+            let capture = loc::capture_timestamp_ext((origin + frame.timestamp.0).max(0) as u64);
+            media.write(frame.payload, vec![capture]).await?;
+            frame_index += 1;
+        }
+
+        if read == 0 {
+            break;
+        }
+    }
+
+    let groups = media.groups();
+    media.finish().await?;
+    catalog.finish().await?;
+    info!(frames = frame_index, groups, "publish done");
+
+    // Let the relay drain in-flight stream data before the QUIC session is
+    // dropped on return; otherwise trailing objects are truncated.
+    tokio::time::sleep(DRAIN_BEFORE_CLOSE).await;
+
+    Ok(())
+}
+
+/// Builds the catalog once the codec is known and re-publishes it at each group
+/// boundary so subscribers that join mid-stream pick it up at the next keyframe.
+struct CatalogPublisher {
+    writer: TrackWriter,
+    namespace: String,
+    name: String,
+    payload: Option<Bytes>,
+}
+
+impl CatalogPublisher {
+    fn new(writer: TrackWriter, namespace: String, name: String) -> Self {
+        Self {
+            writer,
+            namespace,
+            name,
+            payload: None,
+        }
+    }
+
+    async fn maybe_publish(&mut self, frame: &Frame, codec: &str) -> Result<()> {
+        if !frame.keyframe {
+            return Ok(());
+        }
+        if self.payload.is_none() {
+            let built = catalog::build_video_catalog(&self.namespace, &self.name, codec);
+            self.payload = Some(catalog::serialize(&built)?.into());
+            info!(codec = %codec, "codec resolved");
+        }
+        let payload = self.payload.clone().expect("catalog payload built above");
+        self.writer.write_group(payload).await
+    }
+
+    async fn finish(self) -> Result<()> {
+        self.writer.finish().await
+    }
+}

--- a/examples/rust/moq-cli/src/relay_url.rs
+++ b/examples/rust/moq-cli/src/relay_url.rs
@@ -1,0 +1,71 @@
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::str::FromStr;
+
+use anyhow::{Context, Result, bail};
+
+/// A validated relay endpoint: a host with a required port.
+#[derive(Debug, Clone)]
+pub struct RelayUrl {
+    host: String,
+    port: u16,
+}
+
+impl FromStr for RelayUrl {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let url = url::Url::parse(s).context("invalid relay URL")?;
+        let host = url.host_str().context("relay URL has no host")?.to_string();
+        let Some(port) = url.port() else {
+            bail!("relay URL must include a port, got: {s}");
+        };
+        Ok(Self { host, port })
+    }
+}
+
+impl RelayUrl {
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Resolve the host to a connectable address via DNS. The moqt QUIC client
+    /// binds an IPv4 socket, so it can only reach IPv4 destinations; prefer
+    /// IPv4 (e.g. localhost -> 127.0.0.1, not ::1).
+    pub fn resolve(&self) -> Result<SocketAddr> {
+        let addrs: Vec<SocketAddr> = (self.host.as_str(), self.port)
+            .to_socket_addrs()
+            .context("failed to resolve relay address")?
+            .collect();
+        addrs
+            .iter()
+            .copied()
+            .find(SocketAddr::is_ipv4)
+            .or_else(|| addrs.first().copied())
+            .context("relay address resolved to nothing")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_host_and_port() {
+        let relay: RelayUrl = "moqt://localhost:4433".parse().unwrap();
+
+        assert_eq!(relay.host, "localhost");
+        assert_eq!(relay.port, 4433);
+    }
+
+    #[test]
+    fn rejects_url_without_port() {
+        assert!("moqt://localhost".parse::<RelayUrl>().is_err());
+    }
+
+    #[test]
+    fn resolves_to_ipv4() {
+        let relay: RelayUrl = "moqt://localhost:4433".parse().unwrap();
+
+        assert!(relay.resolve().unwrap().is_ipv4());
+    }
+}

--- a/examples/rust/moq-cli/src/subscribe.rs
+++ b/examples/rust/moq-cli/src/subscribe.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use moqt::SessionEvent;
+use tokio::io::AsyncWriteExt;
+use tracing::info;
+
+use crate::catalog;
+use crate::cli::SubscribeArgs;
+use crate::transport::{TrackReader, connect_session, subscribe_track};
+
+pub async fn run(args: SubscribeArgs) -> Result<()> {
+    let track = &args.track;
+    let session = Arc::new(connect_session(&args.relay, args.insecure).await?);
+
+    tokio::spawn({
+        let session = session.clone();
+        async move {
+            loop {
+                match session.receive_event().await {
+                    Ok(SessionEvent::ProtocolViolation()) => {
+                        tracing::error!("protocol violation");
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::error!("event loop error: {e}");
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    // Subscribe to both tracks up front so NextGroupStart catches the first
+    // group; otherwise a burst publisher can finish before we are done
+    // reading the catalog and the media subscription would start too late.
+    let mut catalog_reader =
+        TrackReader::new(subscribe_track(&session, &track.namespace, catalog::TRACK).await?);
+    info!(
+        namespace = track.namespace,
+        track = track.name,
+        "subscribing"
+    );
+    let mut media_reader =
+        TrackReader::new(subscribe_track(&session, &track.namespace, &track.name).await?);
+    info!("subscribed");
+
+    match catalog_reader.next_object().await? {
+        Some(object) => describe_catalog(&catalog::parse(&object)?),
+        None => anyhow::bail!("catalog stream ended before any object"),
+    }
+
+    let mut out = tokio::io::stdout();
+    while let Some(object) = media_reader.next_object().await? {
+        out.write_all(&object).await?;
+        out.flush().await?;
+    }
+
+    Ok(())
+}
+
+fn describe_catalog(catalog: &media_streaming_format::Catalog) {
+    let Some(track) = catalog.tracks.as_ref().and_then(|tracks| tracks.first()) else {
+        info!("catalog has no tracks");
+        return;
+    };
+    info!(
+        track = track.name,
+        packaging = crate::catalog::packaging_str(&track.packaging),
+        codec = track.codec.as_deref().unwrap_or("-"),
+        "catalog resolved"
+    );
+}

--- a/examples/rust/moq-cli/src/track.rs
+++ b/examples/rust/moq-cli/src/track.rs
@@ -1,0 +1,43 @@
+use std::str::FromStr;
+
+use anyhow::{Error, Result, bail};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FullTrackName {
+    pub namespace: String,
+    pub name: String,
+}
+
+impl FromStr for FullTrackName {
+    type Err = Error;
+
+    fn from_str(full: &str) -> Result<Self> {
+        match full.rsplit_once('/') {
+            Some((namespace, name)) if !namespace.is_empty() && !name.is_empty() => {
+                Ok(FullTrackName {
+                    namespace: namespace.to_string(),
+                    name: name.to_string(),
+                })
+            }
+            _ => bail!("full track name must be <namespace>/<track>, got: {full}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_namespace_and_track() {
+        let parsed: FullTrackName = "tokyo/cam01/video".parse().unwrap();
+
+        assert_eq!(parsed.namespace, "tokyo/cam01");
+        assert_eq!(parsed.name, "video");
+    }
+
+    #[test]
+    fn rejects_name_without_namespace() {
+        assert!("video".parse::<FullTrackName>().is_err());
+    }
+}

--- a/examples/rust/moq-cli/src/transport/mod.rs
+++ b/examples/rust/moq-cli/src/transport/mod.rs
@@ -1,0 +1,7 @@
+mod reader;
+mod session;
+mod writer;
+
+pub use reader::TrackReader;
+pub use session::{connect_session, subscribe_track};
+pub use writer::TrackWriter;

--- a/examples/rust/moq-cli/src/transport/reader.rs
+++ b/examples/rust/moq-cli/src/transport/reader.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use bytes::Bytes;
+use moqt::{QUIC, StreamDataReceiver, StreamDataReceiverFactory, Subgroup, SubgroupObject};
+
+/// Reads object payloads from one subscribed track, hiding group boundaries and
+/// header/status objects. The only place that touches moqt's object-reading API.
+pub struct TrackReader {
+    factory: StreamDataReceiverFactory<QUIC>,
+    group: Option<StreamDataReceiver<QUIC>>,
+}
+
+impl TrackReader {
+    pub fn new(factory: StreamDataReceiverFactory<QUIC>) -> Self {
+        Self {
+            factory,
+            group: None,
+        }
+    }
+
+    /// The next object payload, or `None` when the track ends.
+    pub async fn next_object(&mut self) -> Result<Option<Bytes>> {
+        loop {
+            if self.group.is_none() {
+                match self.factory.next().await {
+                    Ok(group) => self.group = Some(group),
+                    Err(e) => {
+                        tracing::debug!("track ended: {e}");
+                        return Ok(None);
+                    }
+                }
+            }
+            let group = self.group.as_mut().expect("group opened above");
+            match group.receive().await {
+                Ok(Subgroup::Object(field)) => match field.subgroup_object {
+                    SubgroupObject::Payload { data, .. } => return Ok(Some(data)),
+                    SubgroupObject::Status { .. } => continue,
+                },
+                Ok(Subgroup::Header(_)) => continue,
+                Err(e) => {
+                    tracing::warn!("group read error, advancing to next group: {e}");
+                    self.group = None;
+                    continue;
+                }
+            }
+        }
+    }
+}

--- a/examples/rust/moq-cli/src/transport/session.rs
+++ b/examples/rust/moq-cli/src/transport/session.rs
@@ -1,0 +1,50 @@
+use anyhow::{Context, Result};
+use moqt::{
+    ClientConfig, DataReceiver, Endpoint, FilterType, GroupOrder, QUIC, Session,
+    StreamDataReceiverFactory, SubscribeOption,
+};
+use tracing::info;
+
+use crate::relay_url::RelayUrl;
+
+const SUBSCRIBER_PRIORITY: u8 = 128;
+
+pub async fn connect_session(relay: &RelayUrl, insecure: bool) -> Result<Session<QUIC>> {
+    let config = ClientConfig {
+        port: 0,
+        verify_certificate: !insecure,
+    };
+    let endpoint = Endpoint::<QUIC>::create_client(&config)?;
+    let remote_address = relay.resolve()?;
+    info!(%remote_address, "connecting to relay");
+    let connecting = endpoint.connect(remote_address, relay.host()).await?;
+    let session = connecting.await?;
+    Ok(session)
+}
+
+pub async fn subscribe_track(
+    session: &Session<QUIC>,
+    namespace: &str,
+    name: &str,
+) -> Result<StreamDataReceiverFactory<QUIC>> {
+    let option = SubscribeOption {
+        subscriber_priority: SUBSCRIBER_PRIORITY,
+        group_order: GroupOrder::Ascending,
+        forward: true,
+        filter_type: FilterType::NextGroupStart,
+    };
+    let subscription = session
+        .subscriber()
+        .subscribe(namespace.to_string(), name.to_string(), option)
+        .await
+        .with_context(|| format!("failed to subscribe {namespace}/{name}"))?;
+    let receiver = session
+        .subscriber()
+        .accept_data_receiver(&subscription)
+        .await
+        .context("failed to accept data receiver")?;
+    let DataReceiver::Stream(factory) = receiver else {
+        anyhow::bail!("expected stream data receiver");
+    };
+    Ok(factory)
+}

--- a/examples/rust/moq-cli/src/transport/writer.rs
+++ b/examples/rust/moq-cli/src/transport/writer.rs
@@ -1,0 +1,121 @@
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use moqt::{
+    ExtensionHeaders, ObjectStatus, QUIC, StreamDataSenderFactory, SubgroupId, SubgroupObject,
+    SubgroupObjectSender,
+};
+
+const PUBLISHER_PRIORITY: u8 = 128;
+
+/// Writes objects to one published track, one group (GOP) at a time.
+/// The only place that touches moqt's object-writing API on the publish side.
+pub struct TrackWriter {
+    factory: StreamDataSenderFactory<QUIC>,
+    next_group_id: u64,
+    group: Option<GroupSender>,
+}
+
+impl TrackWriter {
+    pub fn new(factory: StreamDataSenderFactory<QUIC>) -> Self {
+        Self {
+            factory,
+            next_group_id: 0,
+            group: None,
+        }
+    }
+
+    /// Close the current group (EndOfGroup) and open a new one.
+    pub async fn start_group(&mut self) -> Result<()> {
+        if let Some(group) = self.group.take() {
+            group.finish().await?;
+        }
+        self.group = Some(self.open_group().await?);
+        Ok(())
+    }
+
+    /// Write one object into the current group, with its LOC header extensions.
+    pub async fn write(&mut self, object: Bytes, immutable_extensions: Vec<Bytes>) -> Result<()> {
+        self.group
+            .as_mut()
+            .context("write before start_group")?
+            .write_object(object, immutable_extensions)
+            .await
+    }
+
+    /// Write a single object as its own, immediately-closed group (catalog snapshots).
+    pub async fn write_group(&mut self, object: Bytes) -> Result<()> {
+        if let Some(group) = self.group.take() {
+            group.finish().await?;
+        }
+        let mut group = self.open_group().await?;
+        group.write_object(object, vec![]).await?;
+        group.finish().await
+    }
+
+    /// Close the last open group.
+    pub async fn finish(mut self) -> Result<()> {
+        if let Some(group) = self.group.take() {
+            group.finish().await?;
+        }
+        Ok(())
+    }
+
+    pub fn groups(&self) -> u64 {
+        self.next_group_id
+    }
+
+    async fn open_group(&mut self) -> Result<GroupSender> {
+        let uninit = self.factory.next().await?;
+        let header = uninit.create_header(
+            self.next_group_id,
+            SubgroupId::None,
+            PUBLISHER_PRIORITY,
+            false,
+            false,
+        );
+        let sender = uninit.send_header(header).await?;
+        self.next_group_id += 1;
+        Ok(GroupSender { sender })
+    }
+}
+
+/// A single open group's object stream.
+struct GroupSender {
+    sender: SubgroupObjectSender<QUIC>,
+}
+
+impl GroupSender {
+    async fn write_object(
+        &mut self,
+        object: Bytes,
+        immutable_extensions: Vec<Bytes>,
+    ) -> Result<()> {
+        let ext = ExtensionHeaders {
+            prior_group_id_gap: vec![],
+            prior_object_id_gap: vec![],
+            immutable_extensions,
+        };
+        let field = self
+            .sender
+            .create_object_field(0, ext, SubgroupObject::new_payload(object));
+        self.sender.send(field).await
+    }
+
+    async fn finish(mut self) -> Result<()> {
+        let end_of_group = self.sender.create_object_field(
+            0,
+            empty_ext(),
+            SubgroupObject::new_status(ObjectStatus::EndOfGroup as u64),
+        );
+        self.sender.send(end_of_group).await?;
+        self.sender.close().await
+    }
+}
+
+fn empty_ext() -> ExtensionHeaders {
+    ExtensionHeaders {
+        prior_group_id_gap: vec![],
+        prior_object_id_gap: vec![],
+        immutable_extensions: vec![],
+    }
+}

--- a/shared/packages/src/loc/header_extension.rs
+++ b/shared/packages/src/loc/header_extension.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 pub const LOC_CAPTURE_TIMESTAMP_ID: u64 = 2;
 pub const LOC_VIDEO_FRAME_MARKING_ID: u64 = 4;
 pub const LOC_AUDIO_LEVEL_ID: u64 = 6;
-pub const LOC_VIDEO_CONFIG_ID: u64 = 16;
+pub const LOC_VIDEO_CONFIG_ID: u64 = 13;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]

--- a/spec/draft-ietf-moq-loc-01.txt
+++ b/spec/draft-ietf-moq-loc-01.txt
@@ -1,0 +1,840 @@
+
+
+
+
+Media Over QUIC                                                M. Zanaty
+Internet-Draft                                             S. Nandakumar
+Intended status: Standards Track                                   Cisco
+Expires: 8 January 2026                                      P. Thatcher
+                                                               Microsoft
+                                                             7 July 2025
+
+
+                      Low Overhead Media Container
+                         draft-ietf-moq-loc-01
+
+Abstract
+
+   This specification describes a Low Overhead Media Container (LOC)
+   format for encoded and encrypted audio and video media data to be
+   used primarily for interactive Media over QUIC Transport (MOQT).  It
+   may be used in the WARP streaming specification, which defines a
+   catalog format for publishers to annouce and describe their LOC
+   tracks and for subscribers to consume them.  Examples are also
+   provided for building media applications using LOC and MOQT.
+
+About This Document
+
+   This note is to be removed before publishing as an RFC.
+
+   The latest revision of this draft can be found at https://moq-
+   wg.github.io/loc/draft-ietf-moq-loc.html.  Status information for
+   this document may be found at https://datatracker.ietf.org/doc/draft-
+   ietf-moq-loc/.
+
+   Discussion of this document takes place on the Media Over QUIC
+   Working Group mailing list (mailto:moq@ietf.org), which is archived
+   at https://mailarchive.ietf.org/arch/browse/moq/.  Subscribe at
+   https://www.ietf.org/mailman/listinfo/moq/.
+
+   Source for this draft and an issue tracker can be found at
+   https://github.com/moq-wg/loc.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 1]
+
+Internet-Draft               media-container                   July 2025
+
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 8 January 2026.
+
+Copyright Notice
+
+   Copyright (c) 2025 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Requirements Notation and Conventions . . . . . . . . . .   4
+     1.2.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   4
+   2.  Payload Format  . . . . . . . . . . . . . . . . . . . . . . .   4
+     2.1.  Video Payload Format  . . . . . . . . . . . . . . . . . .   4
+       2.1.1.  Parameter Sets In Payload . . . . . . . . . . . . . .   4
+       2.1.2.  Parameter Sets in Headers . . . . . . . . . . . . . .   5
+       2.1.3.  Length Prefixes in Payload  . . . . . . . . . . . . .   5
+       2.1.4.  Start Code Prefixes in Payload  . . . . . . . . . . .   5
+     2.2.  MOQ Object Mapping  . . . . . . . . . . . . . . . . . . .   5
+     2.3.  LOC Header Extensions . . . . . . . . . . . . . . . . . .   6
+       2.3.1.  Common Header Data  . . . . . . . . . . . . . . . . .   7
+       2.3.2.  Video Header Data . . . . . . . . . . . . . . . . . .   7
+       2.3.3.  Audio Header Data . . . . . . . . . . . . . . . . . .   8
+   3.  Payload Encryption  . . . . . . . . . . . . . . . . . . . . .   8
+   4.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .   8
+     4.1.  Application with one audio track  . . . . . . . . . . . .   9
+     4.2.  Application with one single quality video track . . . . .   9
+     4.3.  Application with single video track with temporal
+           layers  . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     4.4.  Application with mutiple dependent video tracks . . . . .  11
+     4.5.  Application with mutiple dependent video tracks with dyadic
+           framerate levels. . . . . . . . . . . . . . . . . . . . .  12
+     4.6.  Application with multiple simulcast qualities video
+           tracks  . . . . . . . . . . . . . . . . . . . . . . . . .  12
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 2]
+
+Internet-Draft               media-container                   July 2025
+
+
+   5.  Security and Privacy Considerations . . . . . . . . . . . . .  13
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  14
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  14
+   Appendix A.  Acknowledgements . . . . . . . . . . . . . . . . . .  15
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  15
+
+1.  Introduction
+
+   This specification describes a low-overhead media container (LOC)
+   format for encoded and encrypted audio and video media data.
+
+   "Low-overhead" refers to minimal extra encapsulation as well as
+   minimal application overhead when interfacing with WebCodecs
+   [WebCodecs].
+
+   The container format description is specified for all audio and video
+   codecs defined in the WebCodecs Codec Registry
+   [WEBCODECS-CODEC-REGISTRY].  The audio and video payload bitstream is
+   identical to the "internal data" inside an EncodedAudioChunk and
+   EncodedVideoChunk, respectively, specified in the registry.
+
+   (Note: Do we need to support timed text tracks such as Web Video Text
+   Tracks (WebVTT) ?)
+
+   In addition to the media payloads, critical metadata is also
+   specified for audio and video payloads.  (Note: Align with MOQT
+   terminology of either "metadata" or "header".)
+
+   A primary motivation is to align with media formats used in WebCodecs
+   to minimize extra encapsulation and application overhead when
+   interfacing with WebCodecs.  Other container formats like CMAF or RTP
+   would require more extensive application overhead in format
+   conversions, as well as larger encapsultion overhead which may burden
+   some use cases like low bitrate audio scenarios.
+
+   This specification can also be used by applications outside the
+   context of WebCodecs or a web browser.  While the media payloads are
+   defined by referring to the "internal data" of an EncodedAudioChunk
+   or EncodedVideoChunk in the WebCodecs Codec Registry, this "internal
+   data" is the elementary bitstream format of codecs without any
+   encapsulation.  Referring to the WebCodecs Codec Registry avoids
+   duplicating it in an identical IANA registry.
+
+   *  Section 2 defines the core media payload formats.
+
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 3]
+
+Internet-Draft               media-container                   July 2025
+
+
+   *  Section 2.3 defines the metadata associated with audio and video
+      payloads.
+
+   *  Section 3 defines the usage of end-to-end encrypted LOC payloads.
+
+   *  Section 4 provides examples with details for building audio and
+      video applications using LOC over MOQ.
+
+1.1.  Requirements Notation and Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+1.2.  Terminology
+
+   Track, Group, Subgroup, Object, and their corresponding identifiers
+   (ID or alias) are defined in [MoQTransport] and used here to refer to
+   those aspects of the MOQT Object Model.
+
+2.  Payload Format
+
+   The WebCodecs Codec Registry defines the contents of an
+   EncodedAudioChunk and EncodedVideoChunk for the audio and video codec
+   formats in the registry.  The "internal data" in these chunks is used
+   directly in this specification as the "LOC Payload" bitstream.  This
+   "internal data" is the elementary bitstream format of each codec
+   without any encapsulation.
+
+2.1.  Video Payload Format
+
+   For video formats with multiple bitstream formats in the WebCodecs
+   Registry, such as H.264/AVC or H.265/HEVC, the LOC Payload can use
+   either the "canonical" format ("avc" or "hevc") often used in storage
+   containers like MP4 / ISO BMFF, or the "annexB" format used in some
+   non-MP4 applications.  These formats differ in how they carry
+   initialization and configuration information called parameter sets as
+   well as how parts of a video frame are delimited with length prefixes
+   or start codes.
+
+2.1.1.  Parameter Sets In Payload
+
+   Parameter sets can be sent in the bitstream payload before key
+   frames, similar to "annexB" formats.  Newer "canonical" formats such
+   as "avc3" and "hev1" codec strings also support parameter sets in the
+   bitstream payload or outside it in "extradata" metadata headers.
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 4]
+
+Internet-Draft               media-container                   July 2025
+
+
+2.1.2.  Parameter Sets in Headers
+
+   Parameter sets can be sent in headers before key frames, as described
+   in the Config LOC Header Extension Section 2.3.2.1, similar to the
+   original "canonical" formats such as "avc1" and "hvc1" codec strings.
+   The Config contents are the "extradata" bytes defined by the
+   corresponding codec specification, which map to the WebCodecs
+   VideoDecoderConfig description property in the
+   EncodedVideoChunkMetadata.
+
+2.1.3.  Length Prefixes in Payload
+
+   A 4-byte length prefix can be sent before each NAL Unit, similar to
+   "canonical" ("avc" or "hevc") formats.  A length value of 1 should be
+   interpreted as a start code rather than a length.  The length is in
+   network byte order, i.e. big endian, and SHOULD be 4 bytes long to
+   disambiguate from start code prefixes.  A length prefix less than 4
+   bytes long, which is uncommon, MAY be specified in the Config
+   Section 2.3.2.1.
+
+2.1.4.  Start Code Prefixes in Payload
+
+   A 4-byte start code can be sent before each NAL Unit, similar to
+   "annexB" formats.  The start code value is 1 in network byte order,
+   i.e. big endian, and SHOULD be 4 bytes long to disambiguate from
+   length prefixes.  A 3-byte start code, which is uncommon, MAY be used
+   if the track never uses length prefixes or any Config
+   Section 2.3.2.1.
+
+2.2.  MOQ Object Mapping
+
+   An application object when transported as a [MoQTransport] object is
+   composed of a MOQ Object Header, with optional Extensions, and a
+   Payload.  Media objects encoded using the container format defined in
+   this specification populate the MOQ Object Payload with the LOC
+   Payload, and the MOQ Object Header Extensions with the LOC Header
+   Extensions, as shown below.
+
+   The LOC Payload is the "internal data" of an EncodedAudioChunk or
+   EncodedVideoChunk.
+
+   The LOC Header Extensions carry optional metadata related to the
+   Payload.
+
+
+
+
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 5]
+
+Internet-Draft               media-container                   July 2025
+
+
+   <-----------  MOQ Object  ------------>
+   +----------+--------------+-----------+
+   |   MOQ    |  MOQ Header  |    MOQ    |
+   |  Header  |  Extensions  |  Payload  |
+   +----------+--------------+-----------+
+                     |             |
+                     |             |
+              +--------------+-----------+
+              |  LOC Header  |    LOC    |
+              |  Extensions  |  Payload  |
+              +--------------+-----------+
+
+   LOC Header Extensions = some MOQ Object Header Extensions
+   LOC Payload = all MOQ Object Payload
+   LOC Payload = "internal data" of EncodedAudio/VideoChunk
+
+2.3.  LOC Header Extensions
+
+   The LOC Header Extensions carry optional metadata for the
+   corresponding LOC Payload.  The LOC Header Extensions are contained
+   within the MOQ Object Header Extensions.  This metadata provides
+   necessary information for end subscribers, relays and other
+   intermediaries to perform their operations without accessing the
+   media payload.  For example, media switches can use this metadata to
+   perform their media switching decisions without accessing the payload
+   which may be encrypted end-to-end (from original publisher to end
+   subscribers).
+
+   The following sections define specific metadata as LOC Header
+   Extensions and register them in the IANA registry for MOQ Object
+   Header Extensions.
+
+   Other specifications can define other metadata as LOC Header
+   Extensions and register them in the same registry.  Each extension
+   must specify the following information in the IANA registry.
+
+   *  Name: Short name for the metadata (not sent on the wire)
+
+   *  Description: Detailed description (not sent on the wire)
+
+   *  ID: Identifier assigned by the registry (varint)
+
+   *  Length: Length of metadata Value in bytes (varint if ID is odd,
+      omitted if ID is even)
+
+   *  Value: Value of metadata (varint if ID is even, Length bytes if ID
+      is odd)
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 6]
+
+Internet-Draft               media-container                   July 2025
+
+
+2.3.1.  Common Header Data
+
+2.3.1.1.  Capture Timestamp
+
+   *  Name: Capture Timestamp
+
+   *  Description: Wall-clock time in microseconds since the Unix epoch
+      when the encoded media frame was captured, encoded as a varint.
+
+   *  ID: 2 (IANA, please assign from the MOQ Header Extensions
+      Registry)
+
+   *  Length: Varies (1-8 bytes)
+
+   *  Value: Varies
+
+2.3.2.  Video Header Data
+
+2.3.2.1.  Video Config
+
+   *  Name: Video Config
+
+   *  Description: Video codec configuration "extradata", as defined by
+      the corresponding codec specification, which maps to the WebCodecs
+      VideoDecoderConfig description property in the
+      EncodedVideoChunkMetadata.
+
+   *  ID: 13 (IANA, please assign from the MOQ Header Extensions
+      Registry)
+
+   *  Length: Varies
+
+   *  Value: Varies
+
+2.3.2.2.  Video Frame Marking
+
+   *  Name: Video Frame Marking
+
+   *  Description: Flags for video frames which are independent,
+      discardable, or base layer sync points, as well as temporal and
+      spatial layer identification, as defined in [RFC9626], encoded in
+      the least significant bits of a varint.
+
+   *  ID: 4 (IANA, please assign from the MOQ Header Extensions
+      Registry)
+
+   *  Length: Varies (1-4 bytes)
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 7]
+
+Internet-Draft               media-container                   July 2025
+
+
+   *  Value: Varies
+
+2.3.3.  Audio Header Data
+
+2.3.3.1.  Audio Level
+
+   *  Name: Audio Level
+
+   *  Description: The magnitude of the audio level of the corresponding
+      audio frame as well as a voice activity indicator as defined in
+      section 3 of [RFC6464], encoded in the least significant 8 bits of
+      a varint.
+
+   *  ID: 6 (IANA, please assign from the MOQ Header Extensions
+      Registry)
+
+   *  Length: Varies (1-2 bytes)
+
+   *  Value: Varies
+
+3.  Payload Encryption
+
+   When end to end encryption is supported, the encoded payload is
+   encrypted with symmetric keys derived from key establishment
+   mechanisms, such as [MOQ-MLS], and the payload itself is protected
+   using mechanisms defined in [SecureObjects].
+
+4.  Examples
+
+   This section provides examples with details for building audio and
+   video applications using MOQ and LOC; more specifically, it provides
+   information on:
+
+   *  Using a WARP catalog [MoQCatalog] to describe track information,
+
+   *  Packaging media into LOC streaming format, and
+
+   *  Mapping application media objects to the MOQT object model and
+      transport.
+
+   The figure below shows the conceptual model for mapping media
+   application data to the MOQT object model and underlying QUIC
+   transport.
+
+
+
+
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 8]
+
+Internet-Draft               media-container                   July 2025
+
+
+   +------------------------------+
+   |     Media Application        |
+   |    Audio, Video Frames       |
+   +---------------+--------------+
+                   |
+                   |
+   +---------------v--------------------+
+   |        MOQT Object Model           |
+   | Tracks, Groups, Subgroups, Objects |
+   +---------------+--------------------+
+                   |
+                   |
+   +---------------v--------------+
+   |             QUIC             |
+   |        Streams, Datagrams    |
+   +------------------------------+
+
+4.1.  Application with one audio track
+
+   An example is shown below for an Opus mono channel audio track at
+   48Khz.
+
+   codec: "opus"
+   bitrate: 24000
+   samplerate: 480000
+   channelConfig: "mono"
+   lang: "en"
+
+   When ready for publishing, each encoded audio chunk, say 10ms,
+   represents a MOQT Object.  In this setup, there is one MOQT Object
+   per MOQT Group, where the GroupID in the object header is increment
+   by one for each encoded audio chunk and the ObjectID is defaulted to
+   value 0.
+
+   These objects can be sent as QUIC streams or datagrams.  When mapped
+   to QUIC datagrams, each object must fit entirely within a QUIC
+   datagram, and when mapped to QUIC Streams, each such unitary group is
+   sent over an individual unidirectional QUIC stream since there is
+   just one SubGroup per each MOQT Group.
+
+4.2.  Application with one single quality video track
+
+   An example is shown below for an H.264 video track with 1280x720p
+   resolution and 30 fps frame rate at 1 Mbps bitrate.
+
+
+
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                 [Page 9]
+
+Internet-Draft               media-container                   July 2025
+
+
+   codec: "avc3.42E01E"
+   bitrate: 1000000
+   framerate: 30
+   width: 1280
+   height: 720
+
+   When ready for publishing, each encoded video chunk is considered as
+   input to MOQT Object payload.  If encrypted, the output of encryption
+   will serve as the object's payload.  The GroupID is incremented by 1
+   at IDR Frame boundaries.  The ObjectID is increment by 1 for each
+   encoded video frame, starting at 0 and resetting to 0 at the start of
+   a new group.  The first encoded video frame, MOQT Object with
+   ObjectID 0, shall be the Independent (IDR) frame and the rest of the
+   encoded video frames corresponds to dependent (delta) frames,
+   organized in the decode order.
+
+   When mapping to QUIC for sending, one unidirectional QUIC stream is
+   setup to deliver all the encoded video chunks within a MOQT group.
+
+   When decoding at the 'End Consumer', the objects from each of the
+   QUIC streams are fed in the GroupID then ObjectID order to the
+   decoder for the track.
+
+4.3.  Application with single video track with temporal layers
+
+   An example is shown below for an H.264 video track with 1280x720p
+   resolution and 2 temporal layers at 30 fps and 60 fps frame rate.
+
+   codec: "avc3.42E01F"
+   bitrate: 1500000
+   framerate: 60
+   width: 1280
+   height: 720
+
+   When ready for publishing, each encoded video chunk is considered as
+   input to MOQT Object payload.  If encrypted, the output of encryption
+   will serve as the object's payload.  The GroupID is incremented by 1
+   at Independent (IDR) frame boundaries.  Each MOQT group shall contain
+   2 SubGroups corresponding to the 2 temporal layers as shown below:
+
+   Layer:0/30fps Subgroup: 0 ObjectID: even
+   Layer:1/60fps Subgroup: 1 ObjectID: odd
+
+   Within the MOQT group, ObjectID is increment by 1 for each encoded
+   video frame, starting at 0 and resetting to 0 at the start of a new
+   group.  The first encoded video frame, MOQT Object with ObjectID 0,
+   shall be the Indepedent (IDR) frame and the rest of the encoded video
+   frames corresponds to dependent (delta) frames, organized in the
+
+
+
+Zanaty, et al.           Expires 8 January 2026                [Page 10]
+
+Internet-Draft               media-container                   July 2025
+
+
+   decode order.  When mapping to QUIC for sending, one unidirectional
+   QUIC stream is used per SubGroup, thus resulting in 2 QUIC streams
+   per MOQT group.
+
+   When decoding at the 'End Consumer' for a given MOQT group, the
+   objects must be fed in the GroupID then ObjectID order.  This implies
+   that the consumer media application needs to order objects across the
+   SubGroup QUIC streams.
+
+4.4.  Application with mutiple dependent video tracks
+
+   An example is shown below for an H.264 video track with 2 spatial
+   qualities at 360p and 720p each at 30 fps
+
+   Video Track 1
+   codec: "avc3.42E01E"
+   bitrate: 500000
+   framerate: 30
+   width: 640
+   height: 360
+
+   Video Track 2
+   codec: "svc1.56401F"
+   bitrate: 1000000
+   framerate: 30
+   width: 1280
+   height: 720
+
+   When ready for publishing, the mapping to the MOQT object model and
+   to underlying QUIC, follows the same procedures as described in
+   Section 4.2 for each video track.
+
+   When decoding at the 'End Consumer' for a given MOQT group, the
+   objects must be fed in the GroupID then ObjectID order in the
+   ascending quality track order.
+
+   For the example in the section, this would imply following pattern
+   when decoding group 5.
+
+   Track 1 Group 5 Object 0
+   Track 2 Group 5 Object 0
+   Track 1 Group 5 Object 1
+   Track 2 Group 5 Object 1
+   ....
+
+
+
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                [Page 11]
+
+Internet-Draft               media-container                   July 2025
+
+
+4.5.  Application with mutiple dependent video tracks with dyadic
+      framerate levels.
+
+   An example is shown below for an H.264 video track with 2 spatial
+   qualities at 360p and 720p, however, the framerate between tracks
+   vary dyadically.
+
+   Video Track 1
+   codec: "avc3.42E01E"
+   bitrate: 500000
+   framerate: 30
+   width: 640
+   height: 360
+
+   Video Track 2
+   codec: "svc1.56E01F"
+   bitrate: 1000000
+   framerate: 60
+   width: 1280
+   height: 720
+
+   When ready for publishing, the mapping to the MOQT object model and
+   to underlying QUIC, follows the same procedures as described in
+   Section 4.2 for each video track.
+
+   When decoding at the 'End Consumer' for a given MOQT group, the
+   objects from across the tracks must be fed in the timestamp order to
+   the decoder, if no frame reordering is present in the encoding.
+
+   If the encoding uses frame reordering, or if timestamp cannot be
+   obtained, the object to choose next shall follow the below formula.
+
+   Object Decode Order = ObjectID * multiplier + offset
+
+   multiplier = 2^(maxlayer-max(0,layer-1))
+   offset = 2^(maxlayer-layer) MOD multiplier
+
+4.6.  Application with multiple simulcast qualities video tracks
+
+   An example is shown below for an H.264 video track with 2 simulcast
+   spatial qualities at 360p and 720p each at 30 fps.
+
+
+
+
+
+
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                [Page 12]
+
+Internet-Draft               media-container                   July 2025
+
+
+   Video Track 1
+   codec: "avc3.42E01E"
+   bitrate: 500000
+   framerate: 30
+   width: 640
+   height: 360
+
+   Video Track 2
+   codec: "avc3.42E01F"
+   bitrate: 1000000
+   framerate: 30
+   width: 1280
+   height: 720
+
+   When ready for publishing, the mapping to the MOQT object model and
+   to underlying QUIC, follows the same procedures as described in
+   Section 4.2 for each video track.
+
+   When decoding at the 'End Consumer', the objects from the QUIC stream
+   are fed in the GroupID then ObjectID order to the decoders setup for
+   the corresponding video tracks.
+
+5.  Security and Privacy Considerations
+
+   The metadata in LOC Header Extensions is visible to relays, since the
+   MOQ Object Header Extensions are often not encrypted end-to-end (from
+   original publisher to end subscribers) in common schemes.  In some
+   cases, this may be an intentional design intent for proper relay
+   operation.  In other cases, this may be unintentional or undesirable
+   leaking of the metadata to relays.  Each metadata that is defined
+   should consider the security and privacy aspects of granting relays
+   visibility to the metadata.  End-to-end encyption schemes should
+   support end-to-end encryption of sensitive metadata.
+
+   The metadata defined and registered in this specification (Capture
+   Timestamp, Video Frame Marking, and Audio Level) may be sensitive
+   metadata that should be encrypted end-to-end.  They are used by media
+   switches, which are not merely relays, and likely have access to some
+   media keys.  This may require end-to-end encryption schemes with
+   multiple different security key contexts for payload versus metadata.
+
+6.  IANA Considerations
+
+   The IANA registry for MOQ Object Header Extensions is populated with
+   the entries specified in section Section 2.3, referencing this
+   specification.
+
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                [Page 13]
+
+Internet-Draft               media-container                   July 2025
+
+
+   This document creates a new entry in the "MoQ Streaming Format"
+   Registry (see [MoQTransport] Sect 8).  The type value is 0x002, the
+   name is "LOC Streaming Format" and the RFC is XXX.
+
+7.  References
+
+7.1.  Normative References
+
+   [MoQTransport]
+              Nandakumar, S., Vasiliev, V., Swett, I., and A. Frindell,
+              "Media over QUIC Transport", Work in Progress, Internet-
+              Draft, draft-ietf-moq-transport-12, 23 June 2025,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-moq-
+              transport-12>.
+
+   [WebCodecs]
+              "WebCodecs", July 2023,
+              <https://www.w3.org/TR/webcodecs/>.
+
+   [WEBCODECS-CODEC-REGISTRY]
+              "WebCodecs Codec Registry", July 2023,
+              <https://www.w3.org/TR/webcodecs-codec-registry/>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/rfc/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/rfc/rfc8174>.
+
+   [RFC9626]  Zanaty, M., Berger, E., and S. Nandakumar, "Video Frame
+              Marking RTP Header Extension", RFC 9626,
+              DOI 10.17487/RFC9626, March 2025,
+              <https://www.rfc-editor.org/rfc/rfc9626>.
+
+   [RFC6464]  Lennox, J., Ed., Ivov, E., and E. Marocco, "A Real-time
+              Transport Protocol (RTP) Header Extension for Client-to-
+              Mixer Audio Level Indication", RFC 6464,
+              DOI 10.17487/RFC6464, December 2011,
+              <https://www.rfc-editor.org/rfc/rfc6464>.
+
+7.2.  Informative References
+
+   [MoQCatalog]
+              Law, W., Curley, L., Vasiliev, V., Nandakumar, S., and K.
+              Pugin, "WARP Streaming Format", Work in Progress,
+
+
+
+Zanaty, et al.           Expires 8 January 2026                [Page 14]
+
+Internet-Draft               media-container                   July 2025
+
+
+              Internet-Draft, draft-ietf-moq-warp-00, 16 March 2025,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-moq-
+              warp-00>.
+
+   [SecureObjects]
+              Jennings, C. F., Nandakumar, S., and R. Barnes, "End-to-
+              End Secure Objects for Media over QUIC Transport", Work in
+              Progress, Internet-Draft, draft-jennings-moq-secure-
+              objects-02, 28 February 2025,
+              <https://datatracker.ietf.org/doc/html/draft-jennings-moq-
+              secure-objects-02>.
+
+   [MOQ-MLS]  Jennings, C. F., Nandakumar, S., and R. Barnes, "End-to-
+              end Security for Media over QUIC", Work in Progress,
+              Internet-Draft, draft-jennings-moq-e2ee-mls-03, 30 June
+              2025, <https://datatracker.ietf.org/doc/html/draft-
+              jennings-moq-e2ee-mls-03>.
+
+Appendix A.  Acknowledgements
+
+   Thanks to Cullen Jennings for suggestions and review.
+
+Authors' Addresses
+
+   Mo Zanaty
+   Cisco
+   Email: mzanaty@cisco.com
+
+
+   Suhas Nandakumar
+   Cisco
+   Email: snandaku@cisco.com
+
+
+   Peter Thatcher
+   Microsoft
+   Email: pthatcher@microsoft.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zanaty, et al.           Expires 8 January 2026                [Page 15]


### PR DESCRIPTION
## 概要

映像をRelayサーバー越しに送受信できるコマンドラインツール（moq-cli）を追加しました。

あわせて、このツールから送った映像を遠隔監視アプリ画面でも見られるように、必要な受信まわりの修正をしています。ライブ再生だけでなく、過去にさかのぼって見る「巻き戻し」でも映せるようにしました。

## 詳細

- **コマンドラインツールの追加**：標準入力で受け取った映像を中継サーバーに送る、または中継サーバーから受け取って標準出力に流す、という送受信ツールです。
- **遠隔監視アプリの修正**：
  - 巻き戻しのときに、映像ペイロードの付加情報 (Object Extension Header) が受け手まで届いていなかったので、届くようにしました。あわせて、ツールが送る素の映像形式 (H.264 Annex-B) もそのままデコードできるようにしました。
  - 受信のゆらぎを吸収してなめらかに再生する仕組みを有効にしました。
- **ついでの小さな修正**：
  - 映像の初期化情報につける番号が仕様と食い違っていた（仕様13／コード16）ので直しました。使われていなかったため実害はなし。
  - 中継サーバーの選択ボタンが2つ同時に選択表示される不具合を直しました。

## テスト

- ツール同士（送る→受け取る）で映像が再生できることを確認。
- ツール→ブラウザ監視画面で、ライブ再生 & 巻き戻しを確認。
- ブラウザ同士の送受信が今までどおり動くことを確認。

## 備考

- 参照用に、映像フォーマットの仕様書（ドラフト）をリポジトリに同梱しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
