### PR TITLE
fix(moqt): FETCHの失敗をリクエスト単位に閉じる(タイムアウト・未応答・RESET)

### DIFF
--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -86,6 +86,7 @@ pub use modules::moqt::domains::fetch_handle::FetchHandle;
 pub use modules::moqt::domains::publisher::Publisher;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::session::Session;
+pub use modules::moqt::domains::session_context::RequestTimeoutError;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::subscriber::DataReceiver;
 #[cfg(not(target_arch = "wasm32"))]

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -86,6 +86,7 @@ pub use modules::moqt::domains::fetch_handle::FetchHandle;
 pub use modules::moqt::domains::publisher::Publisher;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::session::Session;
+#[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::session_context::RequestTimeoutError;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::subscriber::DataReceiver;

--- a/moqt/src/modules/moqt/control_plane/control_messages/messages/parameters/location.rs
+++ b/moqt/src/modules/moqt/control_plane/control_messages/messages/parameters/location.rs
@@ -4,7 +4,7 @@ use crate::modules::extensions::buf_get_ext::BufGetExt;
 use crate::modules::extensions::buf_put_ext::BufPutExt;
 use crate::modules::extensions::result_ext::ResultExt;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Location {
     pub group_id: u64,
     pub object_id: u64,

--- a/moqt/src/modules/moqt/control_plane/control_messages/messages/request_error.rs
+++ b/moqt/src/modules/moqt/control_plane/control_messages/messages/request_error.rs
@@ -3,6 +3,7 @@ use crate::modules::extensions::{
 };
 use bytes::BytesMut;
 use serde::Serialize;
+use std::fmt;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct RequestError {
@@ -10,6 +11,18 @@ pub struct RequestError {
     pub error_code: u64,
     pub reason_phrase: String,
 }
+
+impl fmt::Display for RequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "request {} failed with code {}: {}",
+            self.request_id, self.error_code, self.reason_phrase
+        )
+    }
+}
+
+impl std::error::Error for RequestError {}
 
 impl RequestError {
     pub fn decode(buf: &mut std::io::Cursor<&[u8]>) -> Option<Self> {

--- a/moqt/src/modules/moqt/control_plane/handler/fetch_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/fetch_handler.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::{
     GroupOrder, TransportProtocol,
@@ -17,12 +20,16 @@ use crate::{
     },
 };
 
+/// FETCH_ERROR code for endpoints that do not implement FETCH (draft-14 §9.18).
+const FETCH_ERROR_NOT_SUPPORTED: u64 = 0x3;
+
 #[derive(Debug, Clone)]
 pub struct FetchHandler<T: TransportProtocol> {
     session_context: Arc<SessionContext<T>>,
     pub request_id: u64,
     pub group_order: GroupOrder,
     pub fetch: Fetch,
+    responded: Arc<AtomicBool>,
 }
 
 impl<T: TransportProtocol> FetchHandler<T> {
@@ -34,6 +41,7 @@ impl<T: TransportProtocol> FetchHandler<T> {
             request_id,
             group_order,
             fetch,
+            responded: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -42,6 +50,7 @@ impl<T: TransportProtocol> FetchHandler<T> {
         end_of_track: bool,
         end_location: Location,
     ) -> Result<(), TransportSendError> {
+        self.responded.store(true, Ordering::Relaxed);
         let fetch_ok = FetchOk {
             request_id: self.request_id,
             group_order: self.group_order,
@@ -60,6 +69,7 @@ impl<T: TransportProtocol> FetchHandler<T> {
         error_code: u64,
         reason_phrase: String,
     ) -> Result<(), TransportSendError> {
+        self.responded.store(true, Ordering::Relaxed);
         let err = RequestError {
             request_id: self.request_id,
             error_code,
@@ -69,5 +79,38 @@ impl<T: TransportProtocol> FetchHandler<T> {
             .send_stream
             .send(ControlMessageType::FetchError, err.encode())
             .await
+    }
+}
+
+impl<T: TransportProtocol> Drop for FetchHandler<T> {
+    fn drop(&mut self) {
+        // An application that ignores SessionEvent::Fetch drops the handler
+        // without responding, which would leave the requester waiting for its
+        // control timeout. Auto-answer NOT_SUPPORTED so the failure is prompt
+        // and the peer's session is never at risk. strong_count == 1 limits
+        // this to the last clone; a single fire-and-forget send needs no
+        // owned JoinHandle.
+        if self.responded.load(Ordering::Relaxed) || Arc::strong_count(&self.responded) > 1 {
+            return;
+        }
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let session_context = self.session_context.clone();
+        let request_id = self.request_id;
+        runtime.spawn(async move {
+            let err = RequestError {
+                request_id,
+                error_code: FETCH_ERROR_NOT_SUPPORTED,
+                reason_phrase: "fetch not handled by application".to_string(),
+            };
+            if let Err(error) = session_context
+                .send_stream
+                .send(ControlMessageType::FetchError, err.encode())
+                .await
+            {
+                tracing::warn!(?error, request_id, "failed to auto-reject unhandled fetch");
+            }
+        });
     }
 }

--- a/moqt/src/modules/moqt/data_plane/stream/fetch_data_sender.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/fetch_data_sender.rs
@@ -26,4 +26,8 @@ impl<T: TransportProtocol> FetchDataSender<T> {
     pub async fn close(&self) -> anyhow::Result<()> {
         self.stream_sender.close().await
     }
+
+    pub async fn reset(&self, error_code: u64) -> anyhow::Result<()> {
+        self.stream_sender.reset(error_code).await
+    }
 }

--- a/moqt/src/modules/moqt/data_plane/stream/stream_sender.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/stream_sender.rs
@@ -24,4 +24,8 @@ impl<T: TransportProtocol> StreamSender<T> {
     pub async fn close(&self) -> anyhow::Result<()> {
         Ok(self.send_stream.lock().await.close().await?)
     }
+
+    pub async fn reset(&self, error_code: u64) -> anyhow::Result<()> {
+        Ok(self.send_stream.lock().await.reset(error_code).await?)
+    }
 }

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -25,6 +25,20 @@ use crate::{
 
 const CONTROL_MESSAGE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Returned by [`SessionContext::await_request_response`] when the peer does
+/// not answer in time. Callers map this to a per-request failure (e.g.
+/// FETCH_ERROR TIMEOUT) and keep the session open.
+#[derive(Debug)]
+pub struct RequestTimeoutError;
+
+impl fmt::Display for RequestTimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "request response timed out")
+    }
+}
+
+impl std::error::Error for RequestTimeoutError {}
+
 pub(crate) struct SessionContext<T: TransportProtocol> {
     pub(crate) transport_connection: T::Connection,
     pub(crate) send_stream: BiStreamSender<T>,
@@ -205,6 +219,10 @@ impl<T: TransportProtocol> SessionContext<T> {
     /// resource exhaustion when a peer does not send the expected response.
     /// On timeout, the session is closed with `ControlMessageTimeout` and an
     /// error is returned so the caller can propagate the failure cleanly.
+    ///
+    /// FIXME: SUBSCRIBE and the other request/response exchanges still use
+    /// this session-closing variant; migrating them to
+    /// `await_request_response` is tracked separately.
     pub(crate) async fn await_response(
         &self,
         receiver: tokio::sync::oneshot::Receiver<ResponseMessage>,
@@ -220,6 +238,22 @@ impl<T: TransportProtocol> SessionContext<T> {
                 );
                 anyhow::bail!("control message response timed out")
             }
+        }
+    }
+
+    /// Like `await_response`, but a timeout fails only this request instead of
+    /// closing the session: a FETCH is request-scoped, and a shared
+    /// (inter-relay) session must survive one slow request. §12.2's
+    /// resource-exhaustion concern is met by the caller dropping its pending
+    /// request state on the error path.
+    pub(crate) async fn await_request_response(
+        &self,
+        receiver: tokio::sync::oneshot::Receiver<ResponseMessage>,
+    ) -> anyhow::Result<ResponseMessage> {
+        match tokio::time::timeout(CONTROL_MESSAGE_RESPONSE_TIMEOUT, receiver).await {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(error)) => anyhow::bail!("control response channel closed: {}", error),
+            Err(_) => Err(RequestTimeoutError.into()),
         }
     }
 

--- a/moqt/src/modules/moqt/domains/subscriber.rs
+++ b/moqt/src/modules/moqt/domains/subscriber.rs
@@ -26,6 +26,7 @@ use crate::{
         protocol::TransportProtocol,
         runtime::dispatch::incoming_object::IncomingObject,
     },
+    wire::RequestError,
 };
 
 pub enum DataReceiver<T: TransportProtocol> {
@@ -199,28 +200,49 @@ impl<T: TransportProtocol> Subscriber<T> {
             },
             authorization_tokens: vec![],
         };
-        self.session
-            .send_stream
-            .send(ControlMessageType::Fetch, fetch.encode())
-            .await?;
-        let response = self.session.await_response(fetch_message_rx).await?;
+        let result = async {
+            self.session
+                .send_stream
+                .send(ControlMessageType::Fetch, fetch.encode())
+                .await?;
+            self.session.await_request_response(fetch_message_rx).await
+        }
+        .await;
+        let response = match result {
+            Ok(response) => response,
+            Err(error) => {
+                // Request-scoped failure (send error or timeout): drop the
+                // pending fetch state so nothing leaks. The session stays open.
+                self.remove_pending_fetch(request_id).await;
+                return Err(error);
+            }
+        };
         match response {
             ResponseMessage::FetchOk(fetch_ok) => Ok(FetchHandle::new(fetch_ok)),
-            ResponseMessage::FetchError(_, _, _) => {
-                self.session
-                    .fetch_notification_map
-                    .write()
-                    .await
-                    .remove(&request_id);
-                self.session
-                    .fetch_receiver_map
-                    .lock()
-                    .await
-                    .remove(&request_id);
-                bail!("Fetch error")
+            ResponseMessage::FetchError(request_id, error_code, reason_phrase) => {
+                self.remove_pending_fetch(request_id).await;
+                Err(RequestError {
+                    request_id,
+                    error_code,
+                    reason_phrase,
+                }
+                .into())
             }
             _ => bail!("Protocol violation"),
         }
+    }
+
+    async fn remove_pending_fetch(&self, request_id: u64) {
+        self.session
+            .fetch_notification_map
+            .write()
+            .await
+            .remove(&request_id);
+        self.session
+            .fetch_receiver_map
+            .lock()
+            .await
+            .remove(&request_id);
     }
 
     #[tracing::instrument(
@@ -252,11 +274,9 @@ impl<T: TransportProtocol> Subscriber<T> {
 
         let (fetch_message_tx, fetch_message_rx) =
             tokio::sync::oneshot::channel::<ResponseMessage>();
-        self.session
-            .sender_map
-            .lock()
-            .expect("sender_map poisoned")
-            .insert(request_id, fetch_message_tx);
+        let _registered_sender = self
+            .session
+            .register_response_sender(request_id, fetch_message_tx);
         let fetch = Fetch {
             request_id,
             subscriber_priority: option.subscriber_priority,
@@ -267,25 +287,33 @@ impl<T: TransportProtocol> Subscriber<T> {
             },
             authorization_tokens: vec![],
         };
-        self.session
-            .send_stream
-            .send(ControlMessageType::Fetch, fetch.encode())
-            .await?;
-        let response = self.session.await_response(fetch_message_rx).await?;
+        let result = async {
+            self.session
+                .send_stream
+                .send(ControlMessageType::Fetch, fetch.encode())
+                .await?;
+            self.session.await_request_response(fetch_message_rx).await
+        }
+        .await;
+        let response = match result {
+            Ok(response) => response,
+            Err(error) => {
+                // Request-scoped failure (send error or timeout): drop the
+                // pending fetch state so nothing leaks. The session stays open.
+                self.remove_pending_fetch(request_id).await;
+                return Err(error);
+            }
+        };
         match response {
             ResponseMessage::FetchOk(fetch_ok) => Ok(FetchHandle::new(fetch_ok)),
-            ResponseMessage::FetchError(_, _, _) => {
-                self.session
-                    .fetch_notification_map
-                    .write()
-                    .await
-                    .remove(&request_id);
-                self.session
-                    .fetch_receiver_map
-                    .lock()
-                    .await
-                    .remove(&request_id);
-                bail!("Fetch error")
+            ResponseMessage::FetchError(request_id, error_code, reason_phrase) => {
+                self.remove_pending_fetch(request_id).await;
+                Err(RequestError {
+                    request_id,
+                    error_code,
+                    reason_phrase,
+                }
+                .into())
             }
             _ => bail!("Protocol violation"),
         }

--- a/moqt/src/modules/transport/dual/dual_send_stream.rs
+++ b/moqt/src/modules/transport/dual/dual_send_stream.rs
@@ -28,4 +28,11 @@ impl TransportSendStream for DualSendStream {
             DualSendStream::WebTransport(s) => s.close().await,
         }
     }
+
+    async fn reset(&mut self, error_code: u64) -> Result<(), TransportSendError> {
+        match self {
+            DualSendStream::Quic(s) => s.reset(error_code).await,
+            DualSendStream::WebTransport(s) => s.reset(error_code).await,
+        }
+    }
 }

--- a/moqt/src/modules/transport/quic/quic_send_stream.rs
+++ b/moqt/src/modules/transport/quic/quic_send_stream.rs
@@ -24,6 +24,17 @@ impl TransportSendStream for QUICSendStream {
             .finish()
             .map_err(|_| TransportSendError::ClosedStream)
     }
+
+    async fn reset(&mut self, error_code: u64) -> Result<(), TransportSendError> {
+        let error_code = quinn::VarInt::try_from(error_code).map_err(|source| {
+            TransportSendError::Transport {
+                source: source.into(),
+            }
+        })?;
+        self.send_stream
+            .reset(error_code)
+            .map_err(|_| TransportSendError::ClosedStream)
+    }
 }
 
 fn quic_write_error_to_transport_send_error(error: quinn::WriteError) -> TransportSendError {

--- a/moqt/src/modules/transport/transport_send_stream.rs
+++ b/moqt/src/modules/transport/transport_send_stream.rs
@@ -31,4 +31,5 @@ pub enum TransportSendError {
 pub(crate) trait TransportSendStream: Send + Sync + 'static + Debug {
     async fn send(&mut self, buffer: &BytesMut) -> Result<(), TransportSendError>;
     async fn close(&mut self) -> Result<(), TransportSendError>;
+    async fn reset(&mut self, error_code: u64) -> Result<(), TransportSendError>;
 }

--- a/moqt/src/modules/transport/webtransport/wt_send_stream.rs
+++ b/moqt/src/modules/transport/webtransport/wt_send_stream.rs
@@ -25,6 +25,16 @@ impl TransportSendStream for WtSendStream {
             .finish()
             .map_err(|_| TransportSendError::ClosedStream)
     }
+
+    async fn reset(&mut self, error_code: u64) -> Result<(), TransportSendError> {
+        let error_code =
+            u32::try_from(error_code).map_err(|source| TransportSendError::Transport {
+                source: source.into(),
+            })?;
+        self.send_stream
+            .reset(error_code)
+            .map_err(|_| TransportSendError::ClosedStream)
+    }
 }
 
 fn webtransport_write_error_to_transport_send_error(


### PR DESCRIPTION
## 概要

FETCH転送(relayが上流へFETCHを送る機能、#310)の前提となる修正です。

moqtクレートには「制御メッセージの応答が10秒でタイムアウトするとセッションを切断する」処理が入っており、これがrelayでは問題になることがわかりました。

- clientサイドでは、relayへの制御メッセージがタイムアウトしたときにセッションを切断してもそこまで問題にならない(影響が自分のセッションに閉じるため)
- しかしrelayはrelay間通信を1本のQUICコネクションに多重化しているため、制御メッセージが1つタイムアウトしただけでセッションを切断すると、relay間コネクションごと切れて**他の経路(他トラックの購読・配信)にまで影響が及ぶ**
- 仕様上、タイムアウト時に切断するかどうかは実装裁量(§12.2。`CONTROL_MESSAGE_TIMEOUT (0x11)`は切断を選ぶ場合の終了コード)

そこで方針として、moqtクレート共通で「制御メッセージのタイムアウトではセッションを切断しない」に揃えます。本PRではまずFETCH系を移行し、SUBSCRIBE等は後始末(遅延SUBSCRIBE_OKへのUNSUBSCRIBE送出など)の整備とあわせて後続PRで移行します(コード上にFIXMEを明記済み)。

## 変更内容

- `SessionContext::await_request_response` を追加: タイムアウトを型付きエラー `RequestTimeoutError` として返すだけで、セッションは維持する。`Subscriber::fetch` / `fetch_relative_joining` をこちらに移行し、エラー経路で保留状態(pending map / response sender)を掃除する(従来はセッション破壊が資源解放を兼ねていたため、その代替)
- `FetchHandler`: アプリが応答せずにdropした場合、`FETCH_ERROR NOT_SUPPORTED (0x3)` を自動応答する。FETCH未実装のアプリにFETCHが届いた際、送信側が10秒のタイムアウトを待たされないようにするため
- `Subscriber::fetch` がFETCH_ERROR受信時にコード・理由を捨てていたのを、型付き `wire::RequestError` で返すように変更(relayでのエラーコード中継の前提)
- `TransportSendStream::reset()` をQUIC / WebTransport / Dualに実装し、`FetchDataSender` まで公開。FETCH_OK送信後に応答を完遂できない場合、FIN(=欠番は非存在の意味論が確定)ではなくRESET_STREAMで中断するため(§9.16)
- `Location` に `Ord/PartialOrd` をderive(group_id → object_idの辞書順)

## テスト

- `cargo test -p moqt -p relay`(masterのrelay + 本変更のmoqt)全パス、clippy / fmt クリーン、wasm32ビルド確認済み
- 統合検証は #310 のe2eシナリオFで実施: FETCH_ERRORが即時(<5秒)に返ること、失敗したFETCHの後もpublisherセッションと配信が生存することをassert

🤖 Generated with [Claude Code](https://claude.com/claude-code)