### PR TITLE
refactor(moqt,relay): streamの正常終了・切断・デコード失敗を区別して処理する

### DIFF
--- a/examples/cross-protocol-test/quic-subscriber/src/moqt_receiver.rs
+++ b/examples/cross-protocol-test/quic-subscriber/src/moqt_receiver.rs
@@ -87,8 +87,9 @@ pub async fn subscribe_and_receive(namespace: &str, track_name: &str) -> Result<
                 let mut object_id: u64 = 0;
                 loop {
                     let result = match stream.receive().await {
-                        Ok(r) => r,
-                        Err(_) => break,
+                        Ok(Some(r)) => r,
+                        // FIN or receive error: move on to the next stream
+                        Ok(None) | Err(_) => break,
                     };
                     match result {
                         Subgroup::Header(header) => {

--- a/examples/rust/manual-client/src/client.rs
+++ b/examples/rust/manual-client/src/client.rs
@@ -388,7 +388,7 @@ impl<T: TransportProtocol> Client<T> {
                             let label = label.clone();
                             self.joinset.spawn(async move {
                                 while let Ok(mut stream) = factory.next().await {
-                                    while let Ok(result) = stream.receive().await {
+                                    while let Ok(Some(result)) = stream.receive().await {
                                         tracing::info!("{} :active subscribe stream: {:?}", label, result);
                                     }
                                 }

--- a/examples/rust/moq-cli/src/transport/reader.rs
+++ b/examples/rust/moq-cli/src/transport/reader.rs
@@ -31,11 +31,16 @@ impl TrackReader {
             }
             let group = self.group.as_mut().expect("group opened above");
             match group.receive().await {
-                Ok(Subgroup::Object(field)) => match field.subgroup_object {
+                Ok(Some(Subgroup::Object(field))) => match field.subgroup_object {
                     SubgroupObject::Payload { data, .. } => return Ok(Some(data)),
                     SubgroupObject::Status { .. } => continue,
                 },
-                Ok(Subgroup::Header(_)) => continue,
+                Ok(Some(Subgroup::Header(_))) => continue,
+                Ok(None) => {
+                    // group stream finished (FIN); advance to the next group
+                    self.group = None;
+                    continue;
+                }
                 Err(e) => {
                     tracing::warn!("group read error, advancing to next group: {e}");
                     self.group = None;

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -73,6 +73,8 @@ pub use modules::moqt::data_plane::stream::stream_data_sender::Uninitialized;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::data_plane::stream::stream_data_sender_factory::StreamDataSenderFactory;
 #[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::data_plane::stream::stream_receiver::StreamReceiveError;
+#[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::connecting::Connecting;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::endpoint::ClientConfig;

--- a/moqt/src/modules/moqt/data_plane/stream/stream_data_receiver.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/stream_data_receiver.rs
@@ -33,28 +33,24 @@ impl<T: TransportProtocol> StreamDataReceiver<T> {
         })
     }
 
-    pub async fn receive(&mut self) -> anyhow::Result<Subgroup> {
+    /// Returns `Ok(None)` when the peer finished the stream normally (FIN).
+    /// Transport-level closure and decode failures are reported as distinct
+    /// `StreamReceiveError` variants so callers can react per cause.
+    pub async fn receive(&mut self) -> Result<Option<Subgroup>, StreamReceiveError> {
         if let Some(subgroup_header) = self.first_subgroup_header.take() {
-            return Ok(Subgroup::Header(subgroup_header));
+            return Ok(Some(Subgroup::Header(subgroup_header)));
         }
 
         match self.stream_receiver.receive().await {
-            Ok(Some(UniStreamData::Subgroup(subgroup))) => Ok(subgroup),
+            Ok(Some(UniStreamData::Subgroup(subgroup))) => Ok(Some(subgroup)),
             Ok(Some(UniStreamData::Fetch(_))) => {
                 unreachable!("Unexpected fetch data in subgroup stream")
             }
             Ok(None) => {
-                tracing::info!("Stream data ended");
-                anyhow::bail!("Stream data ended")
+                tracing::debug!("Stream data ended");
+                Ok(None)
             }
-            Err(StreamReceiveError::Closed(error)) => {
-                tracing::info!(error = %error, "Stream data closed");
-                anyhow::bail!("Stream data closed: {error}")
-            }
-            Err(StreamReceiveError::Decode(error)) => {
-                tracing::error!(error = %error, "Failed to decode data from stream");
-                anyhow::bail!("Failed to decode data from stream: {error}")
-            }
+            Err(error) => Err(error),
         }
     }
 }

--- a/moqt/src/modules/moqt/data_plane/stream/stream_receiver.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/stream_receiver.rs
@@ -13,7 +13,7 @@ pub(crate) type BiStreamReceiver<T> = StreamReceiver<T, 1024, ControlMessageDeco
 pub(crate) type UniStreamReceiver<T> = StreamReceiver<T, { 64 * 1024 }, UniStreamDecoder>;
 
 #[derive(Debug)]
-pub(crate) enum StreamReceiveError {
+pub enum StreamReceiveError {
     Closed(String),
     Decode(String),
 }

--- a/relay/src/modules/core/data_receiver/stream_receiver.rs
+++ b/relay/src/modules/core/data_receiver/stream_receiver.rs
@@ -2,20 +2,22 @@ use crate::modules::core::data_object::DataObject;
 
 #[async_trait::async_trait]
 pub(crate) trait StreamReceiver: Send + Sync + 'static {
-    async fn receive_object(&mut self) -> anyhow::Result<DataObject>;
+    /// `Ok(None)` means the stream finished normally (FIN); errors keep the
+    /// transport-closed / decode-failed distinction from `StreamReceiveError`.
+    async fn receive_object(&mut self) -> Result<Option<DataObject>, moqt::StreamReceiveError>;
 }
 
 #[async_trait::async_trait]
 impl<T: moqt::TransportProtocol> StreamReceiver for moqt::StreamDataReceiver<T> {
-    async fn receive_object(&mut self) -> anyhow::Result<DataObject> {
+    async fn receive_object(&mut self) -> Result<Option<DataObject>, moqt::StreamReceiveError> {
         let object = self.receive().await?;
-        match object {
+        Ok(object.map(|object| match object {
             moqt::Subgroup::Header(header) => {
                 tracing::debug!(subgroup_header = ?header, "Received subgroup header");
-                Ok(DataObject::SubgroupHeader(header))
+                DataObject::SubgroupHeader(header)
             }
-            moqt::Subgroup::Object(field) => Ok(DataObject::SubgroupObject(field)),
-        }
+            moqt::Subgroup::Object(field) => DataObject::SubgroupObject(field),
+        }))
     }
 }
 

--- a/relay/src/modules/relay/ingress/stream_reader.rs
+++ b/relay/src/modules/relay/ingress/stream_reader.rs
@@ -96,7 +96,7 @@ impl StreamReader {
             };
 
             match receive_result {
-                Ok(DataObject::SubgroupHeader(header)) => {
+                Ok(Some(DataObject::SubgroupHeader(header))) => {
                     group_id = header.group_id;
                     subgroup_id = StreamSubgroupId::from(&header.subgroup_id);
                     has_subgroup = true;
@@ -116,7 +116,7 @@ impl StreamReader {
                         subgroup_id: subgroup_id.clone(),
                     });
                 }
-                Ok(object) => {
+                Ok(Some(object)) => {
                     let end_reason = match &object {
                         DataObject::SubgroupObject(field) => match &field.subgroup_object {
                             moqt::SubgroupObject::Status { code, .. }
@@ -145,8 +145,33 @@ impl StreamReader {
                         return;
                     }
                 }
-                Err(_) => {
-                    span.record("end_reason", "receiver_error");
+                Ok(None) => {
+                    // FIN: the routine end of a subgroup stream that carries
+                    // no explicit end-of-group status object.
+                    span.record("end_reason", "fin");
+                    if has_subgroup {
+                        cache.close_stream_subgroup(group_id, &subgroup_id).await;
+                        let _ = notify.send(TrackEvent::EndOfGroup);
+                    }
+                    tracing::debug!(%track_key, "stream finished");
+                    return;
+                }
+                Err(moqt::StreamReceiveError::Closed(error)) => {
+                    // Transport-level interruption: RESET_STREAM or the
+                    // publisher connection was lost mid-subgroup.
+                    span.record("end_reason", "transport_closed");
+                    tracing::info!(%track_key, %error, "stream transport closed");
+                    if has_subgroup {
+                        cache.close_stream_subgroup(group_id, &subgroup_id).await;
+                        let _ = notify.send(TrackEvent::EndOfGroup);
+                    }
+                    return;
+                }
+                Err(moqt::StreamReceiveError::Decode(error)) => {
+                    // Malformed data on the wire: a peer bug or protocol
+                    // violation, unlike the two endings above.
+                    span.record("end_reason", "decode_error");
+                    tracing::error!(%track_key, %error, "failed to decode stream data");
                     if has_subgroup {
                         cache.close_stream_subgroup(group_id, &subgroup_id).await;
                         let _ = notify.send(TrackEvent::EndOfGroup);
@@ -178,27 +203,44 @@ mod tests {
 
     use super::*;
 
+    // How the scripted stream ends once all objects were consumed.
+    enum TerminalOutcome {
+        Fin,
+        TransportClosed,
+        DecodeFailed,
+        Hang,
+    }
+
     struct ScriptedStreamReceiver {
         objects: VecDeque<DataObject>,
         // Fired once all scripted objects were consumed; lets tests order a
         // stop signal after ingestion without racing the read loop.
         exhausted_sender: Option<oneshot::Sender<()>>,
-        hang_when_exhausted: bool,
+        terminal: TerminalOutcome,
     }
 
     #[async_trait::async_trait]
     impl StreamReceiver for ScriptedStreamReceiver {
-        async fn receive_object(&mut self) -> anyhow::Result<DataObject> {
+        async fn receive_object(&mut self) -> Result<Option<DataObject>, moqt::StreamReceiveError> {
             if let Some(object) = self.objects.pop_front() {
-                return Ok(object);
+                return Ok(Some(object));
             }
             if let Some(sender) = self.exhausted_sender.take() {
                 let _ = sender.send(());
             }
-            if self.hang_when_exhausted {
-                std::future::pending::<()>().await;
+            match self.terminal {
+                TerminalOutcome::Fin => Ok(None),
+                TerminalOutcome::TransportClosed => Err(moqt::StreamReceiveError::Closed(
+                    "stream reset by peer".to_string(),
+                )),
+                TerminalOutcome::DecodeFailed => Err(moqt::StreamReceiveError::Decode(
+                    "malformed object field".to_string(),
+                )),
+                TerminalOutcome::Hang => {
+                    std::future::pending::<()>().await;
+                    unreachable!()
+                }
             }
-            anyhow::bail!("stream closed")
         }
     }
 
@@ -290,7 +332,7 @@ mod tests {
                 make_end_of_group_object(),
             ]),
             exhausted_sender: None,
-            hang_when_exhausted: false,
+            terminal: TerminalOutcome::Fin,
         };
 
         StreamReader::read_loop(
@@ -326,13 +368,14 @@ mod tests {
         assert_subgroup_closed_after(&env, 0, 1).await;
     }
 
-    #[tokio::test]
-    async fn receiver_error_closes_open_subgroup() {
+    // Runs read_loop over [header, one payload object] ending with `terminal`,
+    // then asserts the open subgroup was closed and EndOfGroup notified.
+    async fn assert_open_subgroup_closed_on(terminal: TerminalOutcome) {
         let mut env = make_env();
         let receiver = ScriptedStreamReceiver {
             objects: VecDeque::from([make_header(0), make_payload_object(0)]),
             exhausted_sender: None,
-            hang_when_exhausted: false,
+            terminal,
         };
 
         StreamReader::read_loop(
@@ -356,13 +399,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fin_closes_open_subgroup() {
+        assert_open_subgroup_closed_on(TerminalOutcome::Fin).await;
+    }
+
+    #[tokio::test]
+    async fn transport_close_closes_open_subgroup() {
+        assert_open_subgroup_closed_on(TerminalOutcome::TransportClosed).await;
+    }
+
+    #[tokio::test]
+    async fn decode_failure_closes_open_subgroup() {
+        assert_open_subgroup_closed_on(TerminalOutcome::DecodeFailed).await;
+    }
+
+    #[tokio::test]
     async fn stop_signal_closes_open_subgroup() {
         let mut env = make_env();
         let (exhausted_sender, exhausted_receiver) = oneshot::channel();
         let receiver = ScriptedStreamReceiver {
             objects: VecDeque::from([make_header(0), make_payload_object(0)]),
             exhausted_sender: Some(exhausted_sender),
-            hang_when_exhausted: true,
+            terminal: TerminalOutcome::Hang,
         };
 
         let read_task = tokio::spawn(StreamReader::read_loop(
@@ -405,7 +463,7 @@ mod tests {
                 make_payload_object(1),
             ]),
             exhausted_sender: None,
-            hang_when_exhausted: false,
+            terminal: TerminalOutcome::Fin,
         };
 
         StreamReader::read_loop(

--- a/tests/cascading-relay-e2e/src/main.rs
+++ b/tests/cascading-relay-e2e/src/main.rs
@@ -681,7 +681,10 @@ async fn subscribe_and_receive_ordered_objects(
         moqt::DataReceiver::Stream(mut factory) => {
             let mut stream = factory.next().await?;
             while payloads.len() < count {
-                if let Subgroup::Object(field) = stream.receive().await?
+                let Some(subgroup) = stream.receive().await? else {
+                    bail!("stream ended before receiving {count} objects");
+                };
+                if let Subgroup::Object(field) = subgroup
                     && let SubgroupObject::Payload { data, .. } = field.subgroup_object
                 {
                     payloads.push(data.to_vec());
@@ -902,7 +905,10 @@ where
         moqt::DataReceiver::Stream(mut factory) => {
             let mut stream = factory.next().await?;
             loop {
-                if let Subgroup::Object(field) = stream.receive().await?
+                let Some(subgroup) = stream.receive().await? else {
+                    anyhow::bail!("stream ended before receiving an object");
+                };
+                if let Subgroup::Object(field) = subgroup
                     && let SubgroupObject::Payload { data, .. } = field.subgroup_object
                 {
                     tracing::info!(

--- a/tests/fetch-e2e/src/main.rs
+++ b/tests/fetch-e2e/src/main.rs
@@ -288,15 +288,15 @@ async fn bob(
         let mut stream = factory.next().await?;
         loop {
             match stream.receive().await {
-                Ok(Subgroup::Header(h)) => {
+                Ok(Some(Subgroup::Header(h))) => {
                     tracing::info!("[bob] live group_id={}", h.group_id);
                     if h.group_id >= 2 {
                         tracing::info!("[bob] group 2 detected, relay cache ready");
                         break 'detect;
                     }
                 }
-                Ok(Subgroup::Object(_)) => {}
-                Err(_) => break, // stream ended, move to next group
+                Ok(Some(Subgroup::Object(_))) => {}
+                Ok(None) | Err(_) => break, // stream ended, move to next group
             }
         }
     }

--- a/tests/multiple-publishers-e2e/src/main.rs
+++ b/tests/multiple-publishers-e2e/src/main.rs
@@ -181,8 +181,10 @@ async fn bob(
             };
             loop {
                 match stream.receive().await {
-                    Ok(Subgroup::Header(h)) => tracing::info!("[bob] live group {}", h.group_id),
-                    Ok(Subgroup::Object(field)) => {
+                    Ok(Some(Subgroup::Header(h))) => {
+                        tracing::info!("[bob] live group {}", h.group_id)
+                    }
+                    Ok(Some(Subgroup::Object(field))) => {
                         if let SubgroupObject::Payload { data, .. } = field.subgroup_object {
                             let payload = String::from_utf8_lossy(&data).to_string();
                             if payload.starts_with("carol:") {
@@ -203,7 +205,7 @@ async fn bob(
                             }
                         }
                     }
-                    Err(_) => break,
+                    Ok(None) | Err(_) => break,
                 }
             }
         }


### PR DESCRIPTION
## 概要

[#303](https://github.com/nttcom/moq-wasm/pull/303) のレビュー議論から派生した変更です(ベースブランチを #303 にしたスタックPRのため、#303 マージ後に master へ自動リターゲットされます)。

これまで `StreamDataReceiver::receive` は、ストリームの3種類の終わり方をすべて `anyhow::Err`(文字列)に潰していました:

1. **FIN(正常終了)** — publisher がステータスオブジェクトなしでストリームを閉じる、全 subgroup が通る通常経路
2. **トランスポート切断** — RESET_STREAM やコネクション断
3. **デコード失敗** — 不正なワイヤデータ(相手のバグ / プロトコル違反)

このため relay の `read_loop` は正常終了した subgroup を毎回 `end_reason="receiver_error"` としてトレースに記録しており、実際の異常(reset・切断)が正常系のノイズに埋もれる状態でした。また原因が文字列に潰れているため、将来原因ごとに処理を分けたくなっても型でマッチできませんでした。

## 変更内容

### moqt
- `StreamDataReceiver::receive` の戻り値を `anyhow::Result<Subgroup>` から `Result<Option<Subgroup>, StreamReceiveError>` に変更。**FIN は `Ok(None)`**(下層の `UniStreamReceiver` が返す形をそのまま透過)、切断は `Err(Closed)`、デコード失敗は `Err(Decode)`
- `StreamReceiveError` を公開エクスポートに追加

### relay
- `StreamReceiver` トレイトの `receive_object` を同じシグネチャに追随
- `read_loop` の終端処理を3分岐に分離。**キャッシュの subgroup close + `EndOfGroup` 通知という動作自体は3経路とも従来どおり変更なし**で、span の `end_reason` とログレベルだけが原因を正しく反映するようになります

| 終わり方 | end_reason | ログレベル |
| --- | --- | --- |
| FIN(正常終了) | `fin` | debug |
| トランスポート切断 | `transport_closed` | info |
| デコード失敗 | `decode_error` | error |

### テスト
- #303 で追加した `receiver_error_closes_open_subgroup`(1件)を、終わり方ごとの3件に分割: `fin_closes_open_subgroup` / `transport_close_closes_open_subgroup` / `decode_failure_closes_open_subgroup`。いずれも「開いている subgroup が close され `EndOfGroup` が通知される」ことを正常とする
- モックレシーバーは台本消費後の終わり方を `TerminalOutcome`(Fin / TransportClosed / DecodeFailed / Hang)で指定する形に変更

### 呼び出し側の追随(examples / tests)
シグネチャ変更に伴い、`while let Ok(...)` で Err 到達に依存してループを抜けていた箇所は `Ok(None)`(FIN)でも抜けるように修正しました。修正しないと FIN 後に `Ok(None)` を受け続けて無限ループになるためです:
- `examples/rust/manual-client`、`examples/cross-protocol-test/quic-subscriber`
- `tests/multiple-publishers-e2e`、`tests/fetch-e2e`、`tests/cascading-relay-e2e`(オブジェクト受信前の FIN は明示的にエラー化)

## テスト

- `cargo test -p moqt -p relay`(moqt 104件 / relay 74件パス)
- `cargo check --workspace --all-targets`、`cargo fmt --check`、`cargo clippy --workspace --all-targets` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)