### PR TITLE
feat: LOC/MSF-compliant object metadata (per-id extension headers + raw payloads)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,6 +3867,8 @@ dependencies = [
 name = "packages"
 version = "0.1.0"
 dependencies = [
+ "bytes",
+ "moqt",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ onvif:
 		--catalog-track catalog \
 		--command-track command \
 		--dump-keyframe \
-		--payload-format avcc \
+		--payload-format annexb \
 		--insecure-skip-tls-verify
 
 onvif-controller:

--- a/architecture_decision_record/moqt/architecture.md
+++ b/architecture_decision_record/moqt/architecture.md
@@ -132,6 +132,11 @@ One struct owns all cross-task state:
 - `object/*` — wire formats: `SubgroupHeader` (types `0x10..=0x1D` encoding
   subgroup-id mode / extensions / end-of-group), `SubgroupObject`,
   `ObjectDatagram`, `FetchObject`, `ExtensionHeaders`, `ObjectStatus`.
+  `ExtensionHeaders` keeps every Object Extension Header as an ordered list of
+  `KeyValuePair`s and re-encodes them unchanged (accessors expose the header
+  types the transport uses); this satisfies the draft-14 §10.2.1.2 requirement
+  to forward unsupported extension headers unmodified, and lets higher layers
+  (e.g. LOC) define their own header types without changing the transport.
 - `codec/*` — incremental decoders (`ControlMessageDecoder`,
   `UniStreamDecoder`, `SubgroupDecoder`, `FetchDecoder`) over a shared
   `tokio_reader`.

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -1750,11 +1750,7 @@ fn authorization_tokens(auth_info: &str) -> Vec<AuthorizationToken> {
 
 #[cfg(web_sys_unstable_apis)]
 fn empty_extension_headers() -> ExtensionHeaders {
-    ExtensionHeaders {
-        prior_group_id_gap: vec![],
-        prior_object_id_gap: vec![],
-        immutable_extensions: vec![],
-    }
+    ExtensionHeaders::default()
 }
 
 #[cfg(web_sys_unstable_apis)]

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -831,12 +831,12 @@ impl MOQTClient {
         object_payload: Vec<u8>,
         loc_header: JsValue,
     ) -> Result<(), JsValue> {
-        let extension_headers = match crate::loc::parse_loc_header(loc_header) {
-            Ok(Some(header)) => crate::loc::loc_header_to_extension_headers(&header),
-            Ok(None) => Ok(empty_extension_headers()),
-            Err(error) => Err(error),
-        }
-        .map_err(|error| js_error(error.to_string()))?;
+        let extension_headers = match crate::loc::parse_loc_header(loc_header)
+            .map_err(|error| js_error(error.to_string()))?
+        {
+            Some(header) => crate::loc::loc_header_to_extension_headers(&header),
+            None => empty_extension_headers(),
+        };
 
         let field = if extension_headers == empty_extension_headers() {
             DatagramField::Payload0x00 {
@@ -869,12 +869,12 @@ impl MOQTClient {
     ) -> Result<(), JsValue> {
         let object_status =
             ObjectStatus::try_from(object_status).map_err(|_| js_error("invalid object status"))?;
-        let extension_headers = match crate::loc::parse_loc_header(loc_header) {
-            Ok(Some(header)) => crate::loc::loc_header_to_extension_headers(&header),
-            Ok(None) => Ok(empty_extension_headers()),
-            Err(error) => Err(error),
-        }
-        .map_err(|error| js_error(error.to_string()))?;
+        let extension_headers = match crate::loc::parse_loc_header(loc_header)
+            .map_err(|error| js_error(error.to_string()))?
+        {
+            Some(header) => crate::loc::loc_header_to_extension_headers(&header),
+            None => empty_extension_headers(),
+        };
 
         let field = if extension_headers == empty_extension_headers() {
             DatagramField::Status0x20 {
@@ -939,12 +939,12 @@ impl MOQTClient {
             .cloned()
             .ok_or_else(|| js_error("subgroup writer is None"))?;
 
-        let extension_headers = match crate::loc::parse_loc_header(loc_header) {
-            Ok(Some(header)) => crate::loc::loc_header_to_extension_headers(&header),
-            Ok(None) => Ok(empty_extension_headers()),
-            Err(error) => Err(error),
-        }
-        .map_err(|error| js_error(error.to_string()))?;
+        let extension_headers = match crate::loc::parse_loc_header(loc_header)
+            .map_err(|error| js_error(error.to_string()))?
+        {
+            Some(header) => crate::loc::loc_header_to_extension_headers(&header),
+            None => empty_extension_headers(),
+        };
         let object_id_delta = {
             let stream_object_numbers = self.stream_object_numbers.borrow();
             match stream_object_numbers.get(&writer_key).copied() {

--- a/bindings/wasm/src/loc.rs
+++ b/bindings/wasm/src/loc.rs
@@ -1,31 +1,13 @@
 use anyhow::Result;
-use bytes::Bytes;
 use moqt::wire::ExtensionHeaders;
 use packages::loc::LocHeader;
 
-const LOC_HEADER_SENTINEL: &[u8] = b"loc:";
-
-pub fn loc_header_to_extension_headers(header: &LocHeader) -> Result<ExtensionHeaders> {
-    let mut immutable_extensions = Vec::with_capacity(1);
-    let mut encoded = Vec::from(LOC_HEADER_SENTINEL);
-    encoded.extend_from_slice(&serde_json::to_vec(header)?);
-    immutable_extensions.push(Bytes::from(encoded));
-
-    Ok(ExtensionHeaders::from_immutable_extensions(
-        immutable_extensions,
-    ))
+pub fn loc_header_to_extension_headers(header: &LocHeader) -> ExtensionHeaders {
+    header.to_extension_headers()
 }
 
 pub fn extension_headers_to_loc_header(headers: &ExtensionHeaders) -> LocHeader {
-    for extension in headers.immutable_extensions() {
-        if let Some(encoded) = extension.as_ref().strip_prefix(LOC_HEADER_SENTINEL)
-            && let Ok(header) = serde_json::from_slice::<LocHeader>(encoded)
-        {
-            return header;
-        }
-    }
-
-    LocHeader::default()
+    LocHeader::from_extension_headers(headers)
 }
 
 pub fn parse_loc_header(value: wasm_bindgen::JsValue) -> Result<Option<LocHeader>> {

--- a/bindings/wasm/src/loc.rs
+++ b/bindings/wasm/src/loc.rs
@@ -11,15 +11,13 @@ pub fn loc_header_to_extension_headers(header: &LocHeader) -> Result<ExtensionHe
     encoded.extend_from_slice(&serde_json::to_vec(header)?);
     immutable_extensions.push(Bytes::from(encoded));
 
-    Ok(ExtensionHeaders {
-        prior_group_id_gap: vec![],
-        prior_object_id_gap: vec![],
+    Ok(ExtensionHeaders::from_immutable_extensions(
         immutable_extensions,
-    })
+    ))
 }
 
 pub fn extension_headers_to_loc_header(headers: &ExtensionHeaders) -> LocHeader {
-    for extension in &headers.immutable_extensions {
+    for extension in headers.immutable_extensions() {
         if let Some(encoded) = extension.as_ref().strip_prefix(LOC_HEADER_SENTINEL)
             && let Ok(header) = serde_json::from_slice::<LocHeader>(encoded)
         {

--- a/bridges/live-ingest/src/moqt.rs
+++ b/bridges/live-ingest/src/moqt.rs
@@ -663,11 +663,7 @@ impl<T: TransportProtocol> Drop for ConnectedPublisher<T> {
 }
 
 fn empty_extension_headers() -> ExtensionHeaders {
-    ExtensionHeaders {
-        prior_group_id_gap: vec![],
-        prior_object_id_gap: vec![],
-        immutable_extensions: vec![],
-    }
+    ExtensionHeaders::default()
 }
 
 fn is_supported_track(track_name: &str) -> bool {

--- a/bridges/onvif/README.md
+++ b/bridges/onvif/README.md
@@ -71,7 +71,7 @@ cargo run -p moqt-bridge-onvif --bin moqt-onvif-client -- \
   --username admin \
   --password secret \
   --moqt-url https://127.0.0.1:4433 \
-  --payload-format avcc \
+  --payload-format annexb \
   --dump-keyframe \
   --insecure-skip-tls-verify
 ```

--- a/bridges/onvif/src/bin/moqt-onvif-client.rs
+++ b/bridges/onvif/src/bin/moqt-onvif-client.rs
@@ -1785,19 +1785,13 @@ fn loc_header_to_extension_headers(header: &LocHeader) -> Result<ExtensionHeader
     encoded.extend_from_slice(&serde_json::to_vec(header)?);
     immutable_extensions.push(Bytes::from(encoded));
 
-    Ok(ExtensionHeaders {
-        prior_group_id_gap: vec![],
-        prior_object_id_gap: vec![],
+    Ok(ExtensionHeaders::from_immutable_extensions(
         immutable_extensions,
-    })
+    ))
 }
 
 fn empty_extension_headers() -> ExtensionHeaders {
-    ExtensionHeaders {
-        prior_group_id_gap: vec![],
-        prior_object_id_gap: vec![],
-        immutable_extensions: vec![],
-    }
+    ExtensionHeaders::default()
 }
 
 fn parse_namespace(value: &str) -> Vec<String> {

--- a/bridges/onvif/src/bin/moqt-onvif-client.rs
+++ b/bridges/onvif/src/bin/moqt-onvif-client.rs
@@ -16,7 +16,7 @@ use moqt_bridge_onvif::{
     soap_client,
 };
 use packages::loc::{CaptureTimestamp, LocHeader, LocHeaderExtension, VideoConfig};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::HashSet;
 use std::io::Write;
 use std::net::ToSocketAddrs;
@@ -81,7 +81,7 @@ struct MoqtArgs {
     video_codec: String,
 
     /// Payload format to send over MoQ: annexb or avcc
-    #[arg(long, default_value = "avcc")]
+    #[arg(long, default_value = "annexb")]
     payload_format: String,
 
     /// Dump the first keyframe AnnexB payload for ffprobe (default: /tmp/moqt-onvif-keyframe.h264)
@@ -762,15 +762,12 @@ async fn send_video_packet(
     let loc_header = build_video_loc_header(&packet);
     let extension_headers =
         loc_header_to_extension_headers(&loc_header).context("build loc header extensions")?;
-    let payload = serialize_video_chunk_payload(&packet)?;
+    let payload = Bytes::from(packet.data);
     let Some(stream) = state.stream.as_mut() else {
         return Ok(());
     };
-    let object = stream.create_object_field(
-        0,
-        extension_headers,
-        SubgroupObject::new_payload(payload.into()),
-    );
+    let object =
+        stream.create_object_field(0, extension_headers, SubgroupObject::new_payload(payload));
     stream.send(object).await.context("send subgroup object")?;
     let total_delay_us = now_micros().saturating_sub(packet.ingest_wallclock_micros);
     log::info!(
@@ -820,15 +817,12 @@ async fn send_audio_packet(
     let loc_header = build_audio_loc_header(&packet);
     let extension_headers = loc_header_to_extension_headers(&loc_header)
         .context("build audio loc header extensions")?;
-    let payload = serialize_audio_chunk_payload(&packet)?;
+    let payload = Bytes::from(packet.data);
     let Some(stream) = state.stream.as_mut() else {
         return Ok(());
     };
-    let object = stream.create_object_field(
-        0,
-        extension_headers,
-        SubgroupObject::new_payload(payload.into()),
-    );
+    let object =
+        stream.create_object_field(0, extension_headers, SubgroupObject::new_payload(payload));
     stream
         .send(object)
         .await
@@ -861,75 +855,6 @@ async fn send_audio_packet(
         spawn_pending_group_close(pending);
     }
     Ok(())
-}
-
-#[derive(Serialize)]
-struct VideoChunkMetadata<'a> {
-    #[serde(rename = "type")]
-    kind: &'static str,
-    timestamp: u64,
-    duration: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    codec: Option<&'a str>,
-    #[serde(rename = "descriptionBase64", skip_serializing_if = "Option::is_none")]
-    description_base64: Option<&'a str>,
-    #[serde(rename = "avcFormat", skip_serializing_if = "Option::is_none")]
-    avc_format: Option<&'a str>,
-}
-
-#[derive(Serialize)]
-struct AudioChunkMetadata<'a> {
-    #[serde(rename = "type")]
-    kind: &'static str,
-    timestamp: u64,
-    duration: Option<u64>,
-    codec: &'a str,
-    #[serde(rename = "descriptionBase64", skip_serializing_if = "Option::is_none")]
-    description_base64: Option<&'a str>,
-    #[serde(rename = "sampleRate", skip_serializing_if = "Option::is_none")]
-    sample_rate: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    channels: Option<u8>,
-}
-
-fn serialize_video_chunk_payload(packet: &EncodedPacket) -> Result<Vec<u8>> {
-    let avc_format = match packet.avc_format.as_deref() {
-        Some("avcc") => Some("avc"),
-        Some("annexb") => Some("annexb"),
-        other => other,
-    };
-    let metadata = VideoChunkMetadata {
-        kind: if packet.is_keyframe { "key" } else { "delta" },
-        timestamp: packet.timestamp_us,
-        duration: packet.duration_us,
-        codec: packet.codec.as_deref(),
-        description_base64: packet.description_base64.as_deref(),
-        avc_format,
-    };
-    let meta_bytes = serde_json::to_vec(&metadata).context("serialize chunk metadata")?;
-    let mut payload = Vec::with_capacity(4 + meta_bytes.len() + packet.data.len());
-    payload.extend_from_slice(&(meta_bytes.len() as u32).to_be_bytes());
-    payload.extend_from_slice(&meta_bytes);
-    payload.extend_from_slice(&packet.data);
-    Ok(payload)
-}
-
-fn serialize_audio_chunk_payload(packet: &EncodedAudioPacket) -> Result<Vec<u8>> {
-    let metadata = AudioChunkMetadata {
-        kind: "key",
-        timestamp: packet.timestamp_us,
-        duration: packet.duration_us,
-        codec: packet.codec.as_str(),
-        description_base64: packet.description_base64.as_deref(),
-        sample_rate: packet.sample_rate,
-        channels: packet.channels,
-    };
-    let meta_bytes = serde_json::to_vec(&metadata).context("serialize audio chunk metadata")?;
-    let mut payload = Vec::with_capacity(4 + meta_bytes.len() + packet.data.len());
-    payload.extend_from_slice(&(meta_bytes.len() as u32).to_be_bytes());
-    payload.extend_from_slice(&meta_bytes);
-    payload.extend_from_slice(&packet.data);
-    Ok(payload)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/examples/browser/examples/call/src/components/CallRoom.tsx
+++ b/examples/browser/examples/call/src/components/CallRoom.tsx
@@ -8,7 +8,7 @@ import { MemberGrid } from './MemberGrid'
 import { RoomHeader } from './RoomHeader'
 import { useSessionEventHandlers } from '../hooks/useSessionEventHandlers'
 import { useCallMedia } from '../hooks/useCallMedia'
-import type { CallCatalogTrack, CatalogSubscribeRole } from '../types/catalog'
+import type { CallCatalogTrack, CatalogSubscribeRole, TrackMediaConfig } from '../types/catalog'
 import type { RemoteMediaStreams } from '../types/media'
 import type { SidebarStatsSample } from '../types/stats'
 import { updateSubscriptionState } from '../utils/state/roomState'
@@ -433,7 +433,16 @@ export function CallRoom({ session, onLeave }: CallRoomProps) {
         return
       }
     }
-    const trackCodec = role === 'audio' || role === 'video' || role === 'screenshare' ? selectedTrack?.codec : undefined
+    const trackMediaConfig: TrackMediaConfig | undefined =
+      role === 'audio' || role === 'video' || role === 'screenshare'
+        ? {
+            codec: selectedTrack?.codec,
+            framerate: role === 'video' || role === 'screenshare' ? selectedTrack?.framerate : undefined,
+            samplerate: role === 'audio' ? selectedTrack?.samplerate : undefined,
+            channelConfig: role === 'audio' ? selectedTrack?.channelConfig : undefined,
+            initData: selectedTrack?.initData
+          }
+        : undefined
     const trackState = getSubscriptionStateByRole(member, role)
     const trackKey = buildTrackActionKey(memberId, role)
     if (trackState.isSubscribed || trackState.isSubscribing || catalogUnsubscribingTrackKeys.has(trackKey)) {
@@ -451,7 +460,7 @@ export function CallRoom({ session, onLeave }: CallRoomProps) {
     )
 
     try {
-      const requestId = await session.subscribe(trackNamespace, trackName, undefined, role, trackCodec)
+      const requestId = await session.subscribe(trackNamespace, trackName, undefined, role, trackMediaConfig)
       setRoom((currentRoom) =>
         updateMemberSubscriptionStateByRole(currentRoom, memberId, role, (track) => ({
           ...track,

--- a/examples/browser/examples/call/src/media/callCatalog.ts
+++ b/examples/browser/examples/call/src/media/callCatalog.ts
@@ -311,6 +311,7 @@ export function extractCallCatalogTracks(catalog: unknown): CallCatalogTrack[] {
       hardwareAcceleration: asHardwareAcceleration(rawTrack.hardwareAcceleration),
       samplerate: asNumber(rawTrack.samplerate),
       channelConfig: asString(rawTrack.channelConfig),
+      initData: asString(rawTrack.initData),
       isLive: asBoolean(rawTrack.isLive)
     })
     return acc

--- a/examples/browser/examples/call/src/media/callMediaController.ts
+++ b/examples/browser/examples/call/src/media/callMediaController.ts
@@ -6,7 +6,7 @@ import type { VideoEncodingSettings } from '../types/videoEncoding'
 import type { AudioEncodingSettings } from '../types/audioEncoding'
 import type { AudioCaptureConstraints, CameraCaptureConstraints } from '../types/captureConstraints'
 import type { SubscribeMessage } from '../../../../pkg/moqt_client_wasm'
-import type { CallCatalogTrack, CatalogSubscribeRole, CatalogTrackRole } from '../types/catalog'
+import type { CallCatalogTrack, CatalogSubscribeRole, CatalogTrackRole, TrackMediaConfig } from '../types/catalog'
 import type { JitterBufferEvent } from '../types/media'
 import { isScreenShareTrackName } from '../utils/catalogTrackName'
 import { isCallVideoPipelineDebugEnabled } from '../utils/debug'
@@ -246,13 +246,13 @@ export class CallMediaController {
     trackName: string,
     trackAlias: bigint,
     role?: CatalogSubscribeRole,
-    codec?: string
+    config?: TrackMediaConfig
   ): void {
     const resolvedRole = this.resolveSubscribeRole(trackName, role)
     if (resolvedRole === 'video' || resolvedRole === 'screenshare') {
-      this.subscriber.registerVideoTrack(userId, trackName, trackAlias, codec)
+      this.subscriber.registerVideoTrack(userId, trackName, trackAlias, config)
     } else if (resolvedRole === 'audio') {
-      this.subscriber.registerAudioTrack(userId, trackAlias)
+      this.subscriber.registerAudioTrack(userId, trackAlias, config)
     }
   }
 

--- a/examples/browser/examples/call/src/media/mediaSubscriber.ts
+++ b/examples/browser/examples/call/src/media/mediaSubscriber.ts
@@ -10,6 +10,7 @@ import {
   type AudioJitterConfig
 } from '../types/jitterBuffer'
 import type { JitterBufferEvent } from '../types/media'
+import type { TrackMediaConfig } from '../types/catalog'
 import { isScreenShareTrackName } from '../utils/catalogTrackName'
 import { isCallVideoPipelineDebugEnabled } from '../utils/debug'
 
@@ -123,7 +124,7 @@ export class MediaSubscriber {
     this.handlers = handlers
   }
 
-  registerVideoTrack(userId: string, trackName: string, trackAlias: bigint, codec?: string): void {
+  registerVideoTrack(userId: string, trackName: string, trackAlias: bigint, config?: TrackMediaConfig): void {
     if (this.videoContexts.has(trackAlias)) {
       return
     }
@@ -310,16 +311,21 @@ export class MediaSubscriber {
     const context: VideoSubscriptionContext = { userId, source, worker, writer, stream, frameLogCount: 0 }
     this.videoContexts.set(trackAlias, context)
     this.handlers.onRemoteVideoStream?.(userId, stream, source)
-    if (codec) {
-      worker.postMessage({ type: 'catalog', codec })
+    if (config?.codec || config?.framerate !== undefined || config?.initData !== undefined) {
+      worker.postMessage({
+        type: 'catalog',
+        codec: config?.codec,
+        framerate: config?.framerate,
+        descriptionBase64: config?.initData
+      })
     }
-    const config = this.videoJitterConfigByUserId.get(userId) ?? DEFAULT_VIDEO_JITTER_CONFIG
+    const jitterConfig = this.videoJitterConfigByUserId.get(userId) ?? DEFAULT_VIDEO_JITTER_CONFIG
     if (!this.videoJitterConfigByUserId.has(userId)) {
-      this.videoJitterConfigByUserId.set(userId, config)
+      this.videoJitterConfigByUserId.set(userId, jitterConfig)
     }
     worker.postMessage({
       type: 'config',
-      config: { ...config, debugVideoPipeline: isCallVideoPipelineDebugEnabled() }
+      config: { ...jitterConfig, debugVideoPipeline: isCallVideoPipelineDebugEnabled() }
     })
 
     this.client.setOnSubgroupObjectHandler(trackAlias, (groupId, message) =>
@@ -359,7 +365,7 @@ export class MediaSubscriber {
     )
   }
 
-  registerAudioTrack(userId: string, trackAlias: bigint): void {
+  registerAudioTrack(userId: string, trackAlias: bigint, config?: TrackMediaConfig): void {
     if (this.audioContexts.has(trackAlias)) {
       return
     }
@@ -433,9 +439,19 @@ export class MediaSubscriber {
     this.audioContexts.set(trackAlias, context)
     this.handlers.onRemoteAudioStream?.(userId, context.stream)
     this.maybeReportAudioPlaybackQueue(context, true)
-    const config = this.audioJitterConfigByUserId.get(userId)
-    if (config) {
-      worker.postMessage({ type: 'config', config })
+    const channels = parseChannelCount(config?.channelConfig)
+    if (config?.codec || config?.samplerate !== undefined || channels !== undefined || config?.initData !== undefined) {
+      worker.postMessage({
+        type: 'catalog',
+        codec: config?.codec,
+        sampleRate: config?.samplerate,
+        channels,
+        descriptionBase64: config?.initData
+      })
+    }
+    const jitterConfig = this.audioJitterConfigByUserId.get(userId)
+    if (jitterConfig) {
+      worker.postMessage({ type: 'config', config: jitterConfig })
     }
 
     this.client.setOnSubgroupObjectHandler(trackAlias, (groupId, message) =>
@@ -544,6 +560,25 @@ export class MediaSubscriber {
     context.lastPlaybackQueueReportAtMs = now
     this.handlers.onRemoteAudioPlaybackQueue?.(context.userId, context.pendingPlaybackQueueMs)
   }
+}
+
+function parseChannelCount(channelConfig?: string): number | undefined {
+  const normalized = channelConfig?.trim().toLowerCase()
+  if (!normalized) {
+    return undefined
+  }
+  if (normalized === 'mono') {
+    return 1
+  }
+  if (normalized === 'stereo') {
+    return 2
+  }
+  const match = normalized.match(/^(\d+)ch$/)
+  if (match) {
+    const count = Number(match[1])
+    return Number.isInteger(count) && count > 0 ? count : undefined
+  }
+  return undefined
 }
 
 function estimateAudioDataDurationMs(audioData: AudioData): number {

--- a/examples/browser/examples/call/src/session/localSession.ts
+++ b/examples/browser/examples/call/src/session/localSession.ts
@@ -9,7 +9,7 @@ import { LocalMember } from '../types/member'
 import { ChatMessage } from '../types/chat'
 import { CallMediaController } from '../media/callMediaController'
 import { parseCallCatalogTracks } from '../media/callCatalog'
-import type { CallCatalogTrack, CatalogSubscribeRole } from '../types/catalog'
+import type { CallCatalogTrack, CatalogSubscribeRole, TrackMediaConfig } from '../types/catalog'
 
 interface LocalSessionOptions {
   roomName: string
@@ -186,7 +186,7 @@ export class LocalSession {
     trackName: string,
     authInfo: string = this.defaultAuthInfo,
     role?: CatalogSubscribeRole,
-    codec?: string
+    config?: TrackMediaConfig
   ): Promise<bigint> {
     if (this.state !== LocalSessionState.Ready) {
       throw new Error(`Cannot subscribe when session state is "${this.state}"`)
@@ -219,7 +219,7 @@ export class LocalSession {
         }
       })
     } else if (resolvedRole === 'video' || resolvedRole === 'screenshare' || resolvedRole === 'audio') {
-      this.mediaController.registerRemoteTrack(remoteUser, trackName, trackAlias, resolvedRole, codec)
+      this.mediaController.registerRemoteTrack(remoteUser, trackName, trackAlias, resolvedRole, config)
     }
 
     return requestId

--- a/examples/browser/examples/call/src/types/catalog.ts
+++ b/examples/browser/examples/call/src/types/catalog.ts
@@ -15,6 +15,7 @@ export interface CallCatalogTrack {
   keyframeInterval?: number
   samplerate?: number
   channelConfig?: string
+  initData?: string
   audioStreamUpdateMode?: AudioStreamUpdateMode
   audioStreamUpdateIntervalSeconds?: number
   isLive?: boolean
@@ -22,6 +23,14 @@ export interface CallCatalogTrack {
 
 export interface EditableCallCatalogTrack extends CallCatalogTrack {
   id: string
+}
+
+export type TrackMediaConfig = {
+  codec?: string
+  framerate?: number
+  samplerate?: number
+  channelConfig?: string
+  initData?: string
 }
 
 export interface AudioStreamUpdateSettings {

--- a/examples/browser/examples/media/catalog.ts
+++ b/examples/browser/examples/media/catalog.ts
@@ -68,6 +68,7 @@ type MsfTrack = {
   height?: number
   samplerate?: number
   channelConfig?: string
+  initData?: string
 }
 
 type MsfCatalog = {
@@ -89,6 +90,7 @@ export type MediaCatalogTrack = {
   channelConfig?: string
   width?: number
   height?: number
+  initData?: string
 }
 
 export function getResolvedMediaVideoCodec(): string {
@@ -163,7 +165,8 @@ export function extractCatalogTracks(catalog: unknown, role?: CatalogTrackRole):
       samplerate: asNumber(track.samplerate),
       channelConfig: asString(track.channelConfig),
       width: asNumber(track.width),
-      height: asNumber(track.height)
+      height: asNumber(track.height),
+      initData: asString(track.initData)
     })
     return acc
   }, [])

--- a/examples/browser/examples/media/subscriber/main.ts
+++ b/examples/browser/examples/media/subscriber/main.ts
@@ -139,13 +139,42 @@ function setSelectedCatalogTrack(kind: 'video' | 'audio', trackName: string | nu
   if (select && trackName) {
     select.value = trackName
   }
-  if (kind !== 'video') {
+  if (!trackName) {
     return
   }
-  const track = catalogVideoTracks.find((entry) => entry.name === trackName)
-  if (trackName) {
-    videoDecoderWorker.postMessage({ type: 'catalog', codec: track?.codec ?? getResolvedMediaVideoCodec() })
+  if (kind === 'video') {
+    const track = catalogVideoTracks.find((entry) => entry.name === trackName)
+    videoDecoderWorker.postMessage({
+      type: 'catalog',
+      codec: track?.codec ?? getResolvedMediaVideoCodec(),
+      descriptionBase64: track?.initData
+    })
+    return
   }
+  const track = catalogAudioTracks.find((entry) => entry.name === trackName)
+  if (track) {
+    audioDecoderWorker.postMessage({
+      type: 'catalog',
+      codec: track.codec,
+      sampleRate: track.samplerate,
+      channels: channelCountFromConfig(track.channelConfig),
+      descriptionBase64: track.initData
+    })
+  }
+}
+
+function channelCountFromConfig(channelConfig?: string): number | undefined {
+  if (!channelConfig) {
+    return undefined
+  }
+  if (channelConfig === 'mono') {
+    return 1
+  }
+  if (channelConfig === 'stereo') {
+    return 2
+  }
+  const match = /^(\d+)ch$/.exec(channelConfig)
+  return match ? Number(match[1]) : undefined
 }
 
 function formatCatalogTrackLabel(track: MediaCatalogTrack, kind: 'video' | 'audio'): string {

--- a/examples/browser/examples/onvif/index.html
+++ b/examples/browser/examples/onvif/index.html
@@ -538,7 +538,7 @@
           <form id="connect-form">
             <label>
               MoQ URL
-              <input id="moqt-url" type="text" value="https://relay-1.moqt.research.skyway.io:443" />
+              <input id="moqt-url" type="text" value="https://127.0.0.1:4433" />
             </label>
             <div class="button-row">
               <button class="secondary" type="button" data-url="https://relay-1.moqt.research.skyway.io:443">
@@ -550,7 +550,7 @@
               <button class="secondary" type="button" data-url="https://relay-3.moqt.research.skyway.io:443">
                 relay-3
               </button>
-              <button class="secondary" type="button" data-url="https://127.0.0.1:4433">127.0.0.1</button>
+              <button class="secondary" type="button" data-url="https://127.0.0.1:4433">Local relay-a</button>
             </div>
             <div class="button-row">
               <button id="connect-btn" type="button">Connect</button>

--- a/examples/browser/examples/onvif/main.ts
+++ b/examples/browser/examples/onvif/main.ts
@@ -1,7 +1,7 @@
 import { MoqtClientWrapper } from '@moqt/moqtClient'
 import { parse_msf_catalog_json } from '../../pkg/moqt_client_wasm'
 import type { MOQTClient } from '../../pkg/moqt_client_wasm'
-import { configureRelayUrlControls } from '../../utils/relayPresets'
+import { DEFAULT_LOCAL_RELAY_A_URL, configureRelayUrlControls } from '../../utils/relayPresets'
 
 const moqtClient = new MoqtClientWrapper()
 let audioDecoderWorker: Worker | null = null
@@ -1189,7 +1189,8 @@ function setupUrlPresets(): void {
   const presetContainer = urlInput.closest('form')?.querySelector<HTMLElement>('.button-row')
   configureRelayUrlControls({
     input: urlInput,
-    presetContainer
+    presetContainer,
+    defaultUrl: DEFAULT_LOCAL_RELAY_A_URL
   })
 }
 

--- a/examples/browser/examples/onvif/main.ts
+++ b/examples/browser/examples/onvif/main.ts
@@ -150,6 +150,7 @@ type CatalogTrack = {
   bitrate?: number
   samplerate?: number
   channelConfig?: string
+  initData?: string
 }
 
 type FieldKey = 'pan' | 'tilt' | 'zoom' | 'speed'
@@ -631,6 +632,7 @@ function setupAudioDecoderWorker(): void {
       }
     }
   }
+  notifyAudioDecoderFromCatalog()
 }
 
 function setupVideoCallbacks(trackAlias: bigint): void {
@@ -854,13 +856,43 @@ function applySelectedVideoTrack(track: string): void {
 function applySelectedAudioTrack(track: string): void {
   selectedAudioTrack = track
   updateSelectedAudioTrackLabel(track)
+  notifyAudioDecoderFromCatalog()
 }
 
 function notifyDecoderFromCatalog(trackName: string | null): void {
   if (!trackName) return
   const track = catalogTracks.find((entry) => entry.name === trackName && entry.role === 'video')
   if (!track?.codec && typeof track?.framerate !== 'number') return
-  videoDecoderWorker.postMessage({ type: 'catalog', codec: track.codec, framerate: track.framerate })
+  videoDecoderWorker.postMessage({
+    type: 'catalog',
+    codec: track.codec,
+    framerate: track.framerate,
+    descriptionBase64: track.initData
+  })
+}
+
+function notifyAudioDecoderFromCatalog(): void {
+  if (!audioDecoderWorker || !selectedAudioTrack) return
+  const track = catalogTracks.find((entry) => entry.name === selectedAudioTrack && entry.role === 'audio')
+  if (!track) return
+  const channels = channelCountFromConfig(track.channelConfig)
+  if (!track.codec && typeof track.samplerate !== 'number' && channels === undefined && !track.initData) return
+  audioDecoderWorker.postMessage({
+    type: 'catalog',
+    codec: track.codec,
+    sampleRate: track.samplerate,
+    channels,
+    descriptionBase64: track.initData
+  })
+}
+
+function channelCountFromConfig(channelConfig?: string): number | undefined {
+  const normalized = channelConfig?.trim().toLowerCase()
+  if (!normalized) return undefined
+  if (normalized === 'mono') return 1
+  if (normalized === 'stereo') return 2
+  const match = /^(\d+)ch$/.exec(normalized)
+  return match ? Number(match[1]) : undefined
 }
 
 function appendMeta(container: HTMLElement, label: string, value?: string): void {
@@ -1056,7 +1088,8 @@ function buildCatalogTracks(catalog: MsfCatalog): CatalogTrack[] {
       framerate: track.framerate,
       bitrate: track.bitrate,
       samplerate: track.samplerate,
-      channelConfig: track.channelConfig
+      channelConfig: track.channelConfig,
+      initData: track.initData
     }
   })
 }

--- a/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
+++ b/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
@@ -1,6 +1,6 @@
 import type { SubgroupObjectMessage } from '../../../../pkg/moqt_client_wasm'
 import type { CameraId } from '../types/monitoring'
-import { tryDeserializeChunk, type DeserializedChunk } from '../../../../utils/media/chunk'
+import { type DeserializedChunk } from '../../../../utils/media/chunk'
 import { readLocHeader, bytesToBase64, type LocHeader } from '../../../../utils/media/loc'
 
 export type ReviewFrame = { payload: Uint8Array; locHeader: unknown }
@@ -198,12 +198,9 @@ export class CameraSubscriber {
     this.paused = false
   }
 
-  // Parse a review object: the browser publisher wraps metadata in the payload
-  // (serializeChunk envelope), whereas moq-cli publishes raw LOC objects (coded frame in
-  // the payload, metadata in the LOC extension header). Try the envelope first, then LOC.
-  private deserializeOrLoc(payload: Uint8Array, locHeader: unknown, objectId: bigint): DeserializedChunk | null {
-    const parsed = tryDeserializeChunk(payload)
-    if (parsed) return parsed
+  // Parse a review object: the coded frame is the raw payload and metadata lives in the
+  // LOC extension header (both the browser publisher and moq-cli publish raw LOC objects).
+  private buildChunkFromLoc(payload: Uint8Array, locHeader: unknown, objectId: bigint): DeserializedChunk {
     const loc = readLocHeader(locHeader as LocHeader | undefined)
     const timestamp =
       typeof loc.captureTimestampMicros === 'number' && Number.isFinite(loc.captureTimestampMicros)
@@ -223,11 +220,7 @@ export class CameraSubscriber {
   }
 
   decodeFrame(groupId: bigint, payload: Uint8Array, locHeader?: unknown): void {
-    const parsed = this.deserializeOrLoc(payload, locHeader, 0n)
-    if (!parsed) {
-      log('decodeFrame: failed to parse payload', { camId: this.camId, groupId })
-      return
-    }
+    const parsed = this.buildChunkFromLoc(payload, locHeader, 0n)
 
     if (this.reviewDecoder && this.reviewDecoder.state !== 'closed') {
       this.reviewDecoder.close()
@@ -283,11 +276,10 @@ export class CameraSubscriber {
       return
     }
 
-    const iFrameParsed = this.deserializeOrLoc(iFrame.payload, iFrame.locHeader, 0n)
-    if (!iFrameParsed) return
+    const iFrameParsed = this.buildChunkFromLoc(iFrame.payload, iFrame.locHeader, 0n)
 
     const target = frames.get(targetObjectId)
-    const targetParsed = target ? this.deserializeOrLoc(target.payload, target.locHeader, targetObjectId) : null
+    const targetParsed = target ? this.buildChunkFromLoc(target.payload, target.locHeader, targetObjectId) : null
     // Use timestamp to identify the target frame in the output callback
     const targetTimestamp = targetParsed?.metadata.timestamp ?? null
 
@@ -336,8 +328,7 @@ export class CameraSubscriber {
         log('decodeFrameSequential: missing frame, stopping', { camId: this.camId, objId, targetObjectId })
         break
       }
-      const parsed = this.deserializeOrLoc(entry.payload, entry.locHeader, objId)
-      if (!parsed) break
+      const parsed = this.buildChunkFromLoc(entry.payload, entry.locHeader, objId)
       try {
         this.reviewDecoder.decode(
           new EncodedVideoChunk({
@@ -352,6 +343,7 @@ export class CameraSubscriber {
         break
       }
     }
+    void this.reviewDecoder.flush().catch((e) => console.error('[mon][review] sequential flush error', { camId: this.camId, e }))
   }
 
   dispose(): void {

--- a/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
+++ b/examples/browser/examples/remote-monitoring/src/monitor/cameraSubscriber.ts
@@ -343,7 +343,9 @@ export class CameraSubscriber {
         break
       }
     }
-    void this.reviewDecoder.flush().catch((e) => console.error('[mon][review] sequential flush error', { camId: this.camId, e }))
+    void this.reviewDecoder
+      .flush()
+      .catch((e) => console.error('[mon][review] sequential flush error', { camId: this.camId, e }))
   }
 
   dispose(): void {

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -20,7 +20,8 @@
     "examples/**/*.tsx",
     "examples/media/publisher/files/decoder.js",
     "lib/**/*.ts",
-    "pkg/**/*.d.ts"
+    "pkg/**/*.d.ts",
+    "utils/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/examples/browser/utils/media/audioJitterBuffer.ts
+++ b/examples/browser/utils/media/audioJitterBuffer.ts
@@ -1,4 +1,4 @@
-import { tryDeserializeChunk, type ChunkMetadata } from './chunk'
+import { type ChunkMetadata } from './chunk'
 import { readLocHeader } from './loc'
 import { latencyMsFromCaptureMicros } from './clock'
 import type { JitterBufferSubgroupObject, SubgroupObjectWithLoc } from './jitterBufferTypes'
@@ -46,27 +46,7 @@ export class AudioJitterBuffer {
     const locMetadata = readLocHeader(object.locHeader)
     const captureTimestampMicros = getCaptureTimestampMicros(locMetadata.captureTimestampMicros)
 
-    const parsedFromMetadata = tryDeserializeChunk(object.objectPayload)
-    if (!parsedFromMetadata) {
-      const locHeader = object.locHeader
-      const extensions = locHeader?.extensions ?? []
-      if (!locHeader || extensions.length === 0) {
-        console.debug('[AudioJitterBuffer] Missing metadata and LOC header', {
-          groupId,
-          objectId,
-          payloadLength: object.objectPayloadLength
-        })
-      }
-    }
-    const parsed = parsedFromMetadata ?? buildChunkFromLoc(object)
-    if (!parsed) {
-      console.debug('[AudioJitterBuffer] Failed to build chunk from payload', {
-        groupId,
-        objectId,
-        payloadLength: object.objectPayloadLength
-      })
-      return null
-    }
+    const parsed = buildChunkFromLoc(object)
 
     const bufferObject: JitterBufferSubgroupObject = {
       ...object,
@@ -169,7 +149,7 @@ function isTerminalStatus(status: number | undefined): boolean {
   return status === OBJECT_STATUS_END_OF_GROUP || status === OBJECT_STATUS_END_OF_TRACK
 }
 
-function buildChunkFromLoc(object: SubgroupObjectWithLoc): { metadata: ChunkMetadata; data: Uint8Array } | null {
+function buildChunkFromLoc(object: SubgroupObjectWithLoc): { metadata: ChunkMetadata; data: Uint8Array } {
   const loc = readLocHeader(object.locHeader)
   const captureMicros = getCaptureTimestampMicros(loc.captureTimestampMicros)
   const metadata: ChunkMetadata = {

--- a/examples/browser/utils/media/chunk.ts
+++ b/examples/browser/utils/media/chunk.ts
@@ -1,5 +1,3 @@
-const META_LENGTH_BYTES = 4
-
 export type ChunkMetadata = {
   type: string
   timestamp: number
@@ -14,55 +12,4 @@ export type ChunkMetadata = {
 export type DeserializedChunk = {
   metadata: ChunkMetadata
   data: Uint8Array
-}
-
-export type EncodedChunkLike = {
-  type: string
-  timestamp: number
-  duration?: number | null
-  byteLength: number
-  copyTo: (dest: Uint8Array) => void
-}
-
-export function serializeChunk(chunk: EncodedChunkLike, extraMetadata?: Partial<ChunkMetadata>): Uint8Array {
-  const metadata: ChunkMetadata = {
-    type: chunk.type,
-    timestamp: chunk.timestamp,
-    duration: chunk.duration ?? null,
-    ...extraMetadata
-  }
-  const metaBytes = new TextEncoder().encode(JSON.stringify(metadata))
-  const payload = new Uint8Array(META_LENGTH_BYTES + metaBytes.length + chunk.byteLength)
-  const view = new DataView(payload.buffer)
-  view.setUint32(0, metaBytes.length)
-  payload.set(metaBytes, META_LENGTH_BYTES)
-
-  const data = new Uint8Array(chunk.byteLength)
-  chunk.copyTo(data)
-  payload.set(data, META_LENGTH_BYTES + metaBytes.length)
-  return payload
-}
-
-export function deserializeChunk(payload: Uint8Array): DeserializedChunk {
-  if (payload.byteLength < META_LENGTH_BYTES) {
-    throw new Error('Payload too small to contain metadata')
-  }
-  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength)
-  const metaLength = view.getUint32(0)
-  const totalMetaLength = META_LENGTH_BYTES + metaLength
-  if (payload.byteLength < totalMetaLength) {
-    throw new Error('Payload too small to contain metadata')
-  }
-  const metaBytes = payload.subarray(META_LENGTH_BYTES, META_LENGTH_BYTES + metaLength)
-  const metadata = JSON.parse(new TextDecoder().decode(metaBytes)) as ChunkMetadata
-  const data = payload.subarray(META_LENGTH_BYTES + metaLength)
-  return { metadata, data }
-}
-
-export function tryDeserializeChunk(payload: Uint8Array): DeserializedChunk | null {
-  try {
-    return deserializeChunk(payload)
-  } catch (_error) {
-    return null
-  }
 }

--- a/examples/browser/utils/media/decoders/audioDecoder.ts
+++ b/examples/browser/utils/media/decoders/audioDecoder.ts
@@ -424,9 +424,15 @@ function resolveAudioConfig(metadata: ChunkMetadata): CachedAudioConfig | null {
     cachedAudioConfig?.codec ??
     DEFAULT_AUDIO_DECODER_CONFIG.codec
   const sampleRate =
-    metadata.sampleRate ?? catalogAudioSampleRate ?? cachedAudioConfig?.sampleRate ?? DEFAULT_AUDIO_DECODER_CONFIG.sampleRate
+    metadata.sampleRate ??
+    catalogAudioSampleRate ??
+    cachedAudioConfig?.sampleRate ??
+    DEFAULT_AUDIO_DECODER_CONFIG.sampleRate
   const channels =
-    metadata.channels ?? catalogAudioChannels ?? cachedAudioConfig?.channels ?? DEFAULT_AUDIO_DECODER_CONFIG.numberOfChannels
+    metadata.channels ??
+    catalogAudioChannels ??
+    cachedAudioConfig?.channels ??
+    DEFAULT_AUDIO_DECODER_CONFIG.numberOfChannels
   const descriptionBase64 =
     metadata.descriptionBase64 ?? catalogAudioDescriptionBase64 ?? cachedAudioConfig?.descriptionBase64
 

--- a/examples/browser/utils/media/decoders/audioDecoder.ts
+++ b/examples/browser/utils/media/decoders/audioDecoder.ts
@@ -37,6 +37,10 @@ let remoteTimestampBase: number | null = null
 let lastRebasedTimestamp: number | null = null
 let decoderSignature: string | null = null
 let cachedAudioConfig: CachedAudioConfig | null = null
+let catalogAudioCodec: string | undefined
+let catalogAudioSampleRate: number | undefined
+let catalogAudioChannels: number | undefined
+let catalogAudioDescriptionBase64: string | undefined
 let directDecodeQueue: Promise<void> = Promise.resolve()
 const directLastObjectIds = new Map<string, bigint>()
 
@@ -81,9 +85,18 @@ setInterval(() => {
   }
 }, POP_INTERVAL_MS)
 
+type AudioCatalogMessage = {
+  type: 'catalog'
+  codec?: string
+  sampleRate?: number
+  channels?: number
+  descriptionBase64?: string
+}
+
 type AudioWorkerMessage =
   | SubgroupWorkerMessage
   | { type: 'config'; config: { mode?: string; telemetryEnabled?: boolean; bypassJitterBuffer?: boolean } }
+  | AudioCatalogMessage
 
 self.onmessage = async (event: MessageEvent<AudioWorkerMessage>) => {
   if ((event.data as { type?: string }).type === 'config') {
@@ -97,6 +110,23 @@ self.onmessage = async (event: MessageEvent<AudioWorkerMessage>) => {
     bypassJitterBuffer = config.bypassJitterBuffer ?? bypassJitterBuffer
     if (config.mode === 'ordered' || config.mode === 'latest') {
       jitterBuffer.setMode(config.mode)
+    }
+    return
+  }
+
+  if ((event.data as { type?: string }).type === 'catalog') {
+    const catalog = event.data as AudioCatalogMessage
+    if (catalog.codec) {
+      catalogAudioCodec = catalog.codec
+    }
+    if (typeof catalog.sampleRate === 'number') {
+      catalogAudioSampleRate = catalog.sampleRate
+    }
+    if (typeof catalog.channels === 'number') {
+      catalogAudioChannels = catalog.channels
+    }
+    if (catalog.descriptionBase64) {
+      catalogAudioDescriptionBase64 = catalog.descriptionBase64
     }
     return
   }
@@ -354,7 +384,15 @@ function rebaseTimestamp(remoteTimestamp: number): number {
 }
 
 function resolveAudioConfig(metadata: ChunkMetadata): CachedAudioConfig | null {
-  const hasNewConfig = metadata.codec || metadata.descriptionBase64 || metadata.sampleRate || metadata.channels
+  const hasNewConfig =
+    metadata.codec ||
+    metadata.descriptionBase64 ||
+    metadata.sampleRate ||
+    metadata.channels ||
+    catalogAudioCodec ||
+    catalogAudioSampleRate ||
+    catalogAudioChannels ||
+    catalogAudioDescriptionBase64
   if (!hasNewConfig && !cachedAudioConfig) {
     return {
       codec: DEFAULT_AUDIO_DECODER_CONFIG.codec,
@@ -366,11 +404,15 @@ function resolveAudioConfig(metadata: ChunkMetadata): CachedAudioConfig | null {
   const codec =
     metadata.codec ??
     (metadata.descriptionBase64 ? 'mp4a.40.2' : undefined) ??
+    catalogAudioCodec ??
     cachedAudioConfig?.codec ??
     DEFAULT_AUDIO_DECODER_CONFIG.codec
-  const sampleRate = metadata.sampleRate ?? cachedAudioConfig?.sampleRate ?? DEFAULT_AUDIO_DECODER_CONFIG.sampleRate
-  const channels = metadata.channels ?? cachedAudioConfig?.channels ?? DEFAULT_AUDIO_DECODER_CONFIG.numberOfChannels
-  const descriptionBase64 = metadata.descriptionBase64 ?? cachedAudioConfig?.descriptionBase64
+  const sampleRate =
+    metadata.sampleRate ?? catalogAudioSampleRate ?? cachedAudioConfig?.sampleRate ?? DEFAULT_AUDIO_DECODER_CONFIG.sampleRate
+  const channels =
+    metadata.channels ?? catalogAudioChannels ?? cachedAudioConfig?.channels ?? DEFAULT_AUDIO_DECODER_CONFIG.numberOfChannels
+  const descriptionBase64 =
+    metadata.descriptionBase64 ?? catalogAudioDescriptionBase64 ?? cachedAudioConfig?.descriptionBase64
 
   return { codec, sampleRate, channels, descriptionBase64 }
 }

--- a/examples/browser/utils/media/decoders/audioDecoder.ts
+++ b/examples/browser/utils/media/decoders/audioDecoder.ts
@@ -1,7 +1,7 @@
 import { AudioJitterBuffer } from '../audioJitterBuffer'
 import type { SubgroupObjectWithLoc, JitterBufferSubgroupObject, SubgroupWorkerMessage } from '../jitterBufferTypes'
 import { createBitrateLogger } from '../bitrate'
-import { tryDeserializeChunk, type ChunkMetadata } from '../chunk'
+import { type ChunkMetadata } from '../chunk'
 import { latencyMsFromCaptureMicros } from '../clock'
 import { readLocHeader } from '../loc'
 
@@ -187,10 +187,7 @@ function materializeDirectObject(
   const locMetadata = readLocHeader(object.locHeader)
   const captureTimestampMicros = getCaptureTimestampMicros(locMetadata.captureTimestampMicros)
 
-  const parsed = tryDeserializeChunk(object.objectPayload) ?? buildChunkFromLoc(object)
-  if (!parsed) {
-    return null
-  }
+  const parsed = buildChunkFromLoc(object)
 
   if (typeof captureTimestampMicros === 'number') {
     onReceiveLatency?.(latencyMsFromCaptureMicros(captureTimestampMicros))
@@ -224,8 +221,29 @@ function makeSubgroupKey(groupId: bigint, subgroupId: bigint): string {
   return `${groupId.toString()}:${subgroupId.toString()}`
 }
 
+const OBJECT_STATUS_END_OF_GROUP = 3
+const OBJECT_STATUS_END_OF_TRACK = 4
+
 function isTerminalStatus(status: number | undefined): boolean {
   return status === OBJECT_STATUS_END_OF_GROUP || status === OBJECT_STATUS_END_OF_TRACK
+}
+
+function buildChunkFromLoc(object: SubgroupObjectWithLoc): { metadata: ChunkMetadata; data: Uint8Array } {
+  const loc = readLocHeader(object.locHeader)
+  const captureMicros = getCaptureTimestampMicros(loc.captureTimestampMicros)
+  const metadata: ChunkMetadata = {
+    type: 'key',
+    timestamp: typeof captureMicros === 'number' ? captureMicros : 0,
+    duration: null
+  }
+  return { metadata, data: object.objectPayload }
+}
+
+function getCaptureTimestampMicros(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return undefined
+  }
+  return value
 }
 
 async function decode(subgroupStreamObject: JitterBufferSubgroupObject, captureTimestampMicros?: number) {
@@ -300,14 +318,12 @@ function decodePcmAlawChunk(metadata: ChunkMetadata, payload: Uint8Array, resolv
   }
 
   const timestamp = rebaseTimestamp(metadata.timestamp)
-  const duration = metadata.duration ?? Math.round((numberOfFrames / sampleRate) * 1_000_000)
   const audioData = new AudioData({
     format: 's16',
     sampleRate,
     numberOfFrames,
     numberOfChannels: channels,
     timestamp,
-    duration,
     data: new Uint8Array(pcm.buffer)
   })
   self.postMessage({ type: 'audioData', audioData }, [audioData])

--- a/examples/browser/utils/media/decoders/videoDecoder.ts
+++ b/examples/browser/utils/media/decoders/videoDecoder.ts
@@ -1,7 +1,7 @@
 import { VideoJitterBuffer } from '../videoJitterBuffer'
 import type { JitterBufferSubgroupObject, SubgroupObjectWithLoc, SubgroupWorkerMessage } from '../jitterBufferTypes'
 import { createBitrateLogger } from '../bitrate'
-import { tryDeserializeChunk, type ChunkMetadata } from '../chunk'
+import { type ChunkMetadata } from '../chunk'
 import { latencyMsFromCaptureMicros, monotonicUnixMicros } from '../clock'
 import { bytesToBase64, readLocHeader } from '../loc'
 
@@ -312,7 +312,7 @@ function updateJitterBuffer(config: VideoJitterBufferConfig): void {
   currentDecoderHardwareAcceleration = nextDecoderHardwareAcceleration
   currentJitterConfig = normalizeJitterConfig({ ...currentJitterConfig, ...config })
   updatePacingConfig(config.pacing)
-  jitterBuffer = createJitterBuffer(currentJitterConfig)
+  jitterBuffer = createJitterBuffer()
   if (decoderHardwareAccelerationChanged) {
     if (videoDecoder && videoDecoder.state !== 'closed') {
       try {
@@ -862,13 +862,7 @@ function materializeDirectObject(
 
   const locMetadata = readLocHeader(object.locHeader)
   const captureTimestampMicros = getCaptureTimestampMicros(locMetadata.captureTimestampMicros)
-  const parsed = tryDeserializeChunk(object.objectPayload) ?? buildChunkFromLoc(object, objectId)
-  if (!parsed) {
-    return null
-  }
-  if (!parsed.metadata.descriptionBase64 && locMetadata.videoConfig) {
-    parsed.metadata.descriptionBase64 = bytesToBase64(locMetadata.videoConfig)
-  }
+  const parsed = buildChunkFromLoc(object, objectId)
 
   if (typeof captureTimestampMicros === 'number') {
     onReceiveLatency?.(latencyMsFromCaptureMicros(captureTimestampMicros))
@@ -909,7 +903,7 @@ function isTerminalStatus(status: number | undefined): boolean {
 function buildChunkFromLoc(
   object: SubgroupObjectWithLoc,
   objectId: bigint
-): { metadata: ChunkMetadata; data: Uint8Array } | null {
+): { metadata: ChunkMetadata; data: Uint8Array } {
   const loc = readLocHeader(object.locHeader)
   const captureMicros = getCaptureTimestampMicros(loc.captureTimestampMicros)
   const metadata: ChunkMetadata = {

--- a/examples/browser/utils/media/decoders/videoDecoder.ts
+++ b/examples/browser/utils/media/decoders/videoDecoder.ts
@@ -334,6 +334,8 @@ type CachedVideoConfig = { codec: string; descriptionBase64?: string; avcFormat?
 let cachedVideoConfig: CachedVideoConfig | null = null
 let catalogCodec: string | null = null
 let catalogFramerate: number | null = null
+let catalogDescriptionBase64: string | undefined
+let catalogAvcFormat: 'annexb' | 'avc' | undefined
 let missingCatalogCodecWarned = false
 let directDecodeQueue: Promise<void> = Promise.resolve()
 const directLastObjectIds = new Map<string, bigint>()
@@ -753,7 +755,14 @@ type DecoderControlMessage =
         debugVideoPipeline?: boolean
       }
     }
-  | { type: 'catalog'; codec?: string; framerate?: number }
+  | CatalogMessage
+type CatalogMessage = {
+  type: 'catalog'
+  codec?: string
+  framerate?: number
+  descriptionBase64?: string
+  avcFormat?: 'annexb' | 'avc'
+}
 type WorkerMessage = SubgroupWorkerMessage | DecoderControlMessage
 
 function isConfigMessage(message: WorkerMessage): message is {
@@ -767,7 +776,7 @@ function isConfigMessage(message: WorkerMessage): message is {
   return (message as { type?: string }).type === 'config'
 }
 
-function isCatalogMessage(message: WorkerMessage): message is { type: 'catalog'; codec?: string; framerate?: number } {
+function isCatalogMessage(message: WorkerMessage): message is CatalogMessage {
   return (message as { type?: string }).type === 'catalog'
 }
 
@@ -780,7 +789,7 @@ self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
     return
   }
   if (isCatalogMessage(event.data)) {
-    applyCatalogInfo(event.data.codec, event.data.framerate)
+    applyCatalogInfo(event.data.codec, event.data.framerate, event.data.descriptionBase64, event.data.avcFormat)
     return
   }
   const subgroupStreamObject: SubgroupObjectWithLoc = {
@@ -1114,7 +1123,18 @@ function postDecoderConfig(resolvedConfig: CachedVideoConfig, desired: VideoDeco
   })
 }
 
-function applyCatalogInfo(codec?: string, framerate?: number): void {
+function applyCatalogInfo(
+  codec?: string,
+  framerate?: number,
+  descriptionBase64?: string,
+  avcFormat?: 'annexb' | 'avc'
+): void {
+  if (descriptionBase64) {
+    catalogDescriptionBase64 = descriptionBase64
+  }
+  if (avcFormat) {
+    catalogAvcFormat = avcFormat
+  }
   if (typeof framerate === 'number' && Number.isFinite(framerate) && framerate > 0) {
     if (catalogFramerate !== framerate) {
       catalogFramerate = framerate
@@ -1157,8 +1177,8 @@ function resolveVideoConfig(metadata: ChunkMetadata): CachedVideoConfig | null {
   missingCatalogCodecWarned = false
   return {
     codec,
-    descriptionBase64: metadata.descriptionBase64,
-    avcFormat: metadata.avcFormat ?? (codec.startsWith('avc') ? 'annexb' : undefined)
+    descriptionBase64: metadata.descriptionBase64 ?? catalogDescriptionBase64,
+    avcFormat: metadata.avcFormat ?? catalogAvcFormat ?? (codec.startsWith('avc') ? 'annexb' : undefined)
   }
 }
 

--- a/examples/browser/utils/media/loc.ts
+++ b/examples/browser/utils/media/loc.ts
@@ -5,16 +5,16 @@ export type LocHeader = {
 export type LocHeaderExtension =
   | { type: 'captureTimestamp'; value: { microsSinceUnixEpoch: number } }
   | { type: 'videoConfig'; value: { data: Uint8Array } }
-  | { type: 'videoFrameMarking'; value: { data: Uint8Array } }
+  | { type: 'videoFrameMarking'; value: { flags: number } }
   | { type: 'audioLevel'; value: { level: number } }
   | { type: 'unknown'; value: { id: number; value: LocHeaderValue } }
 
-export type LocHeaderValue = { evenBytes: Uint8Array } | { oddVarint: number }
+export type LocHeaderValue = { even: number } | { odd: Uint8Array }
 
 export type LocMetadata = {
   captureTimestampMicros?: number
   videoConfig?: Uint8Array
-  videoFrameMarking?: Uint8Array
+  videoFrameMarking?: number
   audioLevel?: number
 }
 
@@ -32,10 +32,10 @@ export function buildLocHeader(meta: LocMetadata): LocHeader {
       value: { data: meta.videoConfig }
     })
   }
-  if (meta.videoFrameMarking) {
+  if (typeof meta.videoFrameMarking === 'number') {
     extensions.push({
       type: 'videoFrameMarking',
-      value: { data: meta.videoFrameMarking }
+      value: { flags: meta.videoFrameMarking }
     })
   }
   if (typeof meta.audioLevel === 'number') {
@@ -61,7 +61,7 @@ export function readLocHeader(header?: LocHeader): LocMetadata {
         meta.videoConfig = ext.value.data
         break
       case 'videoFrameMarking':
-        meta.videoFrameMarking = ext.value.data
+        meta.videoFrameMarking = ext.value.flags
         break
       case 'audioLevel':
         meta.audioLevel = ext.value.level

--- a/examples/browser/utils/media/videoJitterBuffer.ts
+++ b/examples/browser/utils/media/videoJitterBuffer.ts
@@ -1,4 +1,4 @@
-import { tryDeserializeChunk, type ChunkMetadata } from './chunk'
+import { type ChunkMetadata } from './chunk'
 import { bytesToBase64, readLocHeader } from './loc'
 import { latencyMsFromCaptureMicros } from './clock'
 import type { JitterBufferSubgroupObject, SubgroupObjectWithLoc } from './jitterBufferTypes'
@@ -34,13 +34,7 @@ export class VideoJitterBuffer {
 
     const locMetadata = readLocHeader(object.locHeader)
     const captureTimestampMicros = getCaptureTimestampMicros(locMetadata.captureTimestampMicros)
-    const parsed = tryDeserializeChunk(object.objectPayload) ?? buildChunkFromLoc(object, objectId)
-    if (!parsed) {
-      return null
-    }
-    if (!parsed.metadata.descriptionBase64 && locMetadata.videoConfig) {
-      parsed.metadata.descriptionBase64 = bytesToBase64(locMetadata.videoConfig)
-    }
+    const parsed = buildChunkFromLoc(object, objectId)
 
     const bufferObject: JitterBufferSubgroupObject = {
       ...object,
@@ -131,7 +125,7 @@ function isTerminalStatus(status: number | undefined): boolean {
 function buildChunkFromLoc(
   object: SubgroupObjectWithLoc,
   objectId: bigint
-): { metadata: ChunkMetadata; data: Uint8Array } | null {
+): { metadata: ChunkMetadata; data: Uint8Array } {
   const loc = readLocHeader(object.locHeader)
   const captureMicros = getCaptureTimestampMicros(loc.captureTimestampMicros)
   const metadata: ChunkMetadata = {

--- a/examples/browser/utils/media/videoTransport.ts
+++ b/examples/browser/utils/media/videoTransport.ts
@@ -1,10 +1,7 @@
 import type { MOQTClient } from '../../pkg/moqt_client_wasm'
 import { MediaTransportState } from './transportState'
-import { serializeChunk } from './chunk'
-import { buildLocHeader, bytesToBase64, arrayBufferToUint8Array, type LocHeader } from './loc'
+import { buildLocHeader, arrayBufferToUint8Array, type LocHeader } from './loc'
 import { monotonicUnixMicros } from './clock'
-
-const H264_BOOTSTRAP_FRAME_INTERVAL_US = 33_333
 
 export type VideoChunkSender = (
   trackAlias: bigint,
@@ -46,15 +43,10 @@ export async function sendVideoChunkViaMoqt({
 
   const shouldIncludeCodec = trackAliases.some((alias) => transportState.shouldSendVideoCodec(alias))
   const decoderConfig = metadata?.decoderConfig as any
-  const codec = typeof decoderConfig?.codec === 'string' ? decoderConfig.codec : undefined
   const configBytes = arrayBufferToUint8Array(decoderConfig?.description)
   const includeConfig = chunk.type === 'key' || shouldIncludeCodec
-  const payload = serializeChunk(chunk, {
-    codec,
-    timestamp: normalizeVideoChunkTimestamp(chunk, codec),
-    descriptionBase64: includeConfig && configBytes ? bytesToBase64(configBytes) : undefined,
-    avcFormat: codec?.startsWith('avc') ? 'annexb' : undefined
-  })
+  const payload = new Uint8Array(chunk.byteLength)
+  chunk.copyTo(payload)
   const resolvedCaptureTimestampMicros =
     typeof captureTimestampMicros === 'number' && Number.isFinite(captureTimestampMicros)
       ? Math.round(captureTimestampMicros)
@@ -132,11 +124,4 @@ export async function sendVideoChunkViaMoqt({
   // sent to; the number is shared across all aliases in the same group.
   transportState.incrementVideoObjectNumber()
   return { needsKeyframe: pending.length > 0 }
-}
-
-function normalizeVideoChunkTimestamp(chunk: EncodedVideoChunk, codec: string | undefined): number {
-  if (codec?.startsWith('avc') && chunk.type === 'key' && chunk.timestamp === 0) {
-    return H264_BOOTSTRAP_FRAME_INTERVAL_US
-  }
-  return chunk.timestamp
 }

--- a/examples/browser/utils/webcodecs.d.ts
+++ b/examples/browser/utils/webcodecs.d.ts
@@ -1,0 +1,6 @@
+// WebCodecs `VideoDecoderConfig.avc` is not yet in the bundled TS lib definitions.
+interface VideoDecoderConfig {
+  avc?: {
+    format?: AvcBitstreamFormat
+  }
+}

--- a/examples/cross-protocol-test/publisher/src/main.rs
+++ b/examples/cross-protocol-test/publisher/src/main.rs
@@ -80,11 +80,7 @@ async fn send_segments(
     let mut group_id: u64 = 0;
 
     while let Some(segment) = rx.recv().await {
-        let ext = ExtensionHeaders {
-            prior_group_id_gap: vec![],
-            prior_object_id_gap: vec![],
-            immutable_extensions: vec![],
-        };
+        let ext = ExtensionHeaders::default();
 
         // グループごとに新しいストリームを開く
         let uninit = stream_factory.next().await?;

--- a/examples/rust/manual-client/src/client.rs
+++ b/examples/rust/manual-client/src/client.rs
@@ -295,11 +295,7 @@ impl<T: TransportProtocol> Client<T> {
                 while id < 10 {
                     let format_text = format!("hello from {}! id: {}", label, id);
                     let data = moqt::SubgroupObject::new_payload(format_text.into());
-                    let extension_headers = moqt::ExtensionHeaders {
-                        prior_group_id_gap: vec![],
-                        prior_object_id_gap: vec![],
-                        immutable_extensions: vec![],
-                    };
+                    let extension_headers = moqt::ExtensionHeaders::default();
                     let obj = stream.create_object_field(0, extension_headers, data);
                     match stream.send(obj).await {
                         Ok(_) => {

--- a/examples/rust/moq-cli/src/transport/writer.rs
+++ b/examples/rust/moq-cli/src/transport/writer.rs
@@ -90,11 +90,7 @@ impl GroupSender {
         object: Bytes,
         immutable_extensions: Vec<Bytes>,
     ) -> Result<()> {
-        let ext = ExtensionHeaders {
-            prior_group_id_gap: vec![],
-            prior_object_id_gap: vec![],
-            immutable_extensions,
-        };
+        let ext = ExtensionHeaders::from_immutable_extensions(immutable_extensions);
         let field = self
             .sender
             .create_object_field(0, ext, SubgroupObject::new_payload(object));
@@ -113,9 +109,5 @@ impl GroupSender {
 }
 
 fn empty_ext() -> ExtensionHeaders {
-    ExtensionHeaders {
-        prior_group_id_gap: vec![],
-        prior_object_id_gap: vec![],
-        immutable_extensions: vec![],
-    }
+    ExtensionHeaders::default()
 }

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -2,6 +2,9 @@ mod modules;
 pub mod wire;
 
 pub use crate::modules::moqt::control_plane::control_messages::messages::parameters::group_order::GroupOrder;
+pub use modules::moqt::control_plane::control_messages::key_value_pair::{
+    KeyValuePair, VariantType,
+};
 pub use modules::moqt::control_plane::control_messages::messages::parameters::content_exists::ContentExists;
 pub use modules::moqt::control_plane::control_messages::messages::parameters::filter_type::FilterType;
 pub use modules::moqt::control_plane::control_messages::messages::parameters::location::Location;

--- a/moqt/src/modules/moqt/data_plane/object/datagram_field.rs
+++ b/moqt/src/modules/moqt/data_plane/object/datagram_field.rs
@@ -463,11 +463,8 @@ mod tests {
         #[test]
         fn payload0x01_encode_decode() {
             // setup
-            let extension_header = ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![Bytes::from(vec![10, 20])],
-            };
+            let extension_header =
+                ExtensionHeaders::from_immutable_extensions(vec![Bytes::from(vec![10, 20])]);
             let field = DatagramField::Payload0x01 {
                 object_id: 456,
                 publisher_priority: 20,
@@ -491,7 +488,7 @@ mod tests {
                 assert_eq!(object_id, 456);
                 assert_eq!(publisher_priority, 20);
                 assert_eq!(
-                    extension_headers.immutable_extensions,
+                    extension_headers.immutable_extensions(),
                     vec![Bytes::from(vec![10, 20])]
                 );
                 assert_eq!(*payload, Bytes::from(vec![6, 7, 8, 9, 10]));
@@ -534,11 +531,7 @@ mod tests {
         #[test]
         fn payload0x03_with_end_of_group_encode_decode() {
             // setup
-            let extension_header = ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            };
+            let extension_header = ExtensionHeaders::default();
             let field = DatagramField::Payload0x03WithEndOfGroup {
                 object_id: 101,
                 publisher_priority: 40,
@@ -561,14 +554,7 @@ mod tests {
             {
                 assert_eq!(object_id, 101);
                 assert_eq!(publisher_priority, 40);
-                assert_eq!(
-                    extension_headers,
-                    ExtensionHeaders {
-                        prior_group_id_gap: vec![],
-                        prior_object_id_gap: vec![],
-                        immutable_extensions: vec![]
-                    }
-                );
+                assert_eq!(extension_headers, ExtensionHeaders::default());
                 assert_eq!(*payload, Bytes::from(vec![16, 17, 18, 19, 20]));
             } else {
                 panic!("Decoded into wrong variant");
@@ -609,14 +595,11 @@ mod tests {
         #[test]
         fn payload0x05_encode_decode() {
             // setup
-            let extension_header = ExtensionHeaders {
-                prior_group_id_gap: vec![3],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            };
+            let mut extension_header = ExtensionHeaders::default();
+            extension_header.push_prior_group_id_gap(3);
             let field = DatagramField::Payload0x05 {
                 publisher_priority: 60,
-                extension_headers: extension_header,
+                extension_headers: extension_header.clone(),
                 payload: Bytes::from(vec![26, 27, 28, 29, 30]),
             };
 
@@ -633,14 +616,7 @@ mod tests {
             } = decoded
             {
                 assert_eq!(publisher_priority, 60);
-                assert_eq!(
-                    extension_headers,
-                    ExtensionHeaders {
-                        prior_group_id_gap: vec![3],
-                        prior_object_id_gap: vec![],
-                        immutable_extensions: vec![]
-                    }
-                );
+                assert_eq!(extension_headers, extension_header);
                 assert_eq!(*payload, vec![26, 27, 28, 29, 30]);
             } else {
                 panic!("Decoded into wrong variant");
@@ -678,14 +654,11 @@ mod tests {
         #[test]
         fn payload0x07_with_end_of_group_encode_decode() {
             // setup
-            let extension_header = ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![3],
-                immutable_extensions: vec![],
-            };
+            let mut extension_header = ExtensionHeaders::default();
+            extension_header.push_prior_object_id_gap(3);
             let field = DatagramField::Payload0x07WithEndOfGroup {
                 publisher_priority: 80,
-                extension_headers: extension_header,
+                extension_headers: extension_header.clone(),
                 payload: Bytes::from(vec![36, 37, 38, 39, 40]),
             };
 
@@ -702,14 +675,7 @@ mod tests {
             } = decoded
             {
                 assert_eq!(publisher_priority, 80);
-                assert_eq!(
-                    extension_headers,
-                    ExtensionHeaders {
-                        prior_group_id_gap: vec![],
-                        prior_object_id_gap: vec![3],
-                        immutable_extensions: vec![]
-                    }
-                );
+                assert_eq!(extension_headers, extension_header);
                 assert_eq!(*payload, vec![36, 37, 38, 39, 40]);
             } else {
                 panic!("Decoded into wrong variant");
@@ -750,11 +716,7 @@ mod tests {
         #[test]
         fn status0x21_encode_decode() {
             // setup
-            let extension_header = ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            };
+            let extension_header = ExtensionHeaders::default();
             let field = DatagramField::Status0x21 {
                 object_id: 141,
                 publisher_priority: 100,
@@ -777,14 +739,7 @@ mod tests {
             {
                 assert_eq!(object_id, 141);
                 assert_eq!(publisher_priority, 100);
-                assert_eq!(
-                    extension_headers,
-                    ExtensionHeaders {
-                        prior_group_id_gap: vec![],
-                        prior_object_id_gap: vec![],
-                        immutable_extensions: vec![]
-                    }
-                );
+                assert_eq!(extension_headers, ExtensionHeaders::default());
                 assert_eq!(status, ObjectStatus::EndOfGroup);
             } else {
                 panic!("Decoded into wrong variant");

--- a/moqt/src/modules/moqt/data_plane/object/extension_headers.rs
+++ b/moqt/src/modules/moqt/data_plane/object/extension_headers.rs
@@ -155,86 +155,30 @@ mod tests {
         assert_eq!(headers.prior_object_id_gap(), vec![2]);
         assert_eq!(headers.immutable_extensions(), vec![Bytes::from(vec![9])]);
     }
-}
 
-#[cfg(test)]
-mod tests {
-    mod success {
-        use crate::modules::moqt::data_plane::object::extension_headers::ExtensionHeaders;
-        use bytes::Bytes;
+    #[test]
+    fn decode_returns_none_on_truncated_block() {
+        // length claims 4 bytes but only 2 follow
+        let bytes = [0x04_u8, 0x3c, 0x05];
+        let mut cursor = std::io::Cursor::new(&bytes[..]);
 
-        #[test]
-        fn packetize_and_depacketize_all_header_types() {
-            let headers = ExtensionHeaders {
-                prior_group_id_gap: vec![1, 2],
-                prior_object_id_gap: vec![3],
-                immutable_extensions: vec![Bytes::from(vec![0xaa, 0xbb])],
-            };
-
-            let buf = headers.encode();
-            let mut cursor = std::io::Cursor::new(&buf[..]);
-            let depacketized = ExtensionHeaders::decode(&mut cursor).unwrap();
-
-            assert_eq!(depacketized, headers);
-            assert_eq!(cursor.position() as usize, buf.len());
-        }
-
-        #[test]
-        fn packetize_and_depacketize_empty() {
-            let headers = ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            };
-
-            let buf = headers.encode();
-            let mut cursor = std::io::Cursor::new(&buf[..]);
-            let depacketized = ExtensionHeaders::decode(&mut cursor).unwrap();
-
-            assert_eq!(depacketized, headers);
-        }
-
-        #[test]
-        fn depacketize_ignores_unknown_even_key() {
-            // length (4) + unknown even key (0x10) + value (7)
-            // + PriorGroupIdGap key (0x3c) + value (5)
-            let bytes = [0x04_u8, 0x10, 0x07, 0x3c, 0x05];
-            let mut cursor = std::io::Cursor::new(&bytes[..]);
-            let depacketized = ExtensionHeaders::decode(&mut cursor).unwrap();
-
-            assert_eq!(depacketized.prior_group_id_gap, vec![5]);
-            assert!(depacketized.prior_object_id_gap.is_empty());
-            assert!(depacketized.immutable_extensions.is_empty());
-        }
+        assert!(ExtensionHeaders::decode(&mut cursor).is_none());
     }
 
-    mod failure {
-        use crate::modules::moqt::data_plane::object::extension_headers::ExtensionHeaders;
+    #[test]
+    fn decode_returns_none_on_truncated_inner_kv_pair() {
+        // length (2) + odd key (0x0b) + value length (5) with no value bytes
+        let bytes = [0x02_u8, 0x0b, 0x05];
+        let mut cursor = std::io::Cursor::new(&bytes[..]);
 
-        #[test]
-        fn depacketize_truncated_block() {
-            // length claims 4 bytes but only 2 follow
-            let bytes = [0x04_u8, 0x3c, 0x05];
-            let mut cursor = std::io::Cursor::new(&bytes[..]);
+        assert!(ExtensionHeaders::decode(&mut cursor).is_none());
+    }
 
-            assert!(ExtensionHeaders::decode(&mut cursor).is_none());
-        }
+    #[test]
+    fn decode_returns_none_on_empty_input() {
+        let bytes: [u8; 0] = [];
+        let mut cursor = std::io::Cursor::new(&bytes[..]);
 
-        #[test]
-        fn depacketize_truncated_inner_kv_pair() {
-            // length (2) + odd key (0x0b) + value length (5) with no value bytes
-            let bytes = [0x02_u8, 0x0b, 0x05];
-            let mut cursor = std::io::Cursor::new(&bytes[..]);
-
-            assert!(ExtensionHeaders::decode(&mut cursor).is_none());
-        }
-
-        #[test]
-        fn depacketize_empty_input() {
-            let bytes: [u8; 0] = [];
-            let mut cursor = std::io::Cursor::new(&bytes[..]);
-
-            assert!(ExtensionHeaders::decode(&mut cursor).is_none());
-        }
+        assert!(ExtensionHeaders::decode(&mut cursor).is_none());
     }
 }

--- a/moqt/src/modules/moqt/data_plane/object/extension_headers.rs
+++ b/moqt/src/modules/moqt/data_plane/object/extension_headers.rs
@@ -11,16 +11,30 @@ pub enum ExtensionHeaderType {
     ImmutableExtensions = 0xb,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+// Every Key-Value-Pair is preserved in receive order and re-encoded unchanged:
+// draft-ietf-moq-transport-14 §10.2.1.2 requires unsupported extension headers
+// to be forwarded and cached without modification. Higher layers (e.g. LOC)
+// assign meaning to specific keys; the transport only exposes accessors for the
+// header types it uses itself.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ExtensionHeaders {
-    pub prior_group_id_gap: Vec<u64>,
-    pub prior_object_id_gap: Vec<u64>,
-    pub immutable_extensions: Vec<Bytes>,
+    pub key_value_pairs: Vec<KeyValuePair>,
 }
 
 impl ExtensionHeaders {
+    pub fn new(key_value_pairs: Vec<KeyValuePair>) -> Self {
+        Self { key_value_pairs }
+    }
+
+    pub fn from_immutable_extensions(values: Vec<Bytes>) -> Self {
+        let mut headers = Self::default();
+        for value in values {
+            headers.push_immutable_extension(value);
+        }
+        headers
+    }
+
     pub fn decode(cursor: &mut impl Buf) -> Option<Self> {
-        let mut kv_pairs = Vec::new();
         let byte_length = cursor
             .try_get_varint()
             .log_context("extension headers length")
@@ -29,61 +43,117 @@ impl ExtensionHeaders {
             return None;
         }
         let end_remaining = cursor.remaining() - byte_length;
+        let mut key_value_pairs = Vec::new();
         while cursor.remaining() > end_remaining {
-            let key_value_pair = KeyValuePair::decode(cursor)?;
-            kv_pairs.push(key_value_pair);
+            key_value_pairs.push(KeyValuePair::decode(cursor)?);
         }
-        let prior_group_id_gap = kv_pairs
-            .iter()
-            .filter(|item| item.key == ExtensionHeaderType::PriorGroupIdGap as u64)
-            .map(|kv_pair| match &kv_pair.value {
-                VariantType::Odd(_) => unreachable!(),
-                VariantType::Even(v) => *v,
-            })
-            .collect();
-        let prior_object_id_gap = kv_pairs
-            .iter()
-            .filter(|item| item.key == ExtensionHeaderType::PriorObjectIdGap as u64)
-            .map(|kv_pair| match &kv_pair.value {
-                VariantType::Odd(_) => unreachable!(),
-                VariantType::Even(v) => *v,
-            })
-            .collect();
-        let immutable_extensions = kv_pairs
-            .iter()
-            .filter(|kv_pair| kv_pair.key == ExtensionHeaderType::ImmutableExtensions as u64)
-            .map(|kv_pair| match &kv_pair.value {
-                VariantType::Odd(value) => value.clone(),
-                VariantType::Even(_) => unreachable!(),
-            })
-            .collect();
-
-        Some(Self {
-            prior_group_id_gap,
-            prior_object_id_gap,
-            immutable_extensions,
-        })
+        Some(Self { key_value_pairs })
     }
 
     pub fn encode(&self) -> bytes::BytesMut {
         let mut kv_buf = bytes::BytesMut::new();
-        for gap in &self.prior_group_id_gap {
-            kv_buf.put_varint(ExtensionHeaderType::PriorGroupIdGap as u64);
-            kv_buf.put_varint(*gap);
-        }
-        for gap in &self.prior_object_id_gap {
-            kv_buf.put_varint(ExtensionHeaderType::PriorObjectIdGap as u64);
-            kv_buf.put_varint(*gap);
-        }
-        for ext in &self.immutable_extensions {
-            kv_buf.put_varint(ExtensionHeaderType::ImmutableExtensions as u64);
-            kv_buf.put_varint(ext.len() as u64);
-            kv_buf.extend_from_slice(ext);
+        for kv_pair in &self.key_value_pairs {
+            kv_buf.unsplit(kv_pair.encode());
         }
         let mut buf = bytes::BytesMut::new();
         buf.put_varint(kv_buf.len() as u64);
         buf.unsplit(kv_buf);
         buf
+    }
+
+    pub fn prior_group_id_gap(&self) -> Vec<u64> {
+        self.even_values(ExtensionHeaderType::PriorGroupIdGap as u64)
+    }
+
+    pub fn prior_object_id_gap(&self) -> Vec<u64> {
+        self.even_values(ExtensionHeaderType::PriorObjectIdGap as u64)
+    }
+
+    pub fn immutable_extensions(&self) -> Vec<Bytes> {
+        self.key_value_pairs
+            .iter()
+            .filter(|kv_pair| kv_pair.key == ExtensionHeaderType::ImmutableExtensions as u64)
+            .filter_map(|kv_pair| match &kv_pair.value {
+                VariantType::Odd(value) => Some(value.clone()),
+                VariantType::Even(_) => None,
+            })
+            .collect()
+    }
+
+    pub fn push_prior_group_id_gap(&mut self, gap: u64) {
+        self.push_even(ExtensionHeaderType::PriorGroupIdGap as u64, gap);
+    }
+
+    pub fn push_prior_object_id_gap(&mut self, gap: u64) {
+        self.push_even(ExtensionHeaderType::PriorObjectIdGap as u64, gap);
+    }
+
+    pub fn push_immutable_extension(&mut self, value: Bytes) {
+        self.key_value_pairs.push(KeyValuePair {
+            key: ExtensionHeaderType::ImmutableExtensions as u64,
+            value: VariantType::Odd(value),
+        });
+    }
+
+    fn even_values(&self, key: u64) -> Vec<u64> {
+        self.key_value_pairs
+            .iter()
+            .filter(|kv_pair| kv_pair.key == key)
+            .filter_map(|kv_pair| match &kv_pair.value {
+                VariantType::Even(value) => Some(*value),
+                VariantType::Odd(_) => None,
+            })
+            .collect()
+    }
+
+    fn push_even(&mut self, key: u64, value: u64) {
+        self.key_value_pairs.push(KeyValuePair {
+            key,
+            value: VariantType::Even(value),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_preserves_unsupported_headers_in_order() {
+        // Keys 2 and 13 are LOC extension header types the transport does not
+        // interpret; draft-14 §10.2.1.2 requires them to be forwarded unmodified.
+        let headers = ExtensionHeaders::new(vec![
+            KeyValuePair {
+                key: 2,
+                value: VariantType::Even(123),
+            },
+            KeyValuePair {
+                key: ExtensionHeaderType::PriorGroupIdGap as u64,
+                value: VariantType::Even(7),
+            },
+            KeyValuePair {
+                key: 13,
+                value: VariantType::Odd(Bytes::from(vec![0xAA, 0xBB])),
+            },
+        ]);
+
+        let mut encoded = headers.encode();
+        let decoded = ExtensionHeaders::decode(&mut encoded).unwrap();
+
+        assert_eq!(decoded, headers);
+        assert_eq!(decoded.prior_group_id_gap(), vec![7]);
+    }
+
+    #[test]
+    fn accessors_filter_by_header_type() {
+        let mut headers = ExtensionHeaders::default();
+        headers.push_prior_group_id_gap(1);
+        headers.push_prior_object_id_gap(2);
+        headers.push_immutable_extension(Bytes::from(vec![9]));
+
+        assert_eq!(headers.prior_group_id_gap(), vec![1]);
+        assert_eq!(headers.prior_object_id_gap(), vec![2]);
+        assert_eq!(headers.immutable_extensions(), vec![Bytes::from(vec![9])]);
     }
 }
 

--- a/moqt/src/modules/moqt/data_plane/object/fetch.rs
+++ b/moqt/src/modules/moqt/data_plane/object/fetch.rs
@@ -212,11 +212,7 @@ mod tests {
                 2,   // subgroup_id
                 3,   // object_id
                 128, // publisher_priority
-                ExtensionHeaders {
-                    prior_group_id_gap: vec![],
-                    prior_object_id_gap: vec![],
-                    immutable_extensions: vec![],
-                },
+                ExtensionHeaders::default(),
                 object,
             )
         }

--- a/moqt/src/modules/moqt/data_plane/object/object_datagram.rs
+++ b/moqt/src/modules/moqt/data_plane/object/object_datagram.rs
@@ -135,11 +135,7 @@ mod tests {
                 field: DatagramField::Payload0x01 {
                     object_id: 3,
                     publisher_priority: 128,
-                    extension_headers: ExtensionHeaders {
-                        prior_group_id_gap: vec![],
-                        prior_object_id_gap: vec![],
-                        immutable_extensions: vec![],
-                    },
+                    extension_headers: ExtensionHeaders::default(),
                     payload: Bytes::from(vec![0, 1, 2, 3]),
                 },
             };

--- a/moqt/src/modules/moqt/data_plane/object/subgroup.rs
+++ b/moqt/src/modules/moqt/data_plane/object/subgroup.rs
@@ -325,11 +325,7 @@ impl SubgroupObjectField {
         let extension_headers = if message_type.has_extensions() {
             ExtensionHeaders::decode(&mut cursor).ok_or(DecodeError::NeedMoreData)?
         } else {
-            ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            }
+            ExtensionHeaders::default()
         };
         let length = SubgroupObject::check_length(&mut cursor).ok_or(DecodeError::NeedMoreData)?;
         let subgroup_object = if length == 0 {
@@ -467,11 +463,7 @@ mod tests {
             let object_field = SubgroupObjectField {
                 message_type,
                 object_id_delta: 1,
-                extension_headers: ExtensionHeaders {
-                    prior_group_id_gap: vec![],
-                    prior_object_id_gap: vec![],
-                    immutable_extensions: vec![],
-                },
+                extension_headers: ExtensionHeaders::default(),
                 subgroup_object: SubgroupObject::new_payload(payload.clone()),
             };
 
@@ -482,7 +474,7 @@ mod tests {
             assert!(
                 depacketized
                     .extension_headers
-                    .immutable_extensions
+                    .immutable_extensions()
                     .is_empty()
             );
             assert_eq!(object_field.subgroup_object, depacketized.subgroup_object);
@@ -492,14 +484,13 @@ mod tests {
         fn subgroup_object_field_packetize_and_depacketize_with_extensions() {
             let message_type = SubgroupHeaderType::new(0x11).unwrap();
             let payload = Bytes::from(vec![0x11, 0x22, 0x33]);
+            let mut extension_headers = ExtensionHeaders::default();
+            extension_headers.push_prior_group_id_gap(10);
+            extension_headers.push_immutable_extension(Bytes::from(vec![0x01, 0x02]));
             let object_field = SubgroupObjectField {
                 message_type,
                 object_id_delta: 5,
-                extension_headers: ExtensionHeaders {
-                    prior_group_id_gap: vec![10],
-                    prior_object_id_gap: vec![],
-                    immutable_extensions: vec![Bytes::from(vec![0x01, 0x02])],
-                },
+                extension_headers,
                 subgroup_object: SubgroupObject::new_payload(payload.clone()),
             };
 
@@ -508,12 +499,12 @@ mod tests {
 
             assert_eq!(object_field.object_id_delta, depacketized.object_id_delta);
             assert_eq!(
-                object_field.extension_headers.prior_group_id_gap,
-                depacketized.extension_headers.prior_group_id_gap
+                object_field.extension_headers.prior_group_id_gap(),
+                depacketized.extension_headers.prior_group_id_gap()
             );
             assert_eq!(
-                object_field.extension_headers.immutable_extensions,
-                depacketized.extension_headers.immutable_extensions
+                object_field.extension_headers.immutable_extensions(),
+                depacketized.extension_headers.immutable_extensions()
             );
             assert_eq!(object_field.subgroup_object, depacketized.subgroup_object);
         }
@@ -524,11 +515,7 @@ mod tests {
             let object_field = SubgroupObjectField {
                 message_type,
                 object_id_delta: 10,
-                extension_headers: ExtensionHeaders {
-                    prior_group_id_gap: vec![],
-                    prior_object_id_gap: vec![],
-                    immutable_extensions: vec![],
-                },
+                extension_headers: ExtensionHeaders::default(),
                 subgroup_object: SubgroupObject::new_status(3), // EndOfGroup
             };
 
@@ -539,7 +526,7 @@ mod tests {
             assert!(
                 depacketized
                     .extension_headers
-                    .immutable_extensions
+                    .immutable_extensions()
                     .is_empty()
             );
             assert_eq!(object_field.subgroup_object, depacketized.subgroup_object);
@@ -573,11 +560,7 @@ mod tests {
             SubgroupObjectField {
                 message_type: SubgroupHeaderType::new(0x10).unwrap(),
                 object_id_delta: delta,
-                extension_headers: ExtensionHeaders {
-                    prior_group_id_gap: vec![],
-                    prior_object_id_gap: vec![],
-                    immutable_extensions: vec![],
-                },
+                extension_headers: ExtensionHeaders::default(),
                 subgroup_object: SubgroupObject::new_payload(bytes::Bytes::new()),
             }
         }

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -144,11 +144,7 @@ mod tests {
         Arc::new(DataObject::SubgroupObject(SubgroupObjectField {
             message_type,
             object_id_delta: 0,
-            extension_headers: ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            extension_headers: ExtensionHeaders::default(),
             subgroup_object: SubgroupObject::new_payload(Bytes::from(payload.to_vec())),
         }))
     }

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -106,11 +106,7 @@ mod tests {
                     DataObject::SubgroupObject(SubgroupObjectField {
                         message_type,
                         object_id_delta: 0,
-                        extension_headers: ExtensionHeaders {
-                            prior_group_id_gap: vec![],
-                            prior_object_id_gap: vec![],
-                            immutable_extensions: vec![],
-                        },
+                        extension_headers: ExtensionHeaders::default(),
                         subgroup_object: SubgroupObject::new_payload(bytes::Bytes::new()),
                     }),
                 )

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -372,11 +372,7 @@ mod tests {
         DataObject::SubgroupObject(SubgroupObjectField {
             message_type,
             object_id_delta: delta,
-            extension_headers: ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            extension_headers: ExtensionHeaders::default(),
             subgroup_object: SubgroupObject::new_payload(Bytes::from(vec![])),
         })
     }

--- a/relay/src/modules/relay/egress/scheduler.rs
+++ b/relay/src/modules/relay/egress/scheduler.rs
@@ -325,11 +325,7 @@ mod tests {
         DataObject::SubgroupObject(SubgroupObjectField {
             message_type,
             object_id_delta: delta,
-            extension_headers: ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            extension_headers: ExtensionHeaders::default(),
             subgroup_object: SubgroupObject::new_payload(Bytes::from(vec![])),
         })
     }

--- a/relay/src/modules/relay/ingress/stream_reader.rs
+++ b/relay/src/modules/relay/ingress/stream_reader.rs
@@ -214,11 +214,7 @@ mod tests {
     }
 
     fn empty_extension_headers() -> ExtensionHeaders {
-        ExtensionHeaders {
-            prior_group_id_gap: vec![],
-            prior_object_id_gap: vec![],
-            immutable_extensions: vec![],
-        }
+        ExtensionHeaders::default()
     }
 
     fn make_payload_object(object_id_delta: u64) -> DataObject {

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -560,11 +560,7 @@ mod tests {
         DataObject::SubgroupObject(SubgroupObjectField {
             message_type,
             object_id_delta: 0,
-            extension_headers: ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            extension_headers: ExtensionHeaders::default(),
             subgroup_object: SubgroupObject::new_payload(Bytes::from(vec![])),
         })
     }

--- a/shared/packages/Cargo.toml
+++ b/shared/packages/Cargo.toml
@@ -11,6 +11,8 @@ default = []
 wasm = ["wasm-bindgen", "serde-wasm-bindgen"]
 
 [dependencies]
+moqt = { path = "../../moqt" }
+bytes = "1"
 serde = { version = "1.0.228", features = ["derive"] }
 wasm-bindgen = { version = "0.2.123", optional = true }
 serde-wasm-bindgen = { version = "0.6.5", optional = true }

--- a/shared/packages/src/loc/header_extension.rs
+++ b/shared/packages/src/loc/header_extension.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+use moqt::{KeyValuePair, VariantType};
 use serde::{Deserialize, Serialize};
 
 pub const LOC_CAPTURE_TIMESTAMP_ID: u64 = 2;
@@ -15,11 +17,14 @@ pub enum LocHeaderExtension {
     Unknown(UnknownHeaderExtension),
 }
 
+// Value carried by an extension header whose id the LOC layer does not model.
+// Per draft-ietf-moq-loc-01 §2.3, even ids carry a varint value and odd ids
+// carry a length-prefixed byte string, mirroring `moqt::VariantType`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum LocHeaderValue {
-    EvenBytes(Vec<u8>),
-    OddVarint(u64),
+    Even(u64),
+    Odd(Vec<u8>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -37,7 +42,7 @@ pub struct VideoConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VideoFrameMarking {
-    pub data: Vec<u8>,
+    pub flags: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,4 +56,64 @@ pub struct AudioLevel {
 pub struct UnknownHeaderExtension {
     pub id: u64,
     pub value: LocHeaderValue,
+}
+
+impl LocHeaderExtension {
+    pub fn to_key_value_pair(&self) -> KeyValuePair {
+        match self {
+            LocHeaderExtension::CaptureTimestamp(ext) => KeyValuePair {
+                key: LOC_CAPTURE_TIMESTAMP_ID,
+                value: VariantType::Even(ext.micros_since_unix_epoch),
+            },
+            LocHeaderExtension::VideoFrameMarking(ext) => KeyValuePair {
+                key: LOC_VIDEO_FRAME_MARKING_ID,
+                value: VariantType::Even(ext.flags),
+            },
+            LocHeaderExtension::AudioLevel(ext) => KeyValuePair {
+                key: LOC_AUDIO_LEVEL_ID,
+                value: VariantType::Even(ext.level as u64),
+            },
+            LocHeaderExtension::VideoConfig(ext) => KeyValuePair {
+                key: LOC_VIDEO_CONFIG_ID,
+                value: VariantType::Odd(Bytes::from(ext.data.clone())),
+            },
+            LocHeaderExtension::Unknown(ext) => KeyValuePair {
+                key: ext.id,
+                value: match &ext.value {
+                    LocHeaderValue::Even(value) => VariantType::Even(*value),
+                    LocHeaderValue::Odd(value) => VariantType::Odd(Bytes::from(value.clone())),
+                },
+            },
+        }
+    }
+
+    pub fn from_key_value_pair(kv_pair: &KeyValuePair) -> Self {
+        match (kv_pair.key, &kv_pair.value) {
+            (LOC_CAPTURE_TIMESTAMP_ID, VariantType::Even(value)) => {
+                LocHeaderExtension::CaptureTimestamp(CaptureTimestamp {
+                    micros_since_unix_epoch: *value,
+                })
+            }
+            (LOC_VIDEO_FRAME_MARKING_ID, VariantType::Even(value)) => {
+                LocHeaderExtension::VideoFrameMarking(VideoFrameMarking { flags: *value })
+            }
+            (LOC_AUDIO_LEVEL_ID, VariantType::Even(value)) => {
+                LocHeaderExtension::AudioLevel(AudioLevel {
+                    level: *value as u8,
+                })
+            }
+            (LOC_VIDEO_CONFIG_ID, VariantType::Odd(value)) => {
+                LocHeaderExtension::VideoConfig(VideoConfig {
+                    data: value.to_vec(),
+                })
+            }
+            (id, value) => LocHeaderExtension::Unknown(UnknownHeaderExtension {
+                id,
+                value: match value {
+                    VariantType::Even(value) => LocHeaderValue::Even(*value),
+                    VariantType::Odd(value) => LocHeaderValue::Odd(value.to_vec()),
+                },
+            }),
+        }
+    }
 }

--- a/shared/packages/src/loc/mod.rs
+++ b/shared/packages/src/loc/mod.rs
@@ -1,3 +1,4 @@
+use moqt::ExtensionHeaders;
 use serde::{Deserialize, Serialize};
 
 pub mod header_extension;
@@ -14,9 +15,114 @@ pub struct LocHeader {
     pub extensions: Vec<LocHeaderExtension>,
 }
 
+impl LocHeader {
+    pub fn to_extension_headers(&self) -> ExtensionHeaders {
+        ExtensionHeaders::new(
+            self.extensions
+                .iter()
+                .map(LocHeaderExtension::to_key_value_pair)
+                .collect(),
+        )
+    }
+
+    pub fn from_extension_headers(headers: &ExtensionHeaders) -> Self {
+        Self {
+            extensions: headers
+                .key_value_pairs
+                .iter()
+                .map(LocHeaderExtension::from_key_value_pair)
+                .collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocObject {
     pub header: LocHeader,
 
     pub payload: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moqt::VariantType;
+
+    #[test]
+    fn even_odd_parity_matches_loc_spec() {
+        // Even ids carry a varint value; the odd id (VideoConfig) carries bytes.
+        let capture = LocHeaderExtension::CaptureTimestamp(CaptureTimestamp {
+            micros_since_unix_epoch: 5,
+        })
+        .to_key_value_pair();
+        assert_eq!(capture.key, LOC_CAPTURE_TIMESTAMP_ID);
+        assert!(matches!(capture.value, VariantType::Even(5)));
+
+        let config = LocHeaderExtension::VideoConfig(VideoConfig {
+            data: vec![1, 2, 3],
+        })
+        .to_key_value_pair();
+        assert_eq!(config.key, LOC_VIDEO_CONFIG_ID);
+        assert!(matches!(config.value, VariantType::Odd(_)));
+    }
+
+    #[test]
+    fn known_extensions_round_trip() {
+        let extensions = vec![
+            LocHeaderExtension::CaptureTimestamp(CaptureTimestamp {
+                micros_since_unix_epoch: 123,
+            }),
+            LocHeaderExtension::VideoFrameMarking(VideoFrameMarking { flags: 0b101 }),
+            LocHeaderExtension::AudioLevel(AudioLevel { level: 42 }),
+            LocHeaderExtension::VideoConfig(VideoConfig {
+                data: vec![9, 8, 7],
+            }),
+        ];
+        for ext in extensions {
+            assert_eq!(
+                ext,
+                LocHeaderExtension::from_key_value_pair(&ext.to_key_value_pair())
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_extension_round_trips_both_parities() {
+        let even = LocHeaderExtension::Unknown(UnknownHeaderExtension {
+            id: 8,
+            value: LocHeaderValue::Even(77),
+        });
+        let odd = LocHeaderExtension::Unknown(UnknownHeaderExtension {
+            id: 9,
+            value: LocHeaderValue::Odd(vec![1, 2]),
+        });
+        assert_eq!(
+            even,
+            LocHeaderExtension::from_key_value_pair(&even.to_key_value_pair())
+        );
+        assert_eq!(
+            odd,
+            LocHeaderExtension::from_key_value_pair(&odd.to_key_value_pair())
+        );
+    }
+
+    #[test]
+    fn loc_header_preserves_order_and_unknown() {
+        let header = LocHeader {
+            extensions: vec![
+                LocHeaderExtension::CaptureTimestamp(CaptureTimestamp {
+                    micros_since_unix_epoch: 1,
+                }),
+                LocHeaderExtension::Unknown(UnknownHeaderExtension {
+                    id: 21,
+                    value: LocHeaderValue::Odd(vec![0xFF]),
+                }),
+                LocHeaderExtension::VideoConfig(VideoConfig { data: vec![5] }),
+            ],
+        };
+        assert_eq!(
+            header,
+            LocHeader::from_extension_headers(&header.to_extension_headers())
+        );
+    }
 }

--- a/tests/cache-eviction-e2e/src/main.rs
+++ b/tests/cache-eviction-e2e/src/main.rs
@@ -97,11 +97,7 @@ async fn send_group(factory: &StreamDataSenderFactory<QUIC>, group_id: u64) -> a
         let payload = format!("g{}:o{}", group_id, obj_id);
         let obj = stream.create_object_field(
             0,
-            ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            ExtensionHeaders::default(),
             SubgroupObject::new_payload(payload.into()),
         );
         stream.send(obj).await?;

--- a/tests/cascading-relay-e2e/src/main.rs
+++ b/tests/cascading-relay-e2e/src/main.rs
@@ -637,11 +637,7 @@ async fn send_ordered_objects(
         let object_id_delta = if index == 0 { 0 } else { 1 };
         let object = stream.create_object_field(
             object_id_delta,
-            ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            ExtensionHeaders::default(),
             SubgroupObject::new_payload(Bytes::from(ordered_object_payload(index))),
         );
         stream.send(object).await?;
@@ -783,11 +779,7 @@ async fn send_test_object(
     let mut stream = uninitialized.send_header(header).await?;
     let object = stream.create_object_field(
         0,
-        ExtensionHeaders {
-            prior_group_id_gap: vec![],
-            prior_object_id_gap: vec![],
-            immutable_extensions: vec![],
-        },
+        ExtensionHeaders::default(),
         SubgroupObject::new_payload(Bytes::from_static(payload)),
     );
     stream.send(object).await?;

--- a/tests/fetch-e2e/src/main.rs
+++ b/tests/fetch-e2e/src/main.rs
@@ -58,11 +58,7 @@ async fn send_group(factory: &StreamDataSenderFactory<QUIC>, group_id: u64) -> a
         let payload = format!("g{}:o{}", group_id, obj_id);
         let obj = stream.create_object_field(
             0,
-            ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            ExtensionHeaders::default(),
             SubgroupObject::new_payload(payload.into()),
         );
         stream.send(obj).await?;

--- a/tests/multiple-publishers-e2e/src/main.rs
+++ b/tests/multiple-publishers-e2e/src/main.rs
@@ -65,11 +65,7 @@ async fn send_group(
         let payload = format!("{}:g{}:o{}", who, group_id, obj_id);
         let obj = stream.create_object_field(
             0,
-            ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            ExtensionHeaders::default(),
             SubgroupObject::new_payload(payload.into()),
         );
         stream.send(obj).await?;

--- a/tests/object-dedup-e2e/src/main.rs
+++ b/tests/object-dedup-e2e/src/main.rs
@@ -61,11 +61,7 @@ async fn send_group(factory: &StreamDataSenderFactory<QUIC>, attempt: &str) -> a
         let payload = format!("alice:{}:g{}:o{}", attempt, GROUP_ID, obj_id);
         let obj = stream.create_object_field(
             0,
-            ExtensionHeaders {
-                prior_group_id_gap: vec![],
-                prior_object_id_gap: vec![],
-                immutable_extensions: vec![],
-            },
+            ExtensionHeaders::default(),
             SubgroupObject::new_payload(payload.into()),
         );
         stream.send(obj).await?;


### PR DESCRIPTION
# feat: LOC/MSF-compliant object metadata (per-id extension headers + raw payloads)

## What / Why
example で送受信するメディアデータを独自 JSON + LOC ペイロードから LOC/MSF 準拠へ移行:
- メタデータ（capture-timestamp, video config）を **per-id Object Extension Header** で運ぶ
- デコーダ設定（codec, SPS/PPS）は **Catalog** から取得
- video ペイロードを **生の符号化フレーム**に（`[len][JSON]` 前置を撤去、audio と同形）

## Commits
- `fix(moqt)`: 転送時に全拡張ヘッダを保持
- `feat(packages)`: LocHeader ⇄ ExtensionHeaders の per-id 変換
- `feat(wasm)`: LOC を per-id 拡張ヘッダで送出（JSON blob 廃止）
- `feat(browser)`: Catalog からデコーダ設定取得（T-04）／video 生バイト化（T-05）
- `fix(moqt)`: rebase 後の ExtensionHeaders 統合

## レビュー時の注意
- **ExtensionHeaders**: master は3種の既知 key だけ保持し他を破棄する形に変更していたが、これは LOC の per-id ヘッダを落とし、transport §10.2.1.2（未サポート拡張は forward 必須）に反する。本 PR は全保持に戻し、3種はアクセサとして提供。

## Verify
- CI green: clippy / fmt / test / tsc。
- 手動 e2e: remote-monitoring（live＋review）, media（video）, call（video＋audio）。
