### PR TITLE
fix(relay): 遅い ClientSetup が accept ループをブロックしないよう接続ごとに spawn

### DIFF
--- a/relay/src/modules/session_handler.rs
+++ b/relay/src/modules/session_handler.rs
@@ -75,50 +75,57 @@ impl SessionHandler {
                             continue;
                         }
                     };
-                    let session = async {
-                        connecting.await.inspect_err(|error| {
-                            tracing::warn!(%error, "failed to establish session");
-                        })
-                    }
-                    .instrument(session_span.clone())
-                    .await;
-                    let session = match session {
-                        Ok(session) => session,
-                        Err(_) => continue,
-                    };
-                    let session_add_span = tracing::info_span!(
-                        parent: &session_span,
-                        "relay.session_repository.add",
-                        session_id = session_id
-                    );
 
-                    async {
-                        tracing::info!("Session accepted");
-                        let mut repo = repo.lock().await;
-                        match accepted_peer.clone() {
-                            SessionPeer::Client => {
-                                repo.add_client(
-                                    session_id,
-                                    Box::new(session),
-                                    relay_session_event_sender.clone(),
-                                    session_span.clone(),
-                                )
-                                .await;
-                            }
-                            SessionPeer::Relay { relay_id } => {
-                                repo.add_relay(
-                                    session_id,
-                                    Box::new(session),
-                                    relay_session_event_sender.clone(),
-                                    session_span.clone(),
-                                    relay_id,
-                                )
-                                .await;
+                    // Spawn per connection so a slow ClientSetup cannot block the accept loop.
+                    let repo = repo.clone();
+                    let relay_session_event_sender = relay_session_event_sender.clone();
+                    let accepted_peer = accepted_peer.clone();
+                    tokio::spawn(async move {
+                        let session = async {
+                            connecting.await.inspect_err(|error| {
+                                tracing::warn!(%error, "failed to establish session");
+                            })
+                        }
+                        .instrument(session_span.clone())
+                        .await;
+                        let session = match session {
+                            Ok(session) => session,
+                            Err(_) => return,
+                        };
+                        let session_add_span = tracing::info_span!(
+                            parent: &session_span,
+                            "relay.session_repository.add",
+                            session_id = session_id
+                        );
+
+                        async {
+                            tracing::info!("Session accepted");
+                            let mut repo = repo.lock().await;
+                            match accepted_peer {
+                                SessionPeer::Client => {
+                                    repo.add_client(
+                                        session_id,
+                                        Box::new(session),
+                                        relay_session_event_sender.clone(),
+                                        session_span.clone(),
+                                    )
+                                    .await;
+                                }
+                                SessionPeer::Relay { relay_id } => {
+                                    repo.add_relay(
+                                        session_id,
+                                        Box::new(session),
+                                        relay_session_event_sender.clone(),
+                                        session_span.clone(),
+                                        relay_id,
+                                    )
+                                    .await;
+                                }
                             }
                         }
-                    }
-                    .instrument(session_add_span)
-                    .await;
+                        .instrument(session_add_span)
+                        .await;
+                    });
                 }
             })
             .unwrap()

--- a/relay/tests/concurrent_accept.rs
+++ b/relay/tests/concurrent_accept.rs
@@ -1,0 +1,83 @@
+//! Regression test for the serial accept-loop bug.
+//!
+//! The relay accept loop must not let a single client that completes the QUIC
+//! handshake but is slow to send its `ClientSetup` block the establishment of
+//! other, unrelated connections.
+
+use std::net::{SocketAddr, UdpSocket};
+use std::path::Path;
+use std::time::Duration;
+
+use moqt::{ClientConfig, Endpoint, QUIC};
+use rcgen::{CertifiedKey, generate_simple_self_signed};
+use relay::RelayServer;
+
+/// Grabs an ephemeral UDP port, then releases it so the relay can bind it.
+fn free_udp_port() -> u16 {
+    let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    socket.local_addr().unwrap().port()
+}
+
+/// Writes a fresh self-signed cert/key into `dir` so the test does not depend on
+/// the (gitignored) relay/keys artifacts. Returns (key_path, cert_path).
+fn generate_certs(dir: &Path) -> (String, String) {
+    let CertifiedKey { cert, signing_key } =
+        generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .unwrap();
+    std::fs::create_dir_all(dir).unwrap();
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+    std::fs::write(&cert_path, cert.pem()).unwrap();
+    std::fs::write(&key_path, signing_key.serialize_pem()).unwrap();
+    (
+        key_path.to_string_lossy().into_owned(),
+        cert_path.to_string_lossy().into_owned(),
+    )
+}
+
+fn client_endpoint() -> Endpoint<QUIC> {
+    Endpoint::<QUIC>::create_client(&ClientConfig {
+        port: 0,
+        verify_certificate: false,
+    })
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn slow_client_setup_does_not_block_new_connections() {
+    let port = free_udp_port();
+    let remote: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    let host = "127.0.0.1";
+
+    let cert_dir = std::env::temp_dir().join(format!("relay-concurrent-accept-{port}"));
+    let (key_path, cert_path) = generate_certs(&cert_dir);
+
+    let server = RelayServer::new(&key_path, &cert_path);
+    // Keep the handler alive for the duration of the test (Drop aborts it).
+    let _handler = server.spawn_client_transport::<QUIC>(port);
+
+    // Client A: complete the QUIC handshake, then hold the connection open
+    // without ever opening the control stream / sending ClientSetup. The
+    // returned `Connecting` future is intentionally NOT awaited.
+    let endpoint_a = client_endpoint();
+    let _connecting_a = endpoint_a
+        .connect(remote, host)
+        .await
+        .expect("client A QUIC handshake should succeed");
+
+    // Client B: a well-behaved client that should be able to fully establish a
+    // session even while A sits idle after its handshake.
+    let endpoint_b = client_endpoint();
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
+        endpoint_b.connect(remote, host).await?.await
+    })
+    .await;
+
+    match result {
+        Err(_) => panic!(
+            "client B timed out establishing a session; a slow client A blocked the accept loop"
+        ),
+        Ok(Err(e)) => panic!("client B failed to establish a session: {e:#}"),
+        Ok(Ok(_session)) => { /* success */ }
+    }
+}


### PR DESCRIPTION
## 概要

relay の接続受理ループが接続を**直列**に処理しており、QUIC handshake は完了したが `ClientSetup` の送信が遅い（または送らない）クライアントがいると、**後続の新規接続がブロックされて確立できない**（QUIC idle timeout）バグを修正します。

## 修正

`connecting.await` 以降（セッション確立〜repo 登録）を `tokio::spawn` に切り出し、accept ループは即座に次の `endpoint.accept()` に戻すようにしました。これにより複数接続の確立が並行に進みます。ロジックは同一で、実行される場所をループ本体からタスクへ移しただけです。

## テスト

`relay/tests/concurrent_accept.rs` に回帰テストを追加。

- クライアント A: QUIC handshake だけ完了させ、`ClientSetup` を送らず（`Connecting` を await しない）接続を保持
- クライアント B: 通常どおりセッション確立を試みる
- **A がアイドルでも B が確立できること**を検証（timeout 2s）

手元では media example（publisher/subscriber）でも問題が発生しないことを確認済みです。