### PR TITLE
ci: ピン留めアクションを node24 ランタイム版に更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -35,13 +36,16 @@ jobs:
         uses: ./.github/actions/setup-wasm-pack
 
       - name: Configure GitHub Pages
-        # actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b = v5.0.0
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+        # actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d = v6.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        # actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 = v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22
+          # no lockfile at repo root; opt out of the v5+ default auto-caching
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -62,8 +66,8 @@ jobs:
             .
 
       - name: Upload GitHub Pages artifact
-        # actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 = v4.6.2
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a = v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: github-pages
           path: ${{ runner.temp }}/artifact.tar
@@ -83,5 +87,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        # actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e = v4.0.5
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        # actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 = v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -267,8 +267,8 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Install wasm-pack
         uses: ./.github/actions/setup-wasm-pack
@@ -327,8 +327,8 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Install wasm-pack
         uses: ./.github/actions/setup-wasm-pack
@@ -411,8 +411,8 @@ jobs:
           toolchain: 1.96.0
 
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
@@ -474,8 +474,8 @@ jobs:
           toolchain: 1.96.0
 
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
@@ -537,8 +537,8 @@ jobs:
           toolchain: 1.96.0
 
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
@@ -600,8 +600,8 @@ jobs:
           toolchain: 1.96.0
 
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
@@ -663,8 +663,8 @@ jobs:
           toolchain: 1.96.0
 
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,8 +93,8 @@ jobs:
       relay_image_source: ${{ steps.filter.outputs.relay_image_source }}
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -212,8 +212,8 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -224,8 +224,8 @@ jobs:
         run: docker save moqt-relay:local-source | gzip > "${RUNNER_TEMP}/relay-image.tar.gz"
 
       - name: Upload relay image artifact
-        # actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 = v4.6.2
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a = v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: relay-image-local
           path: ${{ runner.temp }}/relay-image.tar.gz
@@ -246,14 +246,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        # actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 = v4.4.0
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        # actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 = v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22
           cache: npm
@@ -287,8 +287,8 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: failure()
-        # actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 = v4.6.2
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a = v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: media-e2e-artifacts
           path: |
@@ -306,14 +306,14 @@ jobs:
       packages: read
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        # actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 = v4.4.0
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        # actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 = v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22
           cache: npm
@@ -342,8 +342,8 @@ jobs:
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
-        # actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 = v4.3.0
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c = v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: relay-image-local
           path: ${{ runner.temp }}/relay-image
@@ -356,8 +356,8 @@ jobs:
 
       - name: Log in to GHCR
         if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
-        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 = v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -380,8 +380,8 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: failure()
-        # actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 = v4.6.2
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a = v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: call-e2e-artifacts
           path: |
@@ -399,8 +399,8 @@ jobs:
       packages: read
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -416,8 +416,8 @@ jobs:
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
-        # actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 = v4.3.0
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c = v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: relay-image-local
           path: ${{ runner.temp }}/relay-image
@@ -430,8 +430,8 @@ jobs:
 
       - name: Log in to GHCR
         if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
-        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 = v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -462,8 +462,8 @@ jobs:
       packages: read
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -479,8 +479,8 @@ jobs:
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
-        # actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 = v4.3.0
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c = v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: relay-image-local
           path: ${{ runner.temp }}/relay-image
@@ -493,8 +493,8 @@ jobs:
 
       - name: Log in to GHCR
         if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
-        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 = v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -525,8 +525,8 @@ jobs:
       packages: read
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -542,8 +542,8 @@ jobs:
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
-        # actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 = v4.3.0
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c = v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: relay-image-local
           path: ${{ runner.temp }}/relay-image
@@ -556,8 +556,8 @@ jobs:
 
       - name: Log in to GHCR
         if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
-        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 = v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -588,8 +588,8 @@ jobs:
       packages: read
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -605,8 +605,8 @@ jobs:
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
-        # actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 = v4.3.0
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c = v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: relay-image-local
           path: ${{ runner.temp }}/relay-image
@@ -619,8 +619,8 @@ jobs:
 
       - name: Log in to GHCR
         if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
-        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 = v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -651,8 +651,8 @@ jobs:
       packages: read
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -668,8 +668,8 @@ jobs:
 
       - name: Download local relay image
         if: ${{ needs.changes.outputs.relay_image_source == 'local' }}
-        # actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 = v4.3.0
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c = v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: relay-image-local
           path: ${{ runner.temp }}/relay-image
@@ -682,8 +682,8 @@ jobs:
 
       - name: Log in to GHCR
         if: ${{ needs.changes.outputs.relay_image_source == 'prebuilt' }}
-        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 = v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       - name: Install Clippy and Rustfmt
         run: |
           rustup component add clippy
@@ -83,8 +83,8 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache Rust build artifacts
-        # Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 = v2.9.1
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       - name: Install FFmpeg build dependencies
         uses: ./.github/actions/install-ffmpeg-deps
       - name: Generate code coverage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RUSTFLAGS: "--cfg=tokio_unstable --cfg=web_sys_unstable_apis"
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Cache Rust build artifacts
@@ -44,13 +44,13 @@ jobs:
       CARGO_AUDIT_VERSION: 0.22.2
       CARGO_HOME: /usr/local/cargo
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Cache cargo-audit binary
         id: cache-cargo-audit
-        # actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 = v4.3.0
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        # actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 = v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: /usr/local/cargo/bin/cargo-audit
           key: cargo-audit-${{ runner.os }}-rust-1.96.0-${{ env.CARGO_AUDIT_VERSION }}
@@ -79,7 +79,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Cache Rust build artifacts
@@ -91,7 +91,7 @@ jobs:
         run: |
           RUSTFLAGS="--cfg=web_sys_unstable_apis --cfg=tokio_unstable" cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
@@ -100,7 +100,7 @@ jobs:
     container:
       image: cimg/node:21.6.2@sha256:c95ae0b7d9bc23abf5dd8a7794c79ba480660f71f07ba9d5a95309d18644ac5d
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Install dependencies

--- a/.github/workflows/relay-image.yml
+++ b/.github/workflows/relay-image.yml
@@ -28,8 +28,8 @@ jobs:
       image: ${{ steps.meta.outputs.image }}
     steps:
       - name: Checkout repository
-        # actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 = v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -43,8 +43,8 @@ jobs:
           echo "image=ghcr.io/${repo}/relay:${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        # docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 = v3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 = v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,13 +62,13 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.exists.outputs.found == 'false'
-        # docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f = v3.12.0
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        # docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c = v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
       - name: Build and push relay image
         if: steps.exists.outputs.found == 'false'
-        # docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 = v6.19.2
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        # docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a = v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
           file: relay/Dockerfile


### PR DESCRIPTION
## 概要

GitHub Actions で Node.js 20 ランタイムが非推奨となり、`node20` を宣言するアクションが強制的に Node.js 24 で実行されるようになったため、ジョブごとに以下の warning が出ていました。

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24

ワークフローがピン留めしている各アクションを、`runs.using: node24` を宣言する最新リリースの SHA にピンし直します。各新 SHA の `action.yml` のランタイム宣言は GitHub API で確認済みです。

## 更新内容

| アクション | 旧 → 新 |
|---|---|
| `actions/checkout` | v4.3.1 / v3.6.0 (node16) → v7.0.0 |
| `actions/setup-node` | v4.4.0 → v7.0.0 |
| `actions/upload-artifact` | v4.6.2 → v7.0.1 |
| `actions/download-artifact` | v4.3.0 → v8.0.1 |
| `actions/cache` | v4.3.0 → v6.1.0 |
| `actions/configure-pages` | v5.0.0 → v6.0.0 |
| `actions/deploy-pages` | v4.0.5 → v5.0.0 |
| `docker/login-action` | v3.7.0 → v4.4.0 |
| `docker/setup-buildx-action` | v3.12.0 → v4.2.0 |
| `docker/build-push-action` | v6.19.2 → v7.3.0 |
| `codecov/codecov-action` | v4.6.0 → v7.0.0(composite 化のため Node ランタイム非依存) |

`Swatinem/rust-cache` は既に node24 対応版のため変更なし。`dtolnay/rust-toolchain` とローカル composite action は Node ランタイム非依存のため対象外です。

## 互換性

- codecov v7 でも使用中の入力 `token` / `fail_ci_if_error` は維持されていることを確認済み
- setup-node v5 以降は `package-manager-cache` がデフォルト有効になるため、ルートに lockfile が無い本リポジトリでは deploy.yml で明示的に無効化し、従来挙動を維持
- upload-artifact v7 / download-artifact v8 は相互互換のある現行世代同士
- コンテナジョブ(rust / tarpaulin / cimg/node)はいずれも glibc ベースのため node24 バイナリで動作可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## サプライチェーン検証

fork のコミットは upstream リポジトリの API 経由でも参照できてしまう(commit spoofing)ため、全ピン SHA について「公式リポジトリの refs は fork から偽装できない」性質を利用し、`git ls-remote` で各公式リポジトリのリリースタグの参照先コミットと突き合わせて一致を確認済みです。

この検証で、既存ピンの `Swatinem/rust-cache@e18b4977...` がコメント(v2.9.1)と異なり移動タグ `v2` の参照先(v2.9.1 直後の公式 master コミット)を指していたことが判明したため、監査性のため正式リリース v2.9.1 のタグが指すコミット `c1937114` にピンし直しました(どちらも node24 宣言)。
