### PR TITLE
fix(moqt): 制御メッセージのタイムアウトをリクエスト単位に閉じる

### DIFF
--- a/moqt/src/modules/moqt/control_plane/handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler.rs
@@ -2,6 +2,7 @@ pub mod fetch_handler;
 pub mod publish_handler;
 pub mod publish_namespace_done_handler;
 pub mod publish_namespace_handler;
+pub(crate) mod response_guard;
 pub mod subscribe_handler;
 pub mod subscribe_namespace_handler;
 pub mod unsubscribe_handler;

--- a/moqt/src/modules/moqt/control_plane/handler/fetch_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/fetch_handler.rs
@@ -1,18 +1,18 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::Arc;
 
 use crate::{
     GroupOrder, TransportProtocol,
     modules::{
         moqt::{
-            control_plane::control_messages::{
-                control_message_type::ControlMessageType,
-                messages::{
-                    fetch::Fetch, fetch_ok::FetchOk, parameters::location::Location,
-                    request_error::RequestError,
+            control_plane::{
+                control_messages::{
+                    control_message_type::ControlMessageType,
+                    messages::{
+                        fetch::Fetch, fetch_ok::FetchOk, parameters::location::Location,
+                        request_error::RequestError,
+                    },
                 },
+                handler::response_guard::ResponseGuard,
             },
             domains::session_context::SessionContext,
         },
@@ -20,28 +20,30 @@ use crate::{
     },
 };
 
-/// FETCH_ERROR code for endpoints that do not implement FETCH (draft-14 §9.18).
-const FETCH_ERROR_NOT_SUPPORTED: u64 = 0x3;
-
 #[derive(Debug, Clone)]
 pub struct FetchHandler<T: TransportProtocol> {
     session_context: Arc<SessionContext<T>>,
     pub request_id: u64,
     pub group_order: GroupOrder,
     pub fetch: Fetch,
-    responded: Arc<AtomicBool>,
+    guard: ResponseGuard<T>,
 }
 
 impl<T: TransportProtocol> FetchHandler<T> {
     pub(crate) fn new(session_context: Arc<SessionContext<T>>, fetch: Fetch) -> Self {
         let request_id = fetch.request_id;
         let group_order = fetch.group_order;
+        let guard = ResponseGuard::new(
+            session_context.clone(),
+            request_id,
+            ControlMessageType::FetchError,
+        );
         Self {
             session_context,
             request_id,
             group_order,
             fetch,
-            responded: Arc::new(AtomicBool::new(false)),
+            guard,
         }
     }
 
@@ -50,7 +52,7 @@ impl<T: TransportProtocol> FetchHandler<T> {
         end_of_track: bool,
         end_location: Location,
     ) -> Result<(), TransportSendError> {
-        self.responded.store(true, Ordering::Relaxed);
+        self.guard.mark_responded();
         let fetch_ok = FetchOk {
             request_id: self.request_id,
             group_order: self.group_order,
@@ -69,7 +71,7 @@ impl<T: TransportProtocol> FetchHandler<T> {
         error_code: u64,
         reason_phrase: String,
     ) -> Result<(), TransportSendError> {
-        self.responded.store(true, Ordering::Relaxed);
+        self.guard.mark_responded();
         let err = RequestError {
             request_id: self.request_id,
             error_code,
@@ -79,38 +81,5 @@ impl<T: TransportProtocol> FetchHandler<T> {
             .send_stream
             .send(ControlMessageType::FetchError, err.encode())
             .await
-    }
-}
-
-impl<T: TransportProtocol> Drop for FetchHandler<T> {
-    fn drop(&mut self) {
-        // An application that ignores SessionEvent::Fetch drops the handler
-        // without responding, which would leave the requester waiting for its
-        // control timeout. Auto-answer NOT_SUPPORTED so the failure is prompt
-        // and the peer's session is never at risk. strong_count == 1 limits
-        // this to the last clone; a single fire-and-forget send needs no
-        // owned JoinHandle.
-        if self.responded.load(Ordering::Relaxed) || Arc::strong_count(&self.responded) > 1 {
-            return;
-        }
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
-        let session_context = self.session_context.clone();
-        let request_id = self.request_id;
-        runtime.spawn(async move {
-            let err = RequestError {
-                request_id,
-                error_code: FETCH_ERROR_NOT_SUPPORTED,
-                reason_phrase: "fetch not handled by application".to_string(),
-            };
-            if let Err(error) = session_context
-                .send_stream
-                .send(ControlMessageType::FetchError, err.encode())
-                .await
-            {
-                tracing::warn!(?error, request_id, "failed to auto-reject unhandled fetch");
-            }
-        });
     }
 }

--- a/moqt/src/modules/moqt/control_plane/handler/publish_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/publish_handler.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use crate::{
     FilterType, GroupOrder, PublisherInitiatedSubscription, Subscription, TransportProtocol,
     modules::moqt::{
-        control_plane::control_messages::{
-            control_message_type::ControlMessageType,
-            messages::{
-                parameters::content_exists::ContentExists, publish::Publish, publish_ok::PublishOk,
-                request_error::RequestError,
+        control_plane::{
+            control_messages::{
+                control_message_type::ControlMessageType,
+                messages::{
+                    parameters::content_exists::ContentExists, publish::Publish,
+                    publish_ok::PublishOk, request_error::RequestError,
+                },
             },
+            handler::response_guard::ResponseGuard,
         },
         domains::session_context::SessionContext,
     },
@@ -28,12 +31,19 @@ pub struct PublishHandler<T: TransportProtocol> {
     pub authorization_token: Option<String>,
     pub max_cache_duration: Option<u64>,
     pub delivery_timeout: Option<u64>,
+    guard: ResponseGuard<T>,
 }
 
 impl<T: TransportProtocol> PublishHandler<T> {
     pub(crate) fn new(session_context: Arc<SessionContext<T>>, publish_message: Publish) -> Self {
+        let guard = ResponseGuard::new(
+            session_context.clone(),
+            publish_message.request_id,
+            ControlMessageType::PublishError,
+        );
         Self {
             session_context,
+            guard,
             request_id: publish_message.request_id,
             track_namespace: publish_message.track_namespace_tuple.join("/"),
             track_name: publish_message.track_name,
@@ -53,6 +63,7 @@ impl<T: TransportProtocol> PublishHandler<T> {
         filter_type: FilterType,
         expires: u64,
     ) -> Result<Subscription, TransportSendError> {
+        self.guard.mark_responded();
         let publish_ok = PublishOk {
             request_id: self.request_id,
             forward: self.forward,
@@ -110,6 +121,7 @@ impl<T: TransportProtocol> PublishHandler<T> {
         error_code: u64,
         reason_phrase: String,
     ) -> Result<(), TransportSendError> {
+        self.guard.mark_responded();
         let err = RequestError {
             // TODO: assign correct request id.
             request_id: self.request_id,

--- a/moqt/src/modules/moqt/control_plane/handler/publish_namespace_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/publish_namespace_handler.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use crate::{
     TransportProtocol,
     modules::moqt::{
-        control_plane::control_messages::{
-            control_message_type::ControlMessageType,
-            messages::{
-                namespace_ok::NamespaceOk, publish_namespace::PublishNamespace,
-                request_error::RequestError,
+        control_plane::{
+            control_messages::{
+                control_message_type::ControlMessageType,
+                messages::{
+                    namespace_ok::NamespaceOk, publish_namespace::PublishNamespace,
+                    request_error::RequestError,
+                },
             },
+            handler::response_guard::ResponseGuard,
         },
         domains::session_context::SessionContext,
     },
@@ -21,6 +24,7 @@ pub struct PublishNamespaceHandler<T: TransportProtocol> {
     request_id: u64,
     pub track_namespace: String,
     pub authorization_token: Option<String>,
+    guard: ResponseGuard<T>,
 }
 
 impl<T: TransportProtocol> PublishNamespaceHandler<T> {
@@ -28,8 +32,14 @@ impl<T: TransportProtocol> PublishNamespaceHandler<T> {
         session_context: Arc<SessionContext<T>>,
         publish_namespace: PublishNamespace,
     ) -> Self {
+        let guard = ResponseGuard::new(
+            session_context.clone(),
+            publish_namespace.request_id,
+            ControlMessageType::PublishNamespaceError,
+        );
         Self {
             session_context,
+            guard,
             request_id: publish_namespace.request_id,
             track_namespace: publish_namespace.track_namespace.join("/"),
             authorization_token: None,
@@ -37,6 +47,7 @@ impl<T: TransportProtocol> PublishNamespaceHandler<T> {
     }
 
     pub async fn ok(&self) -> Result<(), TransportSendError> {
+        self.guard.mark_responded();
         let publish_namespace_ok = NamespaceOk {
             request_id: self.request_id,
         };
@@ -54,6 +65,7 @@ impl<T: TransportProtocol> PublishNamespaceHandler<T> {
         error_code: u64,
         reason_phrase: String,
     ) -> Result<(), TransportSendError> {
+        self.guard.mark_responded();
         let err = RequestError {
             request_id: self.request_id,
             error_code,

--- a/moqt/src/modules/moqt/control_plane/handler/response_guard.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/response_guard.rs
@@ -1,0 +1,84 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use crate::{
+    TransportProtocol,
+    modules::moqt::{
+        control_plane::control_messages::{
+            control_message_type::ControlMessageType, messages::request_error::RequestError,
+        },
+        domains::session_context::SessionContext,
+    },
+};
+
+/// NOT_SUPPORTED shares the code 0x3 across every *_ERROR message
+/// (draft-14 §13.1).
+const ERROR_NOT_SUPPORTED: u64 = 0x3;
+
+/// Auto-answers a request with `error_type` NOT_SUPPORTED when the last
+/// handler clone is dropped without responding. An application that ignores
+/// the session event would otherwise leave the requester waiting for its
+/// control timeout.
+#[derive(Debug, Clone)]
+pub(crate) struct ResponseGuard<T: TransportProtocol> {
+    session_context: Arc<SessionContext<T>>,
+    request_id: u64,
+    error_type: ControlMessageType,
+    responded: Arc<AtomicBool>,
+}
+
+impl<T: TransportProtocol> ResponseGuard<T> {
+    pub(crate) fn new(
+        session_context: Arc<SessionContext<T>>,
+        request_id: u64,
+        error_type: ControlMessageType,
+    ) -> Self {
+        Self {
+            session_context,
+            request_id,
+            error_type,
+            responded: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub(crate) fn mark_responded(&self) {
+        self.responded.store(true, Ordering::Relaxed);
+    }
+}
+
+impl<T: TransportProtocol> Drop for ResponseGuard<T> {
+    fn drop(&mut self) {
+        // strong_count == 1 limits this to the last clone; a single
+        // fire-and-forget send needs no owned JoinHandle.
+        if self.responded.load(Ordering::Relaxed) || Arc::strong_count(&self.responded) > 1 {
+            return;
+        }
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let session_context = self.session_context.clone();
+        let request_id = self.request_id;
+        let error_type = self.error_type;
+        runtime.spawn(async move {
+            let err = RequestError {
+                request_id,
+                error_code: ERROR_NOT_SUPPORTED,
+                reason_phrase: "request not handled by application".to_string(),
+            };
+            if let Err(error) = session_context
+                .send_stream
+                .send(error_type, err.encode())
+                .await
+            {
+                tracing::warn!(
+                    ?error,
+                    request_id,
+                    ?error_type,
+                    "failed to auto-reject unhandled request"
+                );
+            }
+        });
+    }
+}

--- a/moqt/src/modules/moqt/control_plane/handler/subscribe_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/subscribe_handler.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use crate::{
     FilterType, GroupOrder, SubscriberInitiatedSubscription, Subscription, TransportProtocol,
     modules::moqt::{
-        control_plane::control_messages::{
-            control_message_type::ControlMessageType,
-            messages::{
-                parameters::content_exists::ContentExists, request_error::RequestError,
-                subscribe::Subscribe, subscribe_ok::SubscribeOk,
+        control_plane::{
+            control_messages::{
+                control_message_type::ControlMessageType,
+                messages::{
+                    parameters::content_exists::ContentExists, request_error::RequestError,
+                    subscribe::Subscribe, subscribe_ok::SubscribeOk,
+                },
             },
+            handler::response_guard::ResponseGuard,
         },
         domains::session_context::SessionContext,
     },
@@ -28,6 +31,7 @@ pub struct SubscribeHandler<T: TransportProtocol> {
     pub authorization_token: Option<String>,
     pub max_cache_duration: Option<u64>,
     pub delivery_timeout: Option<u64>,
+    guard: ResponseGuard<T>,
 }
 
 impl<T: TransportProtocol> SubscribeHandler<T> {
@@ -35,8 +39,14 @@ impl<T: TransportProtocol> SubscribeHandler<T> {
         session_context: Arc<SessionContext<T>>,
         subscribe_message: Subscribe,
     ) -> Self {
+        let guard = ResponseGuard::new(
+            session_context.clone(),
+            subscribe_message.request_id,
+            ControlMessageType::SubscribeError,
+        );
         Self {
             session_context,
+            guard,
             request_id: subscribe_message.request_id,
             track_namespace: subscribe_message.track_namespace.join("/"),
             track_name: subscribe_message.track_name,
@@ -67,6 +77,7 @@ impl<T: TransportProtocol> SubscribeHandler<T> {
         expires: u64,
         content_exists: ContentExists,
     ) -> Result<(), TransportSendError> {
+        self.guard.mark_responded();
         let subscribe_ok = SubscribeOk {
             request_id: self.request_id,
             track_alias,
@@ -92,6 +103,7 @@ impl<T: TransportProtocol> SubscribeHandler<T> {
         error_code: u64,
         reason_phrase: String,
     ) -> Result<(), TransportSendError> {
+        self.guard.mark_responded();
         let err = RequestError {
             // TODO: assign correct request id.
             request_id: self.request_id,

--- a/moqt/src/modules/moqt/control_plane/handler/subscribe_namespace_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/subscribe_namespace_handler.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use crate::{
     TransportProtocol,
     modules::moqt::{
-        control_plane::control_messages::{
-            control_message_type::ControlMessageType,
-            messages::{
-                namespace_ok::NamespaceOk, request_error::RequestError,
-                subscribe_namespace::SubscribeNamespace,
+        control_plane::{
+            control_messages::{
+                control_message_type::ControlMessageType,
+                messages::{
+                    namespace_ok::NamespaceOk, request_error::RequestError,
+                    subscribe_namespace::SubscribeNamespace,
+                },
             },
+            handler::response_guard::ResponseGuard,
         },
         domains::session_context::SessionContext,
     },
@@ -21,6 +24,7 @@ pub struct SubscribeNamespaceHandler<T: TransportProtocol> {
     request_id: u64,
     pub track_namespace_prefix: String,
     pub authorization_token: Option<String>,
+    guard: ResponseGuard<T>,
 }
 
 impl<T: TransportProtocol> SubscribeNamespaceHandler<T> {
@@ -28,8 +32,14 @@ impl<T: TransportProtocol> SubscribeNamespaceHandler<T> {
         session_context: Arc<SessionContext<T>>,
         subscribe_namespace: SubscribeNamespace,
     ) -> Self {
+        let guard = ResponseGuard::new(
+            session_context.clone(),
+            subscribe_namespace.request_id,
+            ControlMessageType::SubscribeNamespaceError,
+        );
         Self {
             session_context,
+            guard,
             request_id: subscribe_namespace.request_id,
             track_namespace_prefix: subscribe_namespace.track_namespace_prefix.join("/"),
             authorization_token: None,
@@ -37,6 +47,7 @@ impl<T: TransportProtocol> SubscribeNamespaceHandler<T> {
     }
 
     pub async fn ok(&self) -> Result<(), TransportSendError> {
+        self.guard.mark_responded();
         let publish_namespace_ok = NamespaceOk {
             request_id: self.request_id,
         };
@@ -55,6 +66,7 @@ impl<T: TransportProtocol> SubscribeNamespaceHandler<T> {
         error_code: u64,
         reason_phrase: String,
     ) -> Result<(), TransportSendError> {
+        self.guard.mark_responded();
         let err = RequestError {
             request_id: self.request_id,
             error_code,

--- a/moqt/src/modules/moqt/domains/publisher.rs
+++ b/moqt/src/modules/moqt/domains/publisher.rs
@@ -26,7 +26,7 @@ use crate::{
                 },
             },
             domains::{
-                session_context::{LateResponseCleanup, SessionContext},
+                session_context::{LateResponseAction, SessionContext},
                 subscription::{PublisherInitiatedSubscription, Subscription},
             },
             protocol::TransportProtocol,
@@ -54,7 +54,7 @@ impl<T: TransportProtocol> Publisher<T> {
         let _registered_sender = self.session.register_response_sender(
             request_id,
             sender,
-            LateResponseCleanup::PublishNamespaceDone {
+            LateResponseAction::PublishNamespaceDone {
                 namespace: vec_namespace.clone(),
             },
         );
@@ -114,11 +114,11 @@ impl<T: TransportProtocol> Publisher<T> {
         let (sender, receiver) = tokio::sync::oneshot::channel::<ResponseMessage>();
         let request_id = self.session.get_request_id();
         // A late PUBLISH_OK is discarded: the peer keeps subscription state
-        // but receives no objects; see LateResponseCleanup::Discard for why
+        // but receives no objects; see LateResponseAction::Discard for why
         // no PUBLISH_DONE is sent yet.
         let _registered_sender =
             self.session
-                .register_response_sender(request_id, sender, LateResponseCleanup::Discard);
+                .register_response_sender(request_id, sender, LateResponseAction::Discard);
         let content_exists = option.content_exists;
         let publish = Publish {
             request_id,

--- a/moqt/src/modules/moqt/domains/publisher.rs
+++ b/moqt/src/modules/moqt/domains/publisher.rs
@@ -66,7 +66,7 @@ impl<T: TransportProtocol> Publisher<T> {
                 publish_namespace.encode(),
             )
             .await?;
-        let response = self.session.await_request_response(receiver).await?;
+        let response = self.session.await_response(receiver).await?;
         match response {
             ResponseMessage::PublishNamespaceOk(response_request_id) => {
                 if request_id != response_request_id {
@@ -137,7 +137,7 @@ impl<T: TransportProtocol> Publisher<T> {
             .send_stream
             .send(ControlMessageType::Publish, bytes)
             .await?;
-        let response = self.session.await_request_response(receiver).await?;
+        let response = self.session.await_response(receiver).await?;
         match response {
             ResponseMessage::PublishOk(message) => {
                 if request_id != message.request_id {

--- a/moqt/src/modules/moqt/domains/publisher.rs
+++ b/moqt/src/modules/moqt/domains/publisher.rs
@@ -26,13 +26,14 @@ use crate::{
                 },
             },
             domains::{
-                session_context::SessionContext,
+                session_context::{LateResponseCleanup, SessionContext},
                 subscription::{PublisherInitiatedSubscription, Subscription},
             },
             protocol::TransportProtocol,
         },
         transport::transport_connection::TransportConnection,
     },
+    wire::RequestError,
 };
 
 pub struct Publisher<T: TransportProtocol> {
@@ -47,10 +48,16 @@ impl<T: TransportProtocol> Publisher<T> {
     }
 
     pub async fn publish_namespace(&self, namespace: String) -> anyhow::Result<()> {
-        let vec_namespace = namespace.split('/').map(|s| s.to_string()).collect();
+        let vec_namespace: Vec<String> = namespace.split('/').map(|s| s.to_string()).collect();
         let (sender, receiver) = tokio::sync::oneshot::channel::<ResponseMessage>();
         let request_id = self.session.get_request_id();
-        let _registered_sender = self.session.register_response_sender(request_id, sender);
+        let _registered_sender = self.session.register_response_sender(
+            request_id,
+            sender,
+            LateResponseCleanup::PublishNamespaceDone {
+                namespace: vec_namespace.clone(),
+            },
+        );
         let publish_namespace = PublishNamespace::new(request_id, vec_namespace, vec![]);
         self.session
             .send_stream
@@ -59,7 +66,7 @@ impl<T: TransportProtocol> Publisher<T> {
                 publish_namespace.encode(),
             )
             .await?;
-        let response = self.session.await_response(receiver).await?;
+        let response = self.session.await_request_response(receiver).await?;
         match response {
             ResponseMessage::PublishNamespaceOk(response_request_id) => {
                 if request_id != response_request_id {
@@ -68,8 +75,13 @@ impl<T: TransportProtocol> Publisher<T> {
                     Ok(())
                 }
             }
-            ResponseMessage::PublishNamespaceError(_, _, _) => {
-                bail!("Publish namespace error")
+            ResponseMessage::PublishNamespaceError(request_id, error_code, reason_phrase) => {
+                Err(RequestError {
+                    request_id,
+                    error_code,
+                    reason_phrase,
+                }
+                .into())
             }
             _ => bail!("Protocol violation"),
         }
@@ -101,7 +113,12 @@ impl<T: TransportProtocol> Publisher<T> {
         let vec_namespace = track_namespace.split('/').map(|s| s.to_string()).collect();
         let (sender, receiver) = tokio::sync::oneshot::channel::<ResponseMessage>();
         let request_id = self.session.get_request_id();
-        let _registered_sender = self.session.register_response_sender(request_id, sender);
+        // A late PUBLISH_OK is discarded: the peer keeps subscription state
+        // but receives no objects; see LateResponseCleanup::Discard for why
+        // no PUBLISH_DONE is sent yet.
+        let _registered_sender =
+            self.session
+                .register_response_sender(request_id, sender, LateResponseCleanup::Discard);
         let content_exists = option.content_exists;
         let publish = Publish {
             request_id,
@@ -120,7 +137,7 @@ impl<T: TransportProtocol> Publisher<T> {
             .send_stream
             .send(ControlMessageType::Publish, bytes)
             .await?;
-        let response = self.session.await_response(receiver).await?;
+        let response = self.session.await_request_response(receiver).await?;
         match response {
             ResponseMessage::PublishOk(message) => {
                 if request_id != message.request_id {
@@ -138,9 +155,14 @@ impl<T: TransportProtocol> Publisher<T> {
                     ))
                 }
             }
-            ResponseMessage::PublishError(_, _, _) => {
+            ResponseMessage::PublishError(request_id, error_code, reason_phrase) => {
                 tracing::info!("Publish error");
-                bail!("Publish error")
+                Err(RequestError {
+                    request_id,
+                    error_code,
+                    reason_phrase,
+                }
+                .into())
             }
             _ => bail!("Protocol violation"),
         }

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -26,7 +26,9 @@ use crate::{
             data_plane::stream::bi_stream_sender::BiStreamSender,
             runtime::dispatch::incoming_object::IncomingObject,
         },
-        transport::transport_connection::TransportConnection,
+        transport::{
+            transport_connection::TransportConnection, transport_send_stream::TransportSendError,
+        },
     },
 };
 
@@ -292,60 +294,57 @@ impl<T: TransportProtocol> SessionContext<T> {
         action: LateResponseAction,
         response: ResponseMessage,
     ) {
-        // The action fires only for the success response it was registered
-        // for: an error response leaves no peer state to withdraw, and a
-        // mismatched response type must not trigger a blind withdrawal.
-        let send_result = match (&action, &response) {
-            (LateResponseAction::Unsubscribe, ResponseMessage::SubscribeOk(_)) => {
-                tracing::warn!(
-                    request_id,
-                    "SUBSCRIBE_OK arrived after the request was abandoned; sending UNSUBSCRIBE"
-                );
-                self.send_stream
-                    .send(
-                        ControlMessageType::UnSubscribe,
-                        Unsubscribe { request_id }.encode(),
-                    )
-                    .await
-            }
-            (
-                LateResponseAction::UnsubscribeNamespace { namespace },
-                ResponseMessage::SubscribeNameSpaceOk(_),
-            ) => {
-                tracing::warn!(
-                    request_id,
-                    "SUBSCRIBE_NAMESPACE_OK arrived after the request was abandoned; sending UNSUBSCRIBE_NAMESPACE"
-                );
-                self.send_stream
-                    .send(
-                        ControlMessageType::UnSubscribeNamespace,
-                        UnsubscribeNamespace::new(namespace.clone()).encode(),
-                    )
-                    .await
-            }
-            (
-                LateResponseAction::PublishNamespaceDone { namespace },
-                ResponseMessage::PublishNamespaceOk(_),
-            ) => {
-                tracing::warn!(
-                    request_id,
-                    "PUBLISH_NAMESPACE_OK arrived after the request was abandoned; sending PUBLISH_NAMESPACE_DONE"
-                );
-                self.send_stream
-                    .send(
-                        ControlMessageType::PublishNamespaceDone,
-                        PublishNamespaceDone::new(namespace.clone()).encode(),
-                    )
-                    .await
-            }
-            _ => {
-                tracing::warn!(
-                    request_id,
-                    ?response,
-                    "discarding response that arrived after the request was abandoned"
-                );
-                Ok(())
-            }
+        // A withdrawal is sent only when the success response matches the
+        // action registered for this request: an error response leaves no
+        // peer state to withdraw, and a mismatched response type must not
+        // trigger a blind withdrawal.
+        let send_result = match &response {
+            ResponseMessage::SubscribeOk(_) => match &action {
+                LateResponseAction::Unsubscribe => {
+                    tracing::warn!(
+                        request_id,
+                        "SUBSCRIBE_OK arrived after the request was abandoned; sending UNSUBSCRIBE"
+                    );
+                    self.send_stream
+                        .send(
+                            ControlMessageType::UnSubscribe,
+                            Unsubscribe { request_id }.encode(),
+                        )
+                        .await
+                }
+                _ => Self::discard_late_response(request_id, &response),
+            },
+            ResponseMessage::SubscribeNameSpaceOk(_) => match &action {
+                LateResponseAction::UnsubscribeNamespace { namespace } => {
+                    tracing::warn!(
+                        request_id,
+                        "SUBSCRIBE_NAMESPACE_OK arrived after the request was abandoned; sending UNSUBSCRIBE_NAMESPACE"
+                    );
+                    self.send_stream
+                        .send(
+                            ControlMessageType::UnSubscribeNamespace,
+                            UnsubscribeNamespace::new(namespace.clone()).encode(),
+                        )
+                        .await
+                }
+                _ => Self::discard_late_response(request_id, &response),
+            },
+            ResponseMessage::PublishNamespaceOk(_) => match &action {
+                LateResponseAction::PublishNamespaceDone { namespace } => {
+                    tracing::warn!(
+                        request_id,
+                        "PUBLISH_NAMESPACE_OK arrived after the request was abandoned; sending PUBLISH_NAMESPACE_DONE"
+                    );
+                    self.send_stream
+                        .send(
+                            ControlMessageType::PublishNamespaceDone,
+                            PublishNamespaceDone::new(namespace.clone()).encode(),
+                        )
+                        .await
+                }
+                _ => Self::discard_late_response(request_id, &response),
+            },
+            _ => Self::discard_late_response(request_id, &response),
         };
         if let Err(error) = send_result {
             tracing::warn!(
@@ -354,6 +353,20 @@ impl<T: TransportProtocol> SessionContext<T> {
                 "failed to withdraw an abandoned request"
             );
         }
+    }
+
+    /// Nothing to withdraw (late error, or a response that does not match
+    /// the registered action): log and drop the response.
+    fn discard_late_response(
+        request_id: RequestId,
+        response: &ResponseMessage,
+    ) -> Result<(), TransportSendError> {
+        tracing::warn!(
+            request_id,
+            ?response,
+            "discarding response that arrived after the request was abandoned"
+        );
+        Ok(())
     }
 
     pub(crate) fn close_with_error(&self, code: TerminationErrorCode, reason: &str) {

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -287,17 +287,15 @@ impl<T: TransportProtocol> SessionContext<T> {
     /// Handles a response that arrived after the caller abandoned the request.
     /// A success response means the peer holds state (subscription, namespace
     /// interest, ...) nobody on this side will consume, so send the matching
-    /// withdrawal; error responses are simply discarded.
+    /// withdrawal. A success response whose type does not match the request
+    /// is a protocol violation and closes the session; error responses are
+    /// simply discarded.
     pub(crate) async fn handle_late_response(
         &self,
         request_id: RequestId,
         action: LateResponseAction,
         response: ResponseMessage,
     ) {
-        // A withdrawal is sent only when the success response matches the
-        // action registered for this request: an error response leaves no
-        // peer state to withdraw, and a mismatched response type must not
-        // trigger a blind withdrawal.
         let send_result = match &response {
             ResponseMessage::SubscribeOk(_) => match &action {
                 LateResponseAction::Unsubscribe => {
@@ -312,7 +310,7 @@ impl<T: TransportProtocol> SessionContext<T> {
                         )
                         .await
                 }
-                _ => Self::discard_late_response(request_id, &response),
+                _ => self.close_on_mismatched_late_response(request_id, &response),
             },
             ResponseMessage::SubscribeNameSpaceOk(_) => match &action {
                 LateResponseAction::UnsubscribeNamespace { namespace } => {
@@ -327,7 +325,7 @@ impl<T: TransportProtocol> SessionContext<T> {
                         )
                         .await
                 }
-                _ => Self::discard_late_response(request_id, &response),
+                _ => self.close_on_mismatched_late_response(request_id, &response),
             },
             ResponseMessage::PublishNamespaceOk(_) => match &action {
                 LateResponseAction::PublishNamespaceDone { namespace } => {
@@ -342,8 +340,12 @@ impl<T: TransportProtocol> SessionContext<T> {
                         )
                         .await
                 }
-                _ => Self::discard_late_response(request_id, &response),
+                _ => self.close_on_mismatched_late_response(request_id, &response),
             },
+            // Late error responses, and late FETCH_OK / PUBLISH_OK for
+            // requests registered with `Discard`. FETCH_OK / PUBLISH_OK for
+            // a request of another kind is not detected here: `Discard` does
+            // not record which request kind it was registered for.
             _ => Self::discard_late_response(request_id, &response),
         };
         if let Err(error) = send_result {
@@ -355,8 +357,8 @@ impl<T: TransportProtocol> SessionContext<T> {
         }
     }
 
-    /// Nothing to withdraw (late error, or a response that does not match
-    /// the registered action): log and drop the response.
+    /// Nothing to withdraw (late error, or a `Discard` action): log and drop
+    /// the response.
     fn discard_late_response(
         request_id: RequestId,
         response: &ResponseMessage,
@@ -365,6 +367,26 @@ impl<T: TransportProtocol> SessionContext<T> {
             request_id,
             ?response,
             "discarding response that arrived after the request was abandoned"
+        );
+        Ok(())
+    }
+
+    /// A success response whose type does not correspond to the request it
+    /// answers means the peer's request-id bookkeeping cannot be trusted, so
+    /// close the session instead of guessing a withdrawal.
+    fn close_on_mismatched_late_response(
+        &self,
+        request_id: RequestId,
+        response: &ResponseMessage,
+    ) -> Result<(), TransportSendError> {
+        tracing::error!(
+            request_id,
+            ?response,
+            "Protocol violation: response type does not match the request; closing session"
+        );
+        self.close_with_error(
+            TerminationErrorCode::ProtocolViolation,
+            "response type does not match the request",
         );
         Ok(())
     }

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -32,7 +32,7 @@ use crate::{
 
 const CONTROL_MESSAGE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Returned by [`SessionContext::await_request_response`] when the peer does
+/// Returned by [`SessionContext::await_response`] when the peer does
 /// not answer in time. Callers map this to a per-request failure (e.g.
 /// FETCH_ERROR TIMEOUT) and keep the session open.
 #[derive(Debug)]
@@ -271,7 +271,7 @@ impl<T: TransportProtocol> SessionContext<T> {
     /// by the caller dropping its pending request state on the error path;
     /// the `sender_map` entry stays behind as `Abandoned` so a late response
     /// is withdrawn instead of closing the session.
-    pub(crate) async fn await_request_response(
+    pub(crate) async fn await_response(
         &self,
         receiver: tokio::sync::oneshot::Receiver<ResponseMessage>,
     ) -> anyhow::Result<ResponseMessage> {

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -292,6 +292,9 @@ impl<T: TransportProtocol> SessionContext<T> {
         action: LateResponseAction,
         response: ResponseMessage,
     ) {
+        // The action fires only for the success response it was registered
+        // for: an error response leaves no peer state to withdraw, and a
+        // mismatched response type must not trigger a blind withdrawal.
         let send_result = match (&action, &response) {
             (LateResponseAction::Unsubscribe, ResponseMessage::SubscribeOk(_)) => {
                 tracing::warn!(

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -69,7 +69,7 @@ pub(crate) enum LateResponseCleanup {
 /// until the response arrives, even after the caller stops waiting, so a
 /// late response is answered with a withdrawal instead of being mistaken
 /// for an unknown Request ID (which must close the session, §9.1).
-pub(crate) enum PendingRequest {
+pub(crate) enum InflightRequest {
     Waiting {
         sender: tokio::sync::oneshot::Sender<ResponseMessage>,
         on_late_response: LateResponseCleanup,
@@ -83,7 +83,7 @@ pub(crate) struct SessionContext<T: TransportProtocol> {
     request_id: AtomicU64,
     track_alias: AtomicU64,
     pub(crate) event_sender: tokio::sync::mpsc::UnboundedSender<SessionEvent<T>>,
-    pub(crate) sender_map: std::sync::Mutex<HashMap<RequestId, PendingRequest>>,
+    pub(crate) sender_map: std::sync::Mutex<HashMap<RequestId, InflightRequest>>,
     pub(crate) receiver_map:
         tokio::sync::Mutex<HashMap<u64, tokio::sync::mpsc::UnboundedReceiver<IncomingObject<T>>>>,
     object_sinks: tokio::sync::Mutex<HashMap<u64, ObjectSink<T>>>,
@@ -128,12 +128,12 @@ impl<T: TransportProtocol> Drop for RegisteredSender<T> {
     fn drop(&mut self) {
         if let Ok(mut requests) = self.session.sender_map.lock()
             && let Some(entry) = requests.get_mut(&self.request_id)
-            && let PendingRequest::Waiting {
+            && let InflightRequest::Waiting {
                 on_late_response, ..
             } = entry
         {
             let cleanup = std::mem::replace(on_late_response, LateResponseCleanup::Discard);
-            *entry = PendingRequest::Abandoned(cleanup);
+            *entry = InflightRequest::Abandoned(cleanup);
         }
     }
 }
@@ -183,7 +183,7 @@ impl<T: TransportProtocol> SessionContext<T> {
     ) -> RegisteredSender<T> {
         self.sender_map.lock().expect("sender_map poisoned").insert(
             request_id,
-            PendingRequest::Waiting {
+            InflightRequest::Waiting {
                 sender,
                 on_late_response,
             },

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -14,6 +14,13 @@ use crate::{
         moqt::{
             control_plane::{
                 constants::TerminationErrorCode,
+                control_messages::{
+                    control_message_type::ControlMessageType,
+                    messages::{
+                        publish_namespace_done::PublishNamespaceDone, unsubscribe::Unsubscribe,
+                        unsubscribe_namespace::UnsubscribeNamespace,
+                    },
+                },
                 enums::{RequestId, ResponseMessage},
             },
             data_plane::stream::bi_stream_sender::BiStreamSender,
@@ -39,14 +46,44 @@ impl fmt::Display for RequestTimeoutError {
 
 impl std::error::Error for RequestTimeoutError {}
 
+/// How to withdraw a request whose success response arrives after the caller
+/// stopped waiting (timeout or cancellation). Late error responses never need
+/// a withdrawal and are always discarded.
+#[derive(Debug)]
+pub(crate) enum LateResponseCleanup {
+    /// Discard the late response without a withdrawal message.
+    ///
+    /// FIXME: PUBLISH and FETCH should withdraw with PUBLISH_DONE /
+    /// FETCH_CANCEL, but decoding those messages is still `todo!()`, so
+    /// sending them would crash a peer running this crate.
+    Discard,
+    /// A late SUBSCRIBE_OK established a subscription nobody consumes.
+    Unsubscribe,
+    /// A late SUBSCRIBE_NAMESPACE_OK registered an unwanted namespace interest.
+    UnsubscribeNamespace { namespace: Vec<String> },
+    /// A late PUBLISH_NAMESPACE_OK accepted an announcement we gave up on.
+    PublishNamespaceDone { namespace: Vec<String> },
+}
+
+/// A request awaiting its response on this session. Kept in `sender_map`
+/// until the response arrives, even after the caller stops waiting, so a
+/// late response is answered with a withdrawal instead of being mistaken
+/// for an unknown Request ID (which must close the session, §9.1).
+pub(crate) enum PendingRequest {
+    Waiting {
+        sender: tokio::sync::oneshot::Sender<ResponseMessage>,
+        on_late_response: LateResponseCleanup,
+    },
+    Abandoned(LateResponseCleanup),
+}
+
 pub(crate) struct SessionContext<T: TransportProtocol> {
     pub(crate) transport_connection: T::Connection,
     pub(crate) send_stream: BiStreamSender<T>,
     request_id: AtomicU64,
     track_alias: AtomicU64,
     pub(crate) event_sender: tokio::sync::mpsc::UnboundedSender<SessionEvent<T>>,
-    pub(crate) sender_map:
-        std::sync::Mutex<HashMap<RequestId, tokio::sync::oneshot::Sender<ResponseMessage>>>,
+    pub(crate) sender_map: std::sync::Mutex<HashMap<RequestId, PendingRequest>>,
     pub(crate) receiver_map:
         tokio::sync::Mutex<HashMap<u64, tokio::sync::mpsc::UnboundedReceiver<IncomingObject<T>>>>,
     object_sinks: tokio::sync::Mutex<HashMap<u64, ObjectSink<T>>>,
@@ -77,9 +114,11 @@ pub(crate) enum IncomingObjectNotification {
     ReceiverClosed,
 }
 
-/// Holds the `sender_map` registration for an in-flight request. Removes the
-/// entry on drop, so a cancelled request does not leave an orphaned sender behind.
-#[must_use = "dropping this removes the sender from sender_map; bind it for the lifetime of the request"]
+/// Holds the `sender_map` registration for an in-flight request. On drop, a
+/// still-waiting entry is downgraded to `Abandoned` (not removed): the caller
+/// gave up, but a late response must still find the entry so it triggers the
+/// registered cleanup instead of a session close.
+#[must_use = "dropping this abandons the request in sender_map; bind it for the lifetime of the request"]
 pub(crate) struct RegisteredSender<T: TransportProtocol> {
     session: Arc<SessionContext<T>>,
     request_id: RequestId,
@@ -87,8 +126,14 @@ pub(crate) struct RegisteredSender<T: TransportProtocol> {
 
 impl<T: TransportProtocol> Drop for RegisteredSender<T> {
     fn drop(&mut self) {
-        if let Ok(mut senders) = self.session.sender_map.lock() {
-            senders.remove(&self.request_id);
+        if let Ok(mut requests) = self.session.sender_map.lock()
+            && let Some(entry) = requests.get_mut(&self.request_id)
+            && let PendingRequest::Waiting {
+                on_late_response, ..
+            } = entry
+        {
+            let cleanup = std::mem::replace(on_late_response, LateResponseCleanup::Discard);
+            *entry = PendingRequest::Abandoned(cleanup);
         }
     }
 }
@@ -127,17 +172,22 @@ impl<T: TransportProtocol> SessionContext<T> {
         track_alias
     }
 
-    /// Inserts the sender into `sender_map` and returns a `RegisteredSender` that
-    /// removes it on drop, ensuring cleanup on both normal completion and cancellation.
+    /// Inserts the sender into `sender_map` and returns a `RegisteredSender`
+    /// that marks the request abandoned on drop. `on_late_response` is the
+    /// withdrawal to send if a success response arrives after abandonment.
     pub(crate) fn register_response_sender(
         self: &Arc<Self>,
         request_id: RequestId,
         sender: tokio::sync::oneshot::Sender<ResponseMessage>,
+        on_late_response: LateResponseCleanup,
     ) -> RegisteredSender<T> {
-        self.sender_map
-            .lock()
-            .expect("sender_map poisoned")
-            .insert(request_id, sender);
+        self.sender_map.lock().expect("sender_map poisoned").insert(
+            request_id,
+            PendingRequest::Waiting {
+                sender,
+                on_late_response,
+            },
+        );
         RegisteredSender {
             session: self.clone(),
             request_id,
@@ -213,39 +263,14 @@ impl<T: TransportProtocol> SessionContext<T> {
         Ok(())
     }
 
-    /// Awaits a response to a control message with a bounded timeout.
+    /// Awaits a response to a control message with a bounded timeout (§12.2).
     ///
-    /// draft-14 §12.2 recommends implementation-defined timeouts to prevent
-    /// resource exhaustion when a peer does not send the expected response.
-    /// On timeout, the session is closed with `ControlMessageTimeout` and an
-    /// error is returned so the caller can propagate the failure cleanly.
-    ///
-    /// FIXME: SUBSCRIBE and the other request/response exchanges still use
-    /// this session-closing variant; migrating them to
-    /// `await_request_response` is tracked separately.
-    pub(crate) async fn await_response(
-        &self,
-        receiver: tokio::sync::oneshot::Receiver<ResponseMessage>,
-    ) -> anyhow::Result<ResponseMessage> {
-        match tokio::time::timeout(CONTROL_MESSAGE_RESPONSE_TIMEOUT, receiver).await {
-            Ok(Ok(response)) => Ok(response),
-            Ok(Err(error)) => anyhow::bail!("control response channel closed: {}", error),
-            Err(_) => {
-                tracing::warn!("control message response timed out; closing session");
-                self.close_with_error(
-                    TerminationErrorCode::ControlMessageTimeout,
-                    "peer did not respond to a control message in time",
-                );
-                anyhow::bail!("control message response timed out")
-            }
-        }
-    }
-
-    /// Like `await_response`, but a timeout fails only this request instead of
-    /// closing the session: a FETCH is request-scoped, and a shared
-    /// (inter-relay) session must survive one slow request. §12.2's
-    /// resource-exhaustion concern is met by the caller dropping its pending
-    /// request state on the error path.
+    /// A timeout fails only this request instead of closing the session:
+    /// requests are request-scoped, and a shared (inter-relay) session must
+    /// survive one slow request. §12.2's resource-exhaustion concern is met
+    /// by the caller dropping its pending request state on the error path;
+    /// the `sender_map` entry stays behind as `Abandoned` so a late response
+    /// is withdrawn instead of closing the session.
     pub(crate) async fn await_request_response(
         &self,
         receiver: tokio::sync::oneshot::Receiver<ResponseMessage>,
@@ -254,6 +279,77 @@ impl<T: TransportProtocol> SessionContext<T> {
             Ok(Ok(response)) => Ok(response),
             Ok(Err(error)) => anyhow::bail!("control response channel closed: {}", error),
             Err(_) => Err(RequestTimeoutError.into()),
+        }
+    }
+
+    /// Handles a response that arrived after the caller abandoned the request.
+    /// A success response means the peer holds state (subscription, namespace
+    /// interest, ...) nobody on this side will consume, so send the matching
+    /// withdrawal; error responses are simply discarded.
+    pub(crate) async fn handle_late_response(
+        &self,
+        request_id: RequestId,
+        cleanup: LateResponseCleanup,
+        response: ResponseMessage,
+    ) {
+        let send_result = match (&cleanup, &response) {
+            (LateResponseCleanup::Unsubscribe, ResponseMessage::SubscribeOk(_)) => {
+                tracing::warn!(
+                    request_id,
+                    "SUBSCRIBE_OK arrived after the request was abandoned; sending UNSUBSCRIBE"
+                );
+                self.send_stream
+                    .send(
+                        ControlMessageType::UnSubscribe,
+                        Unsubscribe { request_id }.encode(),
+                    )
+                    .await
+            }
+            (
+                LateResponseCleanup::UnsubscribeNamespace { namespace },
+                ResponseMessage::SubscribeNameSpaceOk(_),
+            ) => {
+                tracing::warn!(
+                    request_id,
+                    "SUBSCRIBE_NAMESPACE_OK arrived after the request was abandoned; sending UNSUBSCRIBE_NAMESPACE"
+                );
+                self.send_stream
+                    .send(
+                        ControlMessageType::UnSubscribeNamespace,
+                        UnsubscribeNamespace::new(namespace.clone()).encode(),
+                    )
+                    .await
+            }
+            (
+                LateResponseCleanup::PublishNamespaceDone { namespace },
+                ResponseMessage::PublishNamespaceOk(_),
+            ) => {
+                tracing::warn!(
+                    request_id,
+                    "PUBLISH_NAMESPACE_OK arrived after the request was abandoned; sending PUBLISH_NAMESPACE_DONE"
+                );
+                self.send_stream
+                    .send(
+                        ControlMessageType::PublishNamespaceDone,
+                        PublishNamespaceDone::new(namespace.clone()).encode(),
+                    )
+                    .await
+            }
+            _ => {
+                tracing::warn!(
+                    request_id,
+                    ?response,
+                    "discarding response that arrived after the request was abandoned"
+                );
+                Ok(())
+            }
+        };
+        if let Err(error) = send_result {
+            tracing::warn!(
+                request_id,
+                %error,
+                "failed to withdraw an abandoned request"
+            );
         }
     }
 

--- a/moqt/src/modules/moqt/domains/session_context.rs
+++ b/moqt/src/modules/moqt/domains/session_context.rs
@@ -50,7 +50,7 @@ impl std::error::Error for RequestTimeoutError {}
 /// stopped waiting (timeout or cancellation). Late error responses never need
 /// a withdrawal and are always discarded.
 #[derive(Debug)]
-pub(crate) enum LateResponseCleanup {
+pub(crate) enum LateResponseAction {
     /// Discard the late response without a withdrawal message.
     ///
     /// FIXME: PUBLISH and FETCH should withdraw with PUBLISH_DONE /
@@ -72,9 +72,9 @@ pub(crate) enum LateResponseCleanup {
 pub(crate) enum InflightRequest {
     Waiting {
         sender: tokio::sync::oneshot::Sender<ResponseMessage>,
-        on_late_response: LateResponseCleanup,
+        on_late_response: LateResponseAction,
     },
-    Abandoned(LateResponseCleanup),
+    Abandoned(LateResponseAction),
 }
 
 pub(crate) struct SessionContext<T: TransportProtocol> {
@@ -117,7 +117,7 @@ pub(crate) enum IncomingObjectNotification {
 /// Holds the `sender_map` registration for an in-flight request. On drop, a
 /// still-waiting entry is downgraded to `Abandoned` (not removed): the caller
 /// gave up, but a late response must still find the entry so it triggers the
-/// registered cleanup instead of a session close.
+/// registered action instead of a session close.
 #[must_use = "dropping this abandons the request in sender_map; bind it for the lifetime of the request"]
 pub(crate) struct RegisteredSender<T: TransportProtocol> {
     session: Arc<SessionContext<T>>,
@@ -132,8 +132,8 @@ impl<T: TransportProtocol> Drop for RegisteredSender<T> {
                 on_late_response, ..
             } = entry
         {
-            let cleanup = std::mem::replace(on_late_response, LateResponseCleanup::Discard);
-            *entry = InflightRequest::Abandoned(cleanup);
+            let action = std::mem::replace(on_late_response, LateResponseAction::Discard);
+            *entry = InflightRequest::Abandoned(action);
         }
     }
 }
@@ -179,7 +179,7 @@ impl<T: TransportProtocol> SessionContext<T> {
         self: &Arc<Self>,
         request_id: RequestId,
         sender: tokio::sync::oneshot::Sender<ResponseMessage>,
-        on_late_response: LateResponseCleanup,
+        on_late_response: LateResponseAction,
     ) -> RegisteredSender<T> {
         self.sender_map.lock().expect("sender_map poisoned").insert(
             request_id,
@@ -289,11 +289,11 @@ impl<T: TransportProtocol> SessionContext<T> {
     pub(crate) async fn handle_late_response(
         &self,
         request_id: RequestId,
-        cleanup: LateResponseCleanup,
+        action: LateResponseAction,
         response: ResponseMessage,
     ) {
-        let send_result = match (&cleanup, &response) {
-            (LateResponseCleanup::Unsubscribe, ResponseMessage::SubscribeOk(_)) => {
+        let send_result = match (&action, &response) {
+            (LateResponseAction::Unsubscribe, ResponseMessage::SubscribeOk(_)) => {
                 tracing::warn!(
                     request_id,
                     "SUBSCRIBE_OK arrived after the request was abandoned; sending UNSUBSCRIBE"
@@ -306,7 +306,7 @@ impl<T: TransportProtocol> SessionContext<T> {
                     .await
             }
             (
-                LateResponseCleanup::UnsubscribeNamespace { namespace },
+                LateResponseAction::UnsubscribeNamespace { namespace },
                 ResponseMessage::SubscribeNameSpaceOk(_),
             ) => {
                 tracing::warn!(
@@ -321,7 +321,7 @@ impl<T: TransportProtocol> SessionContext<T> {
                     .await
             }
             (
-                LateResponseCleanup::PublishNamespaceDone { namespace },
+                LateResponseAction::PublishNamespaceDone { namespace },
                 ResponseMessage::PublishNamespaceOk(_),
             ) => {
                 tracing::warn!(

--- a/moqt/src/modules/moqt/domains/subscriber.rs
+++ b/moqt/src/modules/moqt/domains/subscriber.rs
@@ -22,7 +22,10 @@ use crate::{
             fetch_data_receiver::FetchDataReceiver, stream_data_receiver::StreamDataReceiver,
             stream_data_receiver_factory::StreamDataReceiverFactory,
         },
-        domains::{fetch_handle::FetchHandle, session_context::SessionContext},
+        domains::{
+            fetch_handle::FetchHandle,
+            session_context::{LateResponseCleanup, SessionContext},
+        },
         protocol::TransportProtocol,
         runtime::dispatch::incoming_object::IncomingObject,
     },
@@ -46,10 +49,16 @@ impl<T: TransportProtocol> Subscriber<T> {
         fields(namespace = %namespace)
     )]
     pub async fn subscribe_namespace(&self, namespace: String) -> anyhow::Result<()> {
-        let vec_namespace = namespace.split('/').map(|s| s.to_string()).collect();
+        let vec_namespace: Vec<String> = namespace.split('/').map(|s| s.to_string()).collect();
         let (sender, receiver) = tokio::sync::oneshot::channel::<ResponseMessage>();
         let request_id = self.session.get_request_id();
-        let _registered_sender = self.session.register_response_sender(request_id, sender);
+        let _registered_sender = self.session.register_response_sender(
+            request_id,
+            sender,
+            LateResponseCleanup::UnsubscribeNamespace {
+                namespace: vec_namespace.clone(),
+            },
+        );
         let subscribe_namespace = SubscribeNamespace::new(request_id, vec_namespace, vec![]);
         self.session
             .send_stream
@@ -59,7 +68,7 @@ impl<T: TransportProtocol> Subscriber<T> {
             )
             .await?;
         tracing::info!("Subscribe namespace");
-        let response = self.session.await_response(receiver).await?;
+        let response = self.session.await_request_response(receiver).await?;
         match response {
             ResponseMessage::SubscribeNameSpaceOk(response_request_id) => {
                 if request_id != response_request_id {
@@ -69,9 +78,14 @@ impl<T: TransportProtocol> Subscriber<T> {
                     Ok(())
                 }
             }
-            ResponseMessage::SubscribeNameSpaceError(_, _, _) => {
+            ResponseMessage::SubscribeNameSpaceError(request_id, error_code, reason_phrase) => {
                 tracing::info!("Subscribe namespace error");
-                bail!("Subscribe namespace error")
+                Err(RequestError {
+                    request_id,
+                    error_code,
+                    reason_phrase,
+                }
+                .into())
             }
             _ => bail!("Protocol violation"),
         }
@@ -93,7 +107,11 @@ impl<T: TransportProtocol> Subscriber<T> {
         let filter_type = option.filter_type;
         let (sender, receiver) = tokio::sync::oneshot::channel::<ResponseMessage>();
         let request_id = self.session.get_request_id();
-        let _registered_sender = self.session.register_response_sender(request_id, sender);
+        let _registered_sender = self.session.register_response_sender(
+            request_id,
+            sender,
+            LateResponseCleanup::Unsubscribe,
+        );
         let subscribe = Subscribe {
             request_id,
             track_namespace: vec_namespace,
@@ -109,7 +127,7 @@ impl<T: TransportProtocol> Subscriber<T> {
             .send_stream
             .send(ControlMessageType::Subscribe, subscribe.encode())
             .await?;
-        let response = self.session.await_response(receiver).await?;
+        let response = self.session.await_request_response(receiver).await?;
         match response {
             ResponseMessage::SubscribeOk(message) => {
                 if request_id != message.request_id {
@@ -145,9 +163,14 @@ impl<T: TransportProtocol> Subscriber<T> {
                     ))
                 }
             }
-            ResponseMessage::SubscribeError(_, _, _) => {
+            ResponseMessage::SubscribeError(request_id, error_code, reason_phrase) => {
                 tracing::info!("Subscribe error");
-                bail!("Subscribe error")
+                Err(RequestError {
+                    request_id,
+                    error_code,
+                    reason_phrase,
+                }
+                .into())
             }
             _ => bail!("Protocol violation"),
         }
@@ -185,9 +208,14 @@ impl<T: TransportProtocol> Subscriber<T> {
 
         let (fetch_message_tx, fetch_message_rx) =
             tokio::sync::oneshot::channel::<ResponseMessage>();
-        let _registered_sender = self
-            .session
-            .register_response_sender(request_id, fetch_message_tx);
+        // A late FETCH_OK is discarded (its data stream is dropped by
+        // FetchNotifier); see LateResponseCleanup::Discard for why no
+        // FETCH_CANCEL is sent yet.
+        let _registered_sender = self.session.register_response_sender(
+            request_id,
+            fetch_message_tx,
+            LateResponseCleanup::Discard,
+        );
         let fetch = Fetch {
             request_id,
             subscriber_priority: option.subscriber_priority,
@@ -274,9 +302,14 @@ impl<T: TransportProtocol> Subscriber<T> {
 
         let (fetch_message_tx, fetch_message_rx) =
             tokio::sync::oneshot::channel::<ResponseMessage>();
-        let _registered_sender = self
-            .session
-            .register_response_sender(request_id, fetch_message_tx);
+        // A late FETCH_OK is discarded (its data stream is dropped by
+        // FetchNotifier); see LateResponseCleanup::Discard for why no
+        // FETCH_CANCEL is sent yet.
+        let _registered_sender = self.session.register_response_sender(
+            request_id,
+            fetch_message_tx,
+            LateResponseCleanup::Discard,
+        );
         let fetch = Fetch {
             request_id,
             subscriber_priority: option.subscriber_priority,

--- a/moqt/src/modules/moqt/domains/subscriber.rs
+++ b/moqt/src/modules/moqt/domains/subscriber.rs
@@ -24,7 +24,7 @@ use crate::{
         },
         domains::{
             fetch_handle::FetchHandle,
-            session_context::{LateResponseCleanup, SessionContext},
+            session_context::{LateResponseAction, SessionContext},
         },
         protocol::TransportProtocol,
         runtime::dispatch::incoming_object::IncomingObject,
@@ -55,7 +55,7 @@ impl<T: TransportProtocol> Subscriber<T> {
         let _registered_sender = self.session.register_response_sender(
             request_id,
             sender,
-            LateResponseCleanup::UnsubscribeNamespace {
+            LateResponseAction::UnsubscribeNamespace {
                 namespace: vec_namespace.clone(),
             },
         );
@@ -110,7 +110,7 @@ impl<T: TransportProtocol> Subscriber<T> {
         let _registered_sender = self.session.register_response_sender(
             request_id,
             sender,
-            LateResponseCleanup::Unsubscribe,
+            LateResponseAction::Unsubscribe,
         );
         let subscribe = Subscribe {
             request_id,
@@ -209,12 +209,12 @@ impl<T: TransportProtocol> Subscriber<T> {
         let (fetch_message_tx, fetch_message_rx) =
             tokio::sync::oneshot::channel::<ResponseMessage>();
         // A late FETCH_OK is discarded (its data stream is dropped by
-        // FetchNotifier); see LateResponseCleanup::Discard for why no
+        // FetchNotifier); see LateResponseAction::Discard for why no
         // FETCH_CANCEL is sent yet.
         let _registered_sender = self.session.register_response_sender(
             request_id,
             fetch_message_tx,
-            LateResponseCleanup::Discard,
+            LateResponseAction::Discard,
         );
         let fetch = Fetch {
             request_id,
@@ -303,12 +303,12 @@ impl<T: TransportProtocol> Subscriber<T> {
         let (fetch_message_tx, fetch_message_rx) =
             tokio::sync::oneshot::channel::<ResponseMessage>();
         // A late FETCH_OK is discarded (its data stream is dropped by
-        // FetchNotifier); see LateResponseCleanup::Discard for why no
+        // FetchNotifier); see LateResponseAction::Discard for why no
         // FETCH_CANCEL is sent yet.
         let _registered_sender = self.session.register_response_sender(
             request_id,
             fetch_message_tx,
-            LateResponseCleanup::Discard,
+            LateResponseAction::Discard,
         );
         let fetch = Fetch {
             request_id,

--- a/moqt/src/modules/moqt/domains/subscriber.rs
+++ b/moqt/src/modules/moqt/domains/subscriber.rs
@@ -68,7 +68,7 @@ impl<T: TransportProtocol> Subscriber<T> {
             )
             .await?;
         tracing::info!("Subscribe namespace");
-        let response = self.session.await_request_response(receiver).await?;
+        let response = self.session.await_response(receiver).await?;
         match response {
             ResponseMessage::SubscribeNameSpaceOk(response_request_id) => {
                 if request_id != response_request_id {
@@ -127,7 +127,7 @@ impl<T: TransportProtocol> Subscriber<T> {
             .send_stream
             .send(ControlMessageType::Subscribe, subscribe.encode())
             .await?;
-        let response = self.session.await_request_response(receiver).await?;
+        let response = self.session.await_response(receiver).await?;
         match response {
             ResponseMessage::SubscribeOk(message) => {
                 if request_id != message.request_id {
@@ -233,7 +233,7 @@ impl<T: TransportProtocol> Subscriber<T> {
                 .send_stream
                 .send(ControlMessageType::Fetch, fetch.encode())
                 .await?;
-            self.session.await_request_response(fetch_message_rx).await
+            self.session.await_response(fetch_message_rx).await
         }
         .await;
         let response = match result {
@@ -325,7 +325,7 @@ impl<T: TransportProtocol> Subscriber<T> {
                 .send_stream
                 .send(ControlMessageType::Fetch, fetch.encode())
                 .await?;
-            self.session.await_request_response(fetch_message_rx).await
+            self.session.await_response(fetch_message_rx).await
         }
         .await;
         let response = match result {

--- a/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
+++ b/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
@@ -21,7 +21,7 @@ use crate::{
         data_plane::stream::{
             received_message::ReceivedMessage, stream_receiver::BiStreamReceiver,
         },
-        domains::session_context::SessionContext,
+        domains::session_context::{PendingRequest, SessionContext},
     },
 };
 
@@ -66,25 +66,45 @@ impl ControlMessageReceiveTask {
                                     }
                                 }
                                 DepacketizeResult::ResponseMessage(request_id, message) => {
-                                    let sender = session
+                                    let pending = session
                                         .sender_map
                                         .lock()
                                         .expect("sender_map poisoned")
                                         .remove(&request_id);
-                                    if let Some(sender) = sender {
-                                        if let Err(error) = sender.send(message) {
-                                            tracing::error!("failed to send message: {:?}", error);
+                                    match pending {
+                                        Some(PendingRequest::Waiting {
+                                            sender,
+                                            on_late_response,
+                                        }) => {
+                                            // The caller can stop waiting between response
+                                            // arrival and this send; fall back to the
+                                            // late-response withdrawal in that case.
+                                            if let Err(message) = sender.send(message) {
+                                                session
+                                                    .handle_late_response(
+                                                        request_id,
+                                                        on_late_response,
+                                                        message,
+                                                    )
+                                                    .await;
+                                            }
                                         }
-                                    } else {
-                                        tracing::error!(
-                                            request_id,
-                                            "Protocol violation: response for unknown or already-completed Request ID; closing session"
-                                        );
-                                        session.close_with_error(
-                                            TerminationErrorCode::ProtocolViolation,
-                                            "received response for unknown or already-completed Request ID",
-                                        );
-                                        break;
+                                        Some(PendingRequest::Abandoned(cleanup)) => {
+                                            session
+                                                .handle_late_response(request_id, cleanup, message)
+                                                .await;
+                                        }
+                                        None => {
+                                            tracing::error!(
+                                                request_id,
+                                                "Protocol violation: response for unknown or already-completed Request ID; closing session"
+                                            );
+                                            session.close_with_error(
+                                                TerminationErrorCode::ProtocolViolation,
+                                                "received response for unknown or already-completed Request ID",
+                                            );
+                                            break;
+                                        }
                                     }
                                 }
                             }

--- a/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
+++ b/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
@@ -89,9 +89,9 @@ impl ControlMessageReceiveTask {
                                                     .await;
                                             }
                                         }
-                                        Some(InflightRequest::Abandoned(cleanup)) => {
+                                        Some(InflightRequest::Abandoned(action)) => {
                                             session
-                                                .handle_late_response(request_id, cleanup, message)
+                                                .handle_late_response(request_id, action, message)
                                                 .await;
                                         }
                                         None => {

--- a/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
+++ b/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
@@ -66,12 +66,12 @@ impl ControlMessageReceiveTask {
                                     }
                                 }
                                 DepacketizeResult::ResponseMessage(request_id, message) => {
-                                    let pending = session
+                                    let inflight_request = session
                                         .sender_map
                                         .lock()
                                         .expect("sender_map poisoned")
                                         .remove(&request_id);
-                                    match pending {
+                                    match inflight_request {
                                         Some(InflightRequest::Waiting {
                                             sender,
                                             on_late_response,

--- a/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
+++ b/moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs
@@ -21,7 +21,7 @@ use crate::{
         data_plane::stream::{
             received_message::ReceivedMessage, stream_receiver::BiStreamReceiver,
         },
-        domains::session_context::{PendingRequest, SessionContext},
+        domains::session_context::{InflightRequest, SessionContext},
     },
 };
 
@@ -72,7 +72,7 @@ impl ControlMessageReceiveTask {
                                         .expect("sender_map poisoned")
                                         .remove(&request_id);
                                     match pending {
-                                        Some(PendingRequest::Waiting {
+                                        Some(InflightRequest::Waiting {
                                             sender,
                                             on_late_response,
                                         }) => {
@@ -89,7 +89,7 @@ impl ControlMessageReceiveTask {
                                                     .await;
                                             }
                                         }
-                                        Some(PendingRequest::Abandoned(cleanup)) => {
+                                        Some(InflightRequest::Abandoned(cleanup)) => {
                                             session
                                                 .handle_late_response(request_id, cleanup, message)
                                                 .await;

--- a/relay/src/modules/enums.rs
+++ b/relay/src/modules/enums.rs
@@ -111,6 +111,22 @@ pub(crate) enum FetchErrorCode {
     ExpiredAuthToken = 0x12,
 }
 
+// https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.9
+// SUBSCRIBE_ERROR error codes.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub(crate) enum SubscribeErrorCode {
+    InternalError = 0x0,
+    Unauthorized = 0x1,
+    Timeout = 0x2,
+    NotSupported = 0x3,
+    TrackDoesNotExist = 0x4,
+    InvalidRange = 0x5,
+    MalformedAuthToken = 0x10,
+    ExpiredAuthToken = 0x12,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum ContentExists {
     False,

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::modules::{
     control_message_forwarder::ControlMessageForwarder,
     core::handler::subscribe::SubscribeHandler,
-    enums::{ContentExists, Location},
+    enums::{ContentExists, Location, SubscribeErrorCode},
     relay::{
         cache::store::TrackCacheStore,
         egress::coordinator::{EgressCommand, EgressStartRequest},
@@ -71,22 +71,43 @@ async fn resolve_subscribe_largest(
 
 enum UpstreamSubscriptionError {
     PublisherNotFound,
-    SubscribeFailed,
+    SubscribeFailed(anyhow::Error),
     IngressStartFailed,
 }
 
 impl UpstreamSubscriptionError {
-    fn code(&self) -> u64 {
-        0
-    }
-
-    fn reason_phrase(&self) -> String {
+    /// SUBSCRIBE_ERROR (code, reason) for the downstream subscriber. An
+    /// upstream SUBSCRIBE_ERROR is relayed verbatim; an upstream timeout maps
+    /// to TIMEOUT so one slow upstream request stays a request-scoped failure.
+    fn subscribe_error_response(&self) -> (u64, String) {
         match self {
-            Self::PublisherNotFound => "Designated namespace and track name do not exist.",
-            Self::SubscribeFailed => "Failed to create upstream subscription.",
-            Self::IngressStartFailed => "Failed to start upstream ingress.",
+            Self::PublisherNotFound => (
+                SubscribeErrorCode::TrackDoesNotExist as u64,
+                "Designated namespace and track name do not exist.".to_string(),
+            ),
+            Self::SubscribeFailed(error) => {
+                if let Some(subscribe_error) = error.downcast_ref::<moqt::wire::RequestError>() {
+                    (
+                        subscribe_error.error_code,
+                        subscribe_error.reason_phrase.clone(),
+                    )
+                } else if error.downcast_ref::<moqt::RequestTimeoutError>().is_some() {
+                    (
+                        SubscribeErrorCode::Timeout as u64,
+                        "Upstream subscribe timed out".to_string(),
+                    )
+                } else {
+                    (
+                        SubscribeErrorCode::InternalError as u64,
+                        "Failed to create upstream subscription.".to_string(),
+                    )
+                }
+            }
+            Self::IngressStartFailed => (
+                SubscribeErrorCode::InternalError as u64,
+                "Failed to start upstream ingress.".to_string(),
+            ),
         }
-        .to_string()
     }
 }
 
@@ -142,8 +163,9 @@ impl Subscribe {
                     track_name = %track_name,
                     "failed to get or create upstream subscription"
                 );
+                let (code, reason_phrase) = err.subscribe_error_response();
                 if let Err(send_error) = self
-                    .response_error(handler.as_ref(), err.code(), err.reason_phrase())
+                    .response_error(handler.as_ref(), code, reason_phrase)
                     .await
                 {
                     tracing::error!(
@@ -320,21 +342,25 @@ impl Subscribe {
             .ok_or(UpstreamSubscriptionError::PublisherNotFound)?;
 
         let pub_session_id = upstream_key.publisher_session_id;
-        let Ok(subscription) = forwarder
+        let subscription = match forwarder
             .subscribe(
                 pub_session_id,
                 upstream_key.track_namespace.clone(),
                 upstream_key.track_name.clone(),
             )
             .await
-        else {
-            tracing::warn!(
-                pub_session_id = %pub_session_id,
-                track_namespace = %upstream_key.track_namespace,
-                track_name = %upstream_key.track_name,
-                "failed to send upstream SUBSCRIBE"
-            );
-            return Err(UpstreamSubscriptionError::SubscribeFailed);
+        {
+            Ok(subscription) => subscription,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    pub_session_id = %pub_session_id,
+                    track_namespace = %upstream_key.track_namespace,
+                    track_name = %upstream_key.track_name,
+                    "upstream SUBSCRIBE failed"
+                );
+                return Err(UpstreamSubscriptionError::SubscribeFailed(error));
+            }
         };
         tracing::info!(
             pub_session_id = %pub_session_id,
@@ -574,6 +600,36 @@ mod tests {
         cache
             .append_stream_object(group_id, &subgroup, Some(0), make_object())
             .await;
+    }
+
+    #[test]
+    fn upstream_timeout_maps_to_subscribe_error_timeout() {
+        let error = UpstreamSubscriptionError::SubscribeFailed(anyhow::Error::new(
+            moqt::RequestTimeoutError,
+        ));
+        let (code, _reason) = error.subscribe_error_response();
+        assert_eq!(code, SubscribeErrorCode::Timeout as u64);
+    }
+
+    #[test]
+    fn upstream_subscribe_error_code_is_relayed_verbatim() {
+        let error = UpstreamSubscriptionError::SubscribeFailed(anyhow::Error::new(
+            moqt::wire::RequestError {
+                request_id: 7,
+                error_code: 0x1,
+                reason_phrase: "unauthorized".to_string(),
+            },
+        ));
+        let (code, reason) = error.subscribe_error_response();
+        assert_eq!(code, 0x1);
+        assert_eq!(reason, "unauthorized");
+    }
+
+    #[test]
+    fn publisher_not_found_maps_to_track_does_not_exist() {
+        let (code, _reason) =
+            UpstreamSubscriptionError::PublisherNotFound.subscribe_error_response();
+        assert_eq!(code, SubscribeErrorCode::TrackDoesNotExist as u64);
     }
 
     // A publisher that left a catalog cache (groups 0..=4) then reconnected as a


### PR DESCRIPTION
## 背景・問題

moqt クレートでは SUBSCRIBE / SUBSCRIBE_NAMESPACE / PUBLISH / PUBLISH_NAMESPACE の応答待ちがタイムアウトすると、セッション全体を `ControlMessageTimeout` でクローズしていました。仕様上はどちらの挙動も許容されますが、relay 間は単一の QUIC コネクションを共有しているため、1 つの制御メッセージのタイムアウトが同じセッション上の他のすべての処理(購読・配信)を巻き込んで切断してしまいます。

#309 で FETCH についてはタイムアウトをリクエスト単位の失敗に閉じる方式を導入済みのため、本 PR で同じ方式を残りの request/response 型の制御メッセージ全体に一般化します。

## 中心となる設計: `InflightRequest` と `LateResponseAction`

タイムアウトを単に「待つのをやめる」で済ませられないのは、遅れて届いた応答の扱いに 2 つの問題があるためです。

1. pending 登録を消してしまうと、遅延応答が「未知の Request ID への応答」になり、仕様上**セッションクローズが必須**(draft-14 §9.1)。タイムアウトでセッションを守ったのに、その後始末でセッションが落ちる
2. 遅延応答が成功(SUBSCRIBE_OK 等)だった場合、**相手側には購読等の状態が確立済み**。こちらは誰も消費しないので、取り消さないと相手はオブジェクトを送り続ける

これを次の 2 つの型で解決します。

### `InflightRequest` — 送信済み・応答未着のリクエスト

```rust
pub(crate) enum InflightRequest {
    /// 呼び出し元が oneshot で応答を待っている
    Waiting {
        sender: oneshot::Sender<ResponseMessage>,
        on_late_response: LateResponseAction,
    },
    /// 呼び出し元は諦めた(タイムアウト/キャンセル)が、プロトコル上は未応答
    Abandoned(LateResponseAction),
}
```

`sender_map` のエントリはタイムアウトで**削除せず** `Waiting` → `Abandoned` に降格します(`RegisteredSender` の Drop 実装)。エントリが残っているので、遅延応答は「未知の Request ID」にならず、登録済みの後始末に接続されます。エントリが実際に消えるのは応答が届いたときです。

### `LateResponseAction` — 遅延応答を受信したときに取る行動

リクエスト送信時に「もし遅れて成功応答が来たら、どう取り消すか」を登録しておく enum です。

| リクエスト | 登録する Action | 遅延成功応答への挙動 |
|---|---|---|
| SUBSCRIBE | `Unsubscribe` | UNSUBSCRIBE を送信(相手に残った購読状態を解消) |
| SUBSCRIBE_NAMESPACE | `UnsubscribeNamespace { namespace }` | UNSUBSCRIBE_NAMESPACE を送信 |
| PUBLISH_NAMESPACE | `PublishNamespaceDone { namespace }` | PUBLISH_NAMESPACE_DONE を送信 |
| PUBLISH / FETCH | `Discard` | 破棄(下記 FIXME) |

設計上のポイント:

- **応答型だけからはアクションを導出できない**: UNSUBSCRIBE_NAMESPACE / PUBLISH_NAMESPACE_DONE のワイヤフォーマットは request_id ではなく **namespace** で対象を指定しますが、NAMESPACE_OK 応答は request_id しか運びません。そのため取り消しに必要な情報をリクエスト送信時に enum へ捕捉しておく必要があります
- **成功応答のみ取り消し対象**: 遅延応答がエラー(SUBSCRIBE_ERROR 等)なら相手側に状態が残っていないため、Action が何であれ破棄します
- **種類不一致はプロトコル違反**: 成功応答が登録された Action と対応しない場合(例: FETCH の request_id に SUBSCRIBE_OK が返る)、相手の request_id 管理が壊れている証拠なので `PROTOCOL_VIOLATION` でセッションをクローズします。`handle_late_response` は「応答型で match → 内側で Action と照合」の二重 match でこの 3 分岐(取り消し / 破棄 / 切断)を表現しています
- **FIXME**: PUBLISH / FETCH の取り消しは本来 PUBLISH_DONE / FETCH_CANCEL ですが、これらのデコードが未実装(`todo!()`)のため、送ると本クレート同士で相手が panic します。当面 `Discard` とし、コード上に FIXME を記載しています。また `Discard` はリクエスト種別を記録しないため、FETCH_OK / PUBLISH_OK の種類不一致はここでは検出できません

## その他の変更

### moqt

- `await_response` をセッションをクローズする実装からリクエスト単位で失敗する実装に置き換え(タイムアウト時は `RequestTimeoutError` を返し、セッションは維持)。#309 で FETCH 用に追加した `await_request_response` は `await_response` に改名して一本化
- `subscribe` / `subscribe_namespace` / `publish` / `publish_namespace` のエラー応答を文字列 `bail!` から型付き `wire::RequestError` に変更(FETCH と同じ形式)。relay が上流のエラーコードをそのまま下流へ中継できるように
- FetchHandler の「未応答のまま drop されたら自動でエラー応答する」仕組み(#309)を `ResponseGuard` として切り出し、Subscribe / SubscribeNamespace / PublishNamespace / Publish の各ハンドラにも適用。アプリケーションが応答せずにハンドラを破棄した場合、相手をタイムアウトまで待たせず即座に `*_ERROR NOT_SUPPORTED` を返します

### relay

- 上流 SUBSCRIBE のタイムアウトを下流への `SUBSCRIBE_ERROR TIMEOUT (0x2)` にマッピング(typed downcast)。上流からの SUBSCRIBE_ERROR はコード・理由をそのまま中継
- `PublisherNotFound` を `TRACK_DOES_NOT_EXIST (0x4)` にマッピング(従来は一律 0x0)
- `SubscribeErrorCode` enum を追加(draft-14 §13.1.2)

## テスト

- relay: エラーマッピングのユニットテスト 3 件を追加(タイムアウト→TIMEOUT、上流コードの素通し、PublisherNotFound→TRACK_DOES_NOT_EXIST)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `cargo fmt --all --check` / `cargo test --workspace` / `cargo check -p moqt-client-wasm --target wasm32-unknown-unknown` すべて通過

## 補足

- master ベースで #310 / #317 とは独立にマージ可能です(依存は master 済みの #309 のみ)
- #310 側と唯一衝突しうるのは `subscriber.rs` の import 行 1 つで、機械的に解消できます

🤖 Generated with [Claude Code](https://claude.com/claude-code)
