### PR TITLE
feat(relay): Malformed Track（draft-14 §2.5 条件8）の検出とトラック隔離

### DIFF
--- a/bindings/wasm/src/messages/subgroup_state.rs
+++ b/bindings/wasm/src/messages/subgroup_state.rs
@@ -43,7 +43,12 @@ impl SubgroupState {
     pub(crate) fn with_track(track_alias: u64) -> Self {
         Self {
             track_alias,
-            group_id: 0,
+            // Time-based instead of 0: reusing a (group, object) location of a
+            // track cached by the relay with different content quarantines the
+            // track as malformed (draft-14 §2.5), and a fresh state (new alias
+            // or rejoined session) cannot know which locations were already
+            // used under this track name.
+            group_id: js_sys::Date::now() as u64,
             subgroup_id: 0,
             object_id: 0,
             header_sent: false,

--- a/bindings/wasm/src/messages/subgroup_state.rs
+++ b/bindings/wasm/src/messages/subgroup_state.rs
@@ -43,11 +43,8 @@ impl SubgroupState {
     pub(crate) fn with_track(track_alias: u64) -> Self {
         Self {
             track_alias,
-            // Time-based instead of 0: reusing a (group, object) location of a
-            // track cached by the relay with different content quarantines the
-            // track as malformed (draft-14 §2.5), and a fresh state (new alias
-            // or rejoined session) cannot know which locations were already
-            // used under this track name.
+            // Time-seeded: reusing a location the relay cached with different
+            // content makes the track malformed (draft-14 §2.5).
             group_id: js_sys::Date::now() as u64,
             subgroup_id: 0,
             object_id: 0,

--- a/bindings/wasm/src/messages/subgroup_state.rs
+++ b/bindings/wasm/src/messages/subgroup_state.rs
@@ -43,8 +43,7 @@ impl SubgroupState {
     pub(crate) fn with_track(track_alias: u64) -> Self {
         Self {
             track_alias,
-            // Time-seeded: reusing a location the relay cached with different
-            // content makes the track malformed (draft-14 §2.5).
+            // Time-seeded to avoid reusing relay-cached locations (draft-14 §2.5).
             group_id: js_sys::Date::now() as u64,
             subgroup_id: 0,
             object_id: 0,

--- a/bindings/wasm/src/messages/subgroup_state.rs
+++ b/bindings/wasm/src/messages/subgroup_state.rs
@@ -43,7 +43,6 @@ impl SubgroupState {
     pub(crate) fn with_track(track_alias: u64) -> Self {
         Self {
             track_alias,
-            // Time-seeded to avoid reusing relay-cached locations (draft-14 §2.5).
             group_id: js_sys::Date::now() as u64,
             subgroup_id: 0,
             object_id: 0,

--- a/examples/browser/examples/call/src/media/mediaPublisher.ts
+++ b/examples/browser/examples/call/src/media/mediaPublisher.ts
@@ -134,7 +134,13 @@ export class MediaPublisher {
     noiseSuppression: true,
     autoGainControl: true
   }
-  private readonly catalogGroupByAlias = new Map<string, bigint>()
+  // Catalog group ids must never reuse a location whose content has changed:
+  // the relay caches by (track, group, object) and quarantines the track as
+  // malformed on a content mismatch (draft-14 §2.5). One monotonic counter per
+  // track (not per subscriber alias), seeded from wall-clock time so a
+  // rejoining session does not collide with groups the relay cached from the
+  // previous session of the same member.
+  private nextCatalogGroupId = BigInt(Date.now())
 
   constructor(
     private readonly client: MoqtClientWrapper,
@@ -208,7 +214,6 @@ export class MediaPublisher {
     await this.stopCamera()
     await this.stopScreenShare()
     await this.stopAudio()
-    this.catalogGroupByAlias.clear()
     this.handlers = {}
   }
 
@@ -1450,13 +1455,11 @@ export class MediaPublisher {
   }
 
   private async sendCatalogObject(client: MOQTClient, trackAlias: bigint): Promise<void> {
-    const aliasKey = trackAlias.toString()
-    const previousGroup = this.catalogGroupByAlias.get(aliasKey) ?? -1n
-    const groupId = previousGroup + 1n
-    this.catalogGroupByAlias.set(aliasKey, groupId)
+    const groupId = this.nextCatalogGroupId
+    this.nextCatalogGroupId += 1n
 
     console.info('[call][catalog] send object', {
-      alias: aliasKey,
+      alias: trackAlias.toString(),
       groupId: groupId.toString(),
       tracks: this.catalogTracks.map((t) => t.role)
     })

--- a/examples/browser/examples/call/src/media/mediaPublisher.ts
+++ b/examples/browser/examples/call/src/media/mediaPublisher.ts
@@ -134,12 +134,8 @@ export class MediaPublisher {
     noiseSuppression: true,
     autoGainControl: true
   }
-  // Catalog group ids must never reuse a location whose content has changed:
-  // the relay caches by (track, group, object) and quarantines the track as
-  // malformed on a content mismatch (draft-14 §2.5). One monotonic counter per
-  // track (not per subscriber alias), seeded from wall-clock time so a
-  // rejoining session does not collide with groups the relay cached from the
-  // previous session of the same member.
+  // Per-track and time-seeded: reusing a location the relay cached with
+  // different content makes the track malformed (draft-14 §2.5).
   private nextCatalogGroupId = BigInt(Date.now())
 
   constructor(

--- a/examples/browser/examples/call/src/media/mediaPublisher.ts
+++ b/examples/browser/examples/call/src/media/mediaPublisher.ts
@@ -134,7 +134,6 @@ export class MediaPublisher {
     noiseSuppression: true,
     autoGainControl: true
   }
-  // Per-track and time-seeded to avoid reusing relay-cached locations (draft-14 §2.5).
   private nextCatalogGroupId = BigInt(Date.now())
 
   constructor(

--- a/examples/browser/examples/call/src/media/mediaPublisher.ts
+++ b/examples/browser/examples/call/src/media/mediaPublisher.ts
@@ -134,8 +134,7 @@ export class MediaPublisher {
     noiseSuppression: true,
     autoGainControl: true
   }
-  // Per-track and time-seeded: reusing a location the relay cached with
-  // different content makes the track malformed (draft-14 §2.5).
+  // Per-track and time-seeded to avoid reusing relay-cached locations (draft-14 §2.5).
   private nextCatalogGroupId = BigInt(Date.now())
 
   constructor(

--- a/examples/browser/utils/media/transportState.ts
+++ b/examples/browser/utils/media/transportState.ts
@@ -25,15 +25,23 @@ function aliasKey(alias: bigint | string): string {
   return normalizeAlias(alias).toString()
 }
 
+// Group ids start from wall-clock time instead of 0: reusing a (group, object)
+// location of a track the relay already cached with different content
+// quarantines the track as malformed (draft-14 §2.5), and a rejoining session
+// publishing the same track name cannot know which locations were already used.
+function initialGroupId(): bigint {
+  return BigInt(Date.now()) - 1n
+}
+
 export class MediaTransportState {
   private readonly video: TrackCounters = {
-    groupId: -1n,
+    groupId: initialGroupId(),
     nextObjectNumber: 0n,
     subgroups: new Map([[0, { sentAliases: new Set<string>() }]])
   }
 
   private readonly audio: TrackCounters = {
-    groupId: -1n,
+    groupId: initialGroupId(),
     nextObjectNumber: 0n,
     subgroups: new Map([[0, { sentAliases: new Set<string>() }]])
   }

--- a/examples/browser/utils/media/transportState.ts
+++ b/examples/browser/utils/media/transportState.ts
@@ -25,8 +25,7 @@ function aliasKey(alias: bigint | string): string {
   return normalizeAlias(alias).toString()
 }
 
-// Time-seeded: reusing a location the relay cached with different content
-// makes the track malformed (draft-14 §2.5).
+// Time-seeded to avoid reusing relay-cached locations (draft-14 §2.5).
 function initialGroupId(): bigint {
   return BigInt(Date.now()) - 1n
 }

--- a/examples/browser/utils/media/transportState.ts
+++ b/examples/browser/utils/media/transportState.ts
@@ -25,10 +25,8 @@ function aliasKey(alias: bigint | string): string {
   return normalizeAlias(alias).toString()
 }
 
-// Group ids start from wall-clock time instead of 0: reusing a (group, object)
-// location of a track the relay already cached with different content
-// quarantines the track as malformed (draft-14 §2.5), and a rejoining session
-// publishing the same track name cannot know which locations were already used.
+// Time-seeded: reusing a location the relay cached with different content
+// makes the track malformed (draft-14 §2.5).
 function initialGroupId(): bigint {
   return BigInt(Date.now()) - 1n
 }

--- a/examples/browser/utils/media/transportState.ts
+++ b/examples/browser/utils/media/transportState.ts
@@ -25,7 +25,6 @@ function aliasKey(alias: bigint | string): string {
   return normalizeAlias(alias).toString()
 }
 
-// Time-seeded to avoid reusing relay-cached locations (draft-14 §2.5).
 function initialGroupId(): bigint {
   return BigInt(Date.now()) - 1n
 }

--- a/moqt/src/modules/moqt/data_plane/object/datagram_field.rs
+++ b/moqt/src/modules/moqt/data_plane/object/datagram_field.rs
@@ -31,6 +31,7 @@ use crate::modules::{
     moqt::data_plane::object::{extension_headers::ExtensionHeaders, object_status::ObjectStatus},
 };
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ObjectDatagramPayload {
     Payload(Bytes),
     Status(ObjectStatus),
@@ -137,6 +138,62 @@ impl DatagramField {
             | Self::Payload0x04 { object_id, .. }
             | Self::Status0x20 { object_id, .. }
             | Self::Status0x21 { object_id, .. } => Some(*object_id),
+            _ => None,
+        }
+    }
+
+    pub fn publisher_priority(&self) -> u8 {
+        match self {
+            Self::Payload0x00 {
+                publisher_priority, ..
+            }
+            | Self::Payload0x01 {
+                publisher_priority, ..
+            }
+            | Self::Payload0x02WithEndOfGroup {
+                publisher_priority, ..
+            }
+            | Self::Payload0x03WithEndOfGroup {
+                publisher_priority, ..
+            }
+            | Self::Payload0x04 {
+                publisher_priority, ..
+            }
+            | Self::Payload0x05 {
+                publisher_priority, ..
+            }
+            | Self::Payload0x06WithEndOfGroup {
+                publisher_priority, ..
+            }
+            | Self::Payload0x07WithEndOfGroup {
+                publisher_priority, ..
+            }
+            | Self::Status0x20 {
+                publisher_priority, ..
+            }
+            | Self::Status0x21 {
+                publisher_priority, ..
+            } => *publisher_priority,
+        }
+    }
+
+    pub fn extension_headers(&self) -> Option<&ExtensionHeaders> {
+        match self {
+            Self::Payload0x01 {
+                extension_headers, ..
+            }
+            | Self::Payload0x03WithEndOfGroup {
+                extension_headers, ..
+            }
+            | Self::Payload0x05 {
+                extension_headers, ..
+            }
+            | Self::Payload0x07WithEndOfGroup {
+                extension_headers, ..
+            }
+            | Self::Status0x21 {
+                extension_headers, ..
+            } => Some(extension_headers),
             _ => None,
         }
     }

--- a/moqt/src/modules/moqt/domains/publisher.rs
+++ b/moqt/src/modules/moqt/domains/publisher.rs
@@ -103,7 +103,6 @@ impl<T: TransportProtocol> Publisher<T> {
         Ok(())
     }
 
-    /// Fire-and-forget: the spec defines no response message for PUBLISH_DONE.
     pub async fn publish_done(
         &self,
         request_id: u64,

--- a/moqt/src/modules/moqt/domains/publisher.rs
+++ b/moqt/src/modules/moqt/domains/publisher.rs
@@ -103,8 +103,7 @@ impl<T: TransportProtocol> Publisher<T> {
         Ok(())
     }
 
-    /// Signals the end of a subscription (draft-14 §9.12). Fire-and-forget:
-    /// the spec defines no response message for PUBLISH_DONE.
+    /// Fire-and-forget: the spec defines no response message for PUBLISH_DONE.
     pub async fn publish_done(
         &self,
         request_id: u64,

--- a/moqt/src/modules/moqt/domains/publisher.rs
+++ b/moqt/src/modules/moqt/domains/publisher.rs
@@ -11,7 +11,8 @@ use crate::{
                 control_messages::{
                     control_message_type::ControlMessageType,
                     messages::{
-                        publish::Publish, publish_namespace::PublishNamespace,
+                        publish::Publish, publish_done::PublishDone,
+                        publish_namespace::PublishNamespace,
                         publish_namespace_done::PublishNamespaceDone,
                     },
                 },
@@ -98,6 +99,23 @@ impl<T: TransportProtocol> Publisher<T> {
                 ControlMessageType::PublishNamespaceDone,
                 publish_namespace_done.encode(),
             )
+            .await?;
+        Ok(())
+    }
+
+    /// Signals the end of a subscription (draft-14 §9.12). Fire-and-forget:
+    /// the spec defines no response message for PUBLISH_DONE.
+    pub async fn publish_done(
+        &self,
+        request_id: u64,
+        status_code: u64,
+        stream_count: u64,
+        error_reason: String,
+    ) -> anyhow::Result<()> {
+        let publish_done = PublishDone::new(request_id, status_code, stream_count, error_reason);
+        self.session
+            .send_stream
+            .send(ControlMessageType::PublishDone, publish_done.encode())
             .await?;
         Ok(())
     }

--- a/relay/src/modules/core/data_object.rs
+++ b/relay/src/modules/core/data_object.rs
@@ -14,6 +14,34 @@ impl DataObject {
         }
     }
 
+    /// Compares the properties draft-14 §2.5 (condition 8) declares immutable
+    /// per Object: payload or status, extension headers, publisher priority,
+    /// and group. Per-hop or per-stream encoding details are excluded:
+    /// `track_alias` is rewritten per hop, `message_type` and
+    /// `object_id_delta` depend on how the carrying stream was encoded (a
+    /// fetch fill re-synthesizes both for the same object).
+    pub(crate) fn matches_immutable_properties(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::SubgroupHeader(a), Self::SubgroupHeader(b)) => {
+                a.group_id == b.group_id
+                    && a.subgroup_id == b.subgroup_id
+                    && a.publisher_priority == b.publisher_priority
+            }
+            (Self::SubgroupObject(a), Self::SubgroupObject(b)) => {
+                // Payload comparison is Bytes ==, which checks length before
+                // the byte-wise compare.
+                a.subgroup_object == b.subgroup_object && a.extension_headers == b.extension_headers
+            }
+            (Self::ObjectDatagram(a), Self::ObjectDatagram(b)) => {
+                a.group_id == b.group_id
+                    && a.field.publisher_priority() == b.field.publisher_priority()
+                    && a.field.extension_headers() == b.field.extension_headers()
+                    && a.field.payload() == b.field.payload()
+            }
+            _ => false,
+        }
+    }
+
     /// Resolves the absolute object_id of this object within its ingest stream.
     /// `prev_object_id` is the resolved object_id of the previous object on the same
     /// stream (`None` at the start of a subgroup or right after its header).
@@ -85,5 +113,59 @@ mod tests {
         let datagram = datagram_without_id();
         // Act / Assert: implicit id starts at 0
         assert_eq!(datagram.resolve_absolute_object_id(None), Some(0));
+    }
+
+    fn subgroup_object(object_id_delta: u64, payload: &'static [u8]) -> DataObject {
+        let message_type =
+            moqt::SubgroupHeader::new(0, 0, moqt::SubgroupId::Value(0), 0, false, false)
+                .message_type;
+        DataObject::SubgroupObject(moqt::SubgroupObjectField {
+            message_type,
+            object_id_delta,
+            extension_headers: moqt::ExtensionHeaders::default(),
+            subgroup_object: moqt::SubgroupObject::new_payload(Bytes::from_static(payload)),
+        })
+    }
+
+    fn datagram(publisher_priority: u8, payload: &'static [u8]) -> DataObject {
+        DataObject::ObjectDatagram(ObjectDatagram::new(
+            0,
+            0,
+            DatagramField::Payload0x00 {
+                object_id: 0,
+                publisher_priority,
+                payload: Bytes::from_static(payload),
+            },
+        ))
+    }
+
+    #[test]
+    fn stream_encoding_details_are_not_immutable_properties() {
+        // The same object can legitimately arrive with a different
+        // object_id_delta (e.g. re-encoded by a fetch fill).
+        let a = subgroup_object(0, b"same");
+        let b = subgroup_object(3, b"same");
+        assert!(a.matches_immutable_properties(&b));
+    }
+
+    #[test]
+    fn differing_payload_is_not_a_match() {
+        let a = subgroup_object(0, b"a");
+        let b = subgroup_object(0, b"b");
+        assert!(!a.matches_immutable_properties(&b));
+    }
+
+    #[test]
+    fn differing_datagram_priority_is_not_a_match() {
+        let a = datagram(1, b"same");
+        let b = datagram(2, b"same");
+        assert!(!a.matches_immutable_properties(&b));
+    }
+
+    #[test]
+    fn identical_datagram_matches() {
+        let a = datagram(1, b"same");
+        let b = datagram(1, b"same");
+        assert!(a.matches_immutable_properties(&b));
     }
 }

--- a/relay/src/modules/core/data_object.rs
+++ b/relay/src/modules/core/data_object.rs
@@ -14,9 +14,8 @@ impl DataObject {
         }
     }
 
-    /// draft-14 §2.5 condition 8 comparison. Excludes per-hop / per-stream
-    /// encoding (`track_alias`, `message_type`, `object_id_delta`): a fetch
-    /// fill legitimately re-encodes them for the same object.
+    /// §2.5 condition 8 comparison. Excludes `track_alias`, `message_type`
+    /// and `object_id_delta`: a fetch fill re-encodes them for the same object.
     pub(crate) fn matches_immutable_properties(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::SubgroupHeader(a), Self::SubgroupHeader(b)) => {

--- a/relay/src/modules/core/data_object.rs
+++ b/relay/src/modules/core/data_object.rs
@@ -133,29 +133,37 @@ mod tests {
 
     #[test]
     fn stream_encoding_details_are_not_immutable_properties() {
+        // Arrange: same payload, different object_id_delta
         let a = subgroup_object(0, b"same");
         let b = subgroup_object(3, b"same");
+        // Act / Assert
         assert!(a.matches_immutable_properties(&b));
     }
 
     #[test]
     fn differing_payload_is_not_a_match() {
+        // Arrange
         let a = subgroup_object(0, b"a");
         let b = subgroup_object(0, b"b");
+        // Act / Assert
         assert!(!a.matches_immutable_properties(&b));
     }
 
     #[test]
     fn differing_datagram_priority_is_not_a_match() {
+        // Arrange
         let a = datagram(1, b"same");
         let b = datagram(2, b"same");
+        // Act / Assert
         assert!(!a.matches_immutable_properties(&b));
     }
 
     #[test]
     fn identical_datagram_matches() {
+        // Arrange
         let a = datagram(1, b"same");
         let b = datagram(1, b"same");
+        // Act / Assert
         assert!(a.matches_immutable_properties(&b));
     }
 }

--- a/relay/src/modules/core/data_object.rs
+++ b/relay/src/modules/core/data_object.rs
@@ -14,12 +14,9 @@ impl DataObject {
         }
     }
 
-    /// Compares the properties draft-14 §2.5 (condition 8) declares immutable
-    /// per Object: payload or status, extension headers, publisher priority,
-    /// and group. Per-hop or per-stream encoding details are excluded:
-    /// `track_alias` is rewritten per hop, `message_type` and
-    /// `object_id_delta` depend on how the carrying stream was encoded (a
-    /// fetch fill re-synthesizes both for the same object).
+    /// draft-14 §2.5 condition 8 comparison. Excludes per-hop / per-stream
+    /// encoding (`track_alias`, `message_type`, `object_id_delta`): a fetch
+    /// fill legitimately re-encodes them for the same object.
     pub(crate) fn matches_immutable_properties(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::SubgroupHeader(a), Self::SubgroupHeader(b)) => {
@@ -28,8 +25,6 @@ impl DataObject {
                     && a.publisher_priority == b.publisher_priority
             }
             (Self::SubgroupObject(a), Self::SubgroupObject(b)) => {
-                // Payload comparison is Bytes ==, which checks length before
-                // the byte-wise compare.
                 a.subgroup_object == b.subgroup_object && a.extension_headers == b.extension_headers
             }
             (Self::ObjectDatagram(a), Self::ObjectDatagram(b)) => {
@@ -141,8 +136,6 @@ mod tests {
 
     #[test]
     fn stream_encoding_details_are_not_immutable_properties() {
-        // The same object can legitimately arrive with a different
-        // object_id_delta (e.g. re-encoded by a fetch fill).
         let a = subgroup_object(0, b"same");
         let b = subgroup_object(3, b"same");
         assert!(a.matches_immutable_properties(&b));

--- a/relay/src/modules/core/data_object.rs
+++ b/relay/src/modules/core/data_object.rs
@@ -14,8 +14,6 @@ impl DataObject {
         }
     }
 
-    /// §2.5 condition 8 comparison. Excludes `track_alias`, `message_type`
-    /// and `object_id_delta`: a fetch fill re-encodes them for the same object.
     pub(crate) fn matches_immutable_properties(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::SubgroupHeader(a), Self::SubgroupHeader(b)) => {

--- a/relay/src/modules/core/publisher.rs
+++ b/relay/src/modules/core/publisher.rs
@@ -19,6 +19,13 @@ pub(crate) trait Publisher: 'static + Send + Sync {
         track_namespace: String,
         track_name: String,
     ) -> anyhow::Result<DownstreamSubscription>;
+    async fn send_publish_done(
+        &self,
+        request_id: u64,
+        status_code: u64,
+        stream_count: u64,
+        error_reason: String,
+    ) -> anyhow::Result<()>;
     fn new_stream_factory(
         &self,
         downstream_subscription: &DownstreamSubscription,
@@ -46,6 +53,17 @@ impl<T: moqt::TransportProtocol> Publisher for moqt::Publisher<T> {
         let option = moqt::PublishOption::default();
         let subscription = self.publish(track_namespace, track_name, option).await?;
         Ok(DownstreamSubscription::from(subscription))
+    }
+
+    async fn send_publish_done(
+        &self,
+        request_id: u64,
+        status_code: u64,
+        stream_count: u64,
+        error_reason: String,
+    ) -> anyhow::Result<()> {
+        self.publish_done(request_id, status_code, stream_count, error_reason)
+            .await
     }
 
     fn new_stream_factory(

--- a/relay/src/modules/core/subscription.rs
+++ b/relay/src/modules/core/subscription.rs
@@ -73,6 +73,10 @@ impl DownstreamSubscription {
         &self.inner
     }
 
+    pub(crate) fn request_id(&self) -> u64 {
+        self.inner.request_id()
+    }
+
     pub(crate) fn track_alias(&self) -> u64 {
         self.inner.track_alias()
     }

--- a/relay/src/modules/enums.rs
+++ b/relay/src/modules/enums.rs
@@ -109,6 +109,22 @@ pub(crate) enum FetchErrorCode {
     ExpiredAuthToken = 0x12,
 }
 
+// https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.12
+// PUBLISH_DONE status codes.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub(crate) enum PublishDoneStatusCode {
+    InternalError = 0x0,
+    Unauthorized = 0x1,
+    TrackEnded = 0x2,
+    SubscriptionEnded = 0x3,
+    GoingAway = 0x4,
+    Expired = 0x5,
+    TooFarBehind = 0x6,
+    MalformedTrack = 0x7,
+}
+
 // https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.9
 // SUBSCRIBE_ERROR error codes.
 #[allow(dead_code)]

--- a/relay/src/modules/enums.rs
+++ b/relay/src/modules/enums.rs
@@ -109,22 +109,6 @@ pub(crate) enum FetchErrorCode {
     ExpiredAuthToken = 0x12,
 }
 
-// https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.12
-// PUBLISH_DONE status codes.
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u64)]
-pub(crate) enum PublishDoneStatusCode {
-    InternalError = 0x0,
-    Unauthorized = 0x1,
-    TrackEnded = 0x2,
-    SubscriptionEnded = 0x3,
-    GoingAway = 0x4,
-    Expired = 0x5,
-    TooFarBehind = 0x6,
-    MalformedTrack = 0x7,
-}
-
 // https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html#section-9.9
 // SUBSCRIBE_ERROR error codes.
 #[allow(dead_code)]

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -295,9 +295,12 @@ mod tests {
 
     #[tokio::test]
     async fn append_identical_duplicate_keeps_first() {
+        // Arrange: the same object arrives twice
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
+        // Act
         let first = cache.append(Some(0), payload_object(b"same")).await;
         let second = cache.append(Some(0), payload_object(b"same")).await;
+        // Assert: first-wins dedup, no malformed flag
         assert_eq!(first, Ok(AppendStatus::Inserted));
         assert_eq!(second, Ok(AppendStatus::Duplicate));
         let snapshot = cache.objects_snapshot().await;
@@ -309,9 +312,12 @@ mod tests {
 
     #[tokio::test]
     async fn append_duplicate_with_different_payload_is_malformed() {
+        // Arrange
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let _ = cache.append(Some(0), payload_object(b"first")).await;
+        // Act: the same object_id arrives again with a different payload
         let outcome = cache.append(Some(0), payload_object(b"second")).await;
+        // Assert: malformed; the first object is kept untouched
         assert_eq!(outcome, Err(TrackMalformed));
         let snapshot = cache.objects_snapshot().await;
         assert_eq!(payload_of(&snapshot[0].1), Bytes::from_static(b"first"));
@@ -319,9 +325,11 @@ mod tests {
 
     #[tokio::test]
     async fn append_identical_header_twice_keeps_first() {
+        // Arrange / Act: the same subgroup header arrives twice
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let first = cache.append(None, header_object(1)).await;
         let second = cache.append(None, header_object(1)).await;
+        // Assert: first-wins, no malformed flag
         assert_eq!(first, Ok(AppendStatus::Inserted));
         assert_eq!(second, Ok(AppendStatus::Duplicate));
         assert!(cache.header().await.is_some());
@@ -329,9 +337,12 @@ mod tests {
 
     #[tokio::test]
     async fn append_header_with_different_priority_is_malformed() {
+        // Arrange
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let _ = cache.append(None, header_object(1)).await;
+        // Act: a second header with a different publisher priority
         let outcome = cache.append(None, header_object(2)).await;
+        // Assert: malformed; the first header survives
         assert_eq!(outcome, Err(TrackMalformed));
         match cache.header().await.unwrap().as_ref() {
             DataObject::SubgroupHeader(h) => assert_eq!(h.publisher_priority, 1),

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -325,8 +325,9 @@ mod tests {
 
     #[tokio::test]
     async fn append_identical_header_twice_keeps_first() {
-        // Arrange / Act: the same subgroup header arrives twice
+        // Arrange
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
+        // Act: the same subgroup header arrives twice
         let first = cache.append(None, header_object(1)).await;
         let second = cache.append(None, header_object(1)).await;
         // Assert: first-wins, no malformed flag

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -33,14 +33,16 @@ pub(crate) enum SubgroupLifecycle {
     Closed = 2,
 }
 
-#[must_use]
+/// The track violated draft-14 §2.5 (same Object, different immutable
+/// properties) and is quarantined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TrackMalformed;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum AppendOutcome {
-    Appended,
+pub(crate) enum AppendStatus {
+    Inserted,
     /// Identical duplicate, ignored (§8.1 first-wins; normal in cascading).
     Duplicate,
-    /// §2.5 condition 8: same Object, different immutable properties.
-    MalformedTrack,
 }
 
 pub(crate) struct GroupCache {
@@ -81,37 +83,37 @@ impl GroupCache {
         &self,
         object_id: Option<u64>,
         object: Arc<DataObject>,
-    ) -> AppendOutcome {
-        let outcome = match object_id {
+    ) -> Result<AppendStatus, TrackMalformed> {
+        let result = match object_id {
             None => {
                 let mut header = self.header.write().await;
                 match header.as_ref() {
                     Some(existing) if existing.matches_immutable_properties(&object) => {
-                        AppendOutcome::Duplicate
+                        Ok(AppendStatus::Duplicate)
                     }
-                    Some(_) => AppendOutcome::MalformedTrack,
+                    Some(_) => Err(TrackMalformed),
                     None => {
                         *header = Some(object);
-                        AppendOutcome::Appended
+                        Ok(AppendStatus::Inserted)
                     }
                 }
             }
             Some(object_id) => match self.objects.write().await.entry(object_id) {
                 Entry::Occupied(existing) => {
                     if existing.get().1.matches_immutable_properties(&object) {
-                        AppendOutcome::Duplicate
+                        Ok(AppendStatus::Duplicate)
                     } else {
-                        AppendOutcome::MalformedTrack
+                        Err(TrackMalformed)
                     }
                 }
                 Entry::Vacant(slot) => {
                     slot.insert((Instant::now(), object));
-                    AppendOutcome::Appended
+                    Ok(AppendStatus::Inserted)
                 }
             },
         };
         self.notify.notify_waiters();
-        outcome
+        result
     }
 
     pub(crate) async fn contains_object(&self, object_id: u64) -> bool {
@@ -301,8 +303,8 @@ mod tests {
         let first = cache.append(Some(0), payload_object(b"same")).await;
         let second = cache.append(Some(0), payload_object(b"same")).await;
         // Assert: first-wins dedup, no malformed flag
-        assert_eq!(first, AppendOutcome::Appended);
-        assert_eq!(second, AppendOutcome::Duplicate);
+        assert_eq!(first, Ok(AppendStatus::Inserted));
+        assert_eq!(second, Ok(AppendStatus::Duplicate));
         let snapshot = cache.objects_snapshot().await;
         assert_eq!(snapshot.len(), 1);
         let (id, object) = &snapshot[0];
@@ -317,7 +319,7 @@ mod tests {
         let _ = cache.append(Some(0), payload_object(b"first")).await;
         let outcome = cache.append(Some(0), payload_object(b"second")).await;
         // Assert: malformed; the first object is kept untouched
-        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        assert_eq!(outcome, Err(TrackMalformed));
         let snapshot = cache.objects_snapshot().await;
         assert_eq!(payload_of(&snapshot[0].1), Bytes::from_static(b"first"));
     }
@@ -329,8 +331,8 @@ mod tests {
         let first = cache.append(None, header_object(1)).await;
         let second = cache.append(None, header_object(1)).await;
         // Assert: first-wins, no malformed flag
-        assert_eq!(first, AppendOutcome::Appended);
-        assert_eq!(second, AppendOutcome::Duplicate);
+        assert_eq!(first, Ok(AppendStatus::Inserted));
+        assert_eq!(second, Ok(AppendStatus::Duplicate));
         assert!(cache.header().await.is_some());
     }
 
@@ -341,7 +343,7 @@ mod tests {
         let _ = cache.append(None, header_object(1)).await;
         let outcome = cache.append(None, header_object(2)).await;
         // Assert: malformed; the first header survives
-        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        assert_eq!(outcome, Err(TrackMalformed));
         match cache.header().await.unwrap().as_ref() {
             DataObject::SubgroupHeader(h) => assert_eq!(h.publisher_priority, 1),
             _ => panic!("expected SubgroupHeader"),

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -295,11 +295,9 @@ mod tests {
 
     #[tokio::test]
     async fn append_identical_duplicate_keeps_first() {
-        // Arrange: the same object arrives twice
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let first = cache.append(Some(0), payload_object(b"same")).await;
         let second = cache.append(Some(0), payload_object(b"same")).await;
-        // Assert: first-wins dedup, no malformed flag
         assert_eq!(first, Ok(AppendStatus::Inserted));
         assert_eq!(second, Ok(AppendStatus::Duplicate));
         let snapshot = cache.objects_snapshot().await;
@@ -311,11 +309,9 @@ mod tests {
 
     #[tokio::test]
     async fn append_duplicate_with_different_payload_is_malformed() {
-        // Arrange: the same object_id arrives again with a different payload
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let _ = cache.append(Some(0), payload_object(b"first")).await;
         let outcome = cache.append(Some(0), payload_object(b"second")).await;
-        // Assert: malformed; the first object is kept untouched
         assert_eq!(outcome, Err(TrackMalformed));
         let snapshot = cache.objects_snapshot().await;
         assert_eq!(payload_of(&snapshot[0].1), Bytes::from_static(b"first"));
@@ -323,11 +319,9 @@ mod tests {
 
     #[tokio::test]
     async fn append_identical_header_twice_keeps_first() {
-        // Arrange: the same subgroup header arrives twice
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let first = cache.append(None, header_object(1)).await;
         let second = cache.append(None, header_object(1)).await;
-        // Assert: first-wins, no malformed flag
         assert_eq!(first, Ok(AppendStatus::Inserted));
         assert_eq!(second, Ok(AppendStatus::Duplicate));
         assert!(cache.header().await.is_some());
@@ -335,11 +329,9 @@ mod tests {
 
     #[tokio::test]
     async fn append_header_with_different_priority_is_malformed() {
-        // Arrange: a second header with a different publisher priority
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let _ = cache.append(None, header_object(1)).await;
         let outcome = cache.append(None, header_object(2)).await;
-        // Assert: malformed; the first header survives
         assert_eq!(outcome, Err(TrackMalformed));
         match cache.header().await.unwrap().as_ref() {
             DataObject::SubgroupHeader(h) => assert_eq!(h.publisher_priority, 1),

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -33,18 +33,13 @@ pub(crate) enum SubgroupLifecycle {
     Closed = 2,
 }
 
-/// Result of appending an object into the cache (draft-14 §8.1 dedup and
-/// §2.5 condition 8 detection).
 #[must_use]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AppendOutcome {
-    /// The object was stored.
     Appended,
-    /// A byte-identical duplicate was ignored (first-wins). Normal in
-    /// cascading topologies where the same object arrives via several paths.
+    /// Identical duplicate ignored (§8.1 first-wins; normal in cascading).
     Duplicate,
-    /// The same Object arrived again with different payload or other
-    /// immutable properties: the track is malformed (draft-14 §2.5).
+    /// Same Object with different immutable properties (§2.5 condition 8).
     MalformedTrack,
 }
 
@@ -88,9 +83,7 @@ impl GroupCache {
         object: Arc<DataObject>,
     ) -> AppendOutcome {
         let outcome = match object_id {
-            // No object_id = subgroup header. Keep the first one (first-wins),
-            // but a later header with different immutable properties (e.g.
-            // publisher priority) makes the track malformed (§2.5 condition 8).
+            // No object_id = subgroup header.
             None => {
                 let mut header = self.header.write().await;
                 match header.as_ref() {
@@ -104,8 +97,6 @@ impl GroupCache {
                     }
                 }
             }
-            // A later identical object with the same object_id is ignored
-            // (draft-14 §8.1 dedup); a differing one is malformed (§2.5).
             Some(object_id) => match self.objects.write().await.entry(object_id) {
                 Entry::Occupied(existing) => {
                     if existing.get().1.matches_immutable_properties(&object) {
@@ -306,11 +297,11 @@ mod tests {
 
     #[tokio::test]
     async fn append_identical_duplicate_keeps_first() {
-        // Arrange: the same object arrives twice (normal in cascading setups)
+        // Arrange: the same object arrives twice
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let first = cache.append(Some(0), payload_object(b"same")).await;
         let second = cache.append(Some(0), payload_object(b"same")).await;
-        // Assert: first-wins dedup, and neither append flags the track
+        // Assert: first-wins dedup, no malformed flag
         assert_eq!(first, AppendOutcome::Appended);
         assert_eq!(second, AppendOutcome::Duplicate);
         let snapshot = cache.objects_snapshot().await;
@@ -323,11 +314,10 @@ mod tests {
     #[tokio::test]
     async fn append_duplicate_with_different_payload_is_malformed() {
         // Arrange: the same object_id arrives again with a different payload
-        // (draft-14 §2.5 condition 8)
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let _ = cache.append(Some(0), payload_object(b"first")).await;
         let outcome = cache.append(Some(0), payload_object(b"second")).await;
-        // Assert: detected as malformed; the first object is kept untouched
+        // Assert: malformed; the first object is kept untouched
         assert_eq!(outcome, AppendOutcome::MalformedTrack);
         let snapshot = cache.objects_snapshot().await;
         assert_eq!(payload_of(&snapshot[0].1), Bytes::from_static(b"first"));
@@ -347,12 +337,11 @@ mod tests {
 
     #[tokio::test]
     async fn append_header_with_different_priority_is_malformed() {
-        // Arrange: a second header for the same subgroup with a different
-        // publisher priority (an immutable property, §2.5 condition 8)
+        // Arrange: a second header with a different publisher priority
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
         let _ = cache.append(None, header_object(1)).await;
         let outcome = cache.append(None, header_object(2)).await;
-        // Assert: detected as malformed; the first header survives
+        // Assert: malformed; the first header survives
         assert_eq!(outcome, AppendOutcome::MalformedTrack);
         match cache.header().await.unwrap().as_ref() {
             DataObject::SubgroupHeader(h) => assert_eq!(h.publisher_priority, 1),

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -37,9 +37,9 @@ pub(crate) enum SubgroupLifecycle {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AppendOutcome {
     Appended,
-    /// Identical duplicate ignored (§8.1 first-wins; normal in cascading).
+    /// Identical duplicate, ignored (§8.1 first-wins; normal in cascading).
     Duplicate,
-    /// Same Object with different immutable properties (§2.5 condition 8).
+    /// §2.5 condition 8: same Object, different immutable properties.
     MalformedTrack,
 }
 
@@ -83,7 +83,6 @@ impl GroupCache {
         object: Arc<DataObject>,
     ) -> AppendOutcome {
         let outcome = match object_id {
-            // No object_id = subgroup header.
             None => {
                 let mut header = self.header.write().await;
                 match header.as_ref() {

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -33,8 +33,6 @@ pub(crate) enum SubgroupLifecycle {
     Closed = 2,
 }
 
-/// The track violated draft-14 §2.5 (same Object, different immutable
-/// properties) and is quarantined.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TrackMalformed;
 

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -41,7 +41,6 @@ pub(crate) struct TrackMalformed;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AppendStatus {
     Inserted,
-    /// Identical duplicate, ignored (§8.1 first-wins; normal in cascading).
     Duplicate,
 }
 

--- a/relay/src/modules/relay/cache/group_cache.rs
+++ b/relay/src/modules/relay/cache/group_cache.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, btree_map::Entry},
     ops::Range,
     sync::{
         Arc,
@@ -31,6 +31,21 @@ pub(crate) enum SubgroupLifecycle {
     AwaitingCloseSignal = 1,
     /// The close signal arrived; no more objects will be appended.
     Closed = 2,
+}
+
+/// Result of appending an object into the cache (draft-14 §8.1 dedup and
+/// §2.5 condition 8 detection).
+#[must_use]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AppendOutcome {
+    /// The object was stored.
+    Appended,
+    /// A byte-identical duplicate was ignored (first-wins). Normal in
+    /// cascading topologies where the same object arrives via several paths.
+    Duplicate,
+    /// The same Object arrived again with different payload or other
+    /// immutable properties: the track is malformed (draft-14 §2.5).
+    MalformedTrack,
 }
 
 pub(crate) struct GroupCache {
@@ -67,28 +82,50 @@ impl GroupCache {
         }
     }
 
-    // FIXME: §8.1 also requires treating a duplicate whose payload/subgroup/priority
-    // differs (or an invalid status transition) as Malformed (MUST). Not implemented;
-    // we only ignore duplicates (first-wins).
-    pub(crate) async fn append(&self, object_id: Option<u64>, object: Arc<DataObject>) {
-        match object_id {
-            // No object_id = subgroup header. Keep the first one (first-wins).
+    pub(crate) async fn append(
+        &self,
+        object_id: Option<u64>,
+        object: Arc<DataObject>,
+    ) -> AppendOutcome {
+        let outcome = match object_id {
+            // No object_id = subgroup header. Keep the first one (first-wins),
+            // but a later header with different immutable properties (e.g.
+            // publisher priority) makes the track malformed (§2.5 condition 8).
             None => {
                 let mut header = self.header.write().await;
-                if header.is_none() {
-                    *header = Some(object);
+                match header.as_ref() {
+                    Some(existing) if existing.matches_immutable_properties(&object) => {
+                        AppendOutcome::Duplicate
+                    }
+                    Some(_) => AppendOutcome::MalformedTrack,
+                    None => {
+                        *header = Some(object);
+                        AppendOutcome::Appended
+                    }
                 }
             }
-            // A later object with the same object_id is ignored (draft-14 §8.1 dedup).
-            Some(object_id) => {
-                self.objects
-                    .write()
-                    .await
-                    .entry(object_id)
-                    .or_insert((Instant::now(), object));
-            }
-        }
+            // A later identical object with the same object_id is ignored
+            // (draft-14 §8.1 dedup); a differing one is malformed (§2.5).
+            Some(object_id) => match self.objects.write().await.entry(object_id) {
+                Entry::Occupied(existing) => {
+                    if existing.get().1.matches_immutable_properties(&object) {
+                        AppendOutcome::Duplicate
+                    } else {
+                        AppendOutcome::MalformedTrack
+                    }
+                }
+                Entry::Vacant(slot) => {
+                    slot.insert((Instant::now(), object));
+                    AppendOutcome::Appended
+                }
+            },
+        };
         self.notify.notify_waiters();
+        outcome
+    }
+
+    pub(crate) async fn contains_object(&self, object_id: u64) -> bool {
+        self.objects.read().await.contains_key(&object_id)
     }
 
     pub(crate) async fn evict_expired_objects(&self, ttl: Duration) -> Option<Range<u64>> {
@@ -268,30 +305,56 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn append_same_object_id_keeps_first() {
-        // Arrange: two objects with the same object_id but distinct payloads
+    async fn append_identical_duplicate_keeps_first() {
+        // Arrange: the same object arrives twice (normal in cascading setups)
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
-        cache.append(Some(0), payload_object(b"first")).await;
-        cache.append(Some(0), payload_object(b"second")).await;
-        // Act
+        let first = cache.append(Some(0), payload_object(b"same")).await;
+        let second = cache.append(Some(0), payload_object(b"same")).await;
+        // Assert: first-wins dedup, and neither append flags the track
+        assert_eq!(first, AppendOutcome::Appended);
+        assert_eq!(second, AppendOutcome::Duplicate);
         let snapshot = cache.objects_snapshot().await;
-        // Assert: only the first object survives (first-wins dedup)
         assert_eq!(snapshot.len(), 1);
         let (id, object) = &snapshot[0];
         assert_eq!(*id, 0);
-        assert_eq!(payload_of(object), Bytes::from_static(b"first"));
+        assert_eq!(payload_of(object), Bytes::from_static(b"same"));
     }
 
     #[tokio::test]
-    async fn append_header_twice_keeps_first() {
-        // Arrange: two subgroup headers distinguished by publisher_priority
+    async fn append_duplicate_with_different_payload_is_malformed() {
+        // Arrange: the same object_id arrives again with a different payload
+        // (draft-14 §2.5 condition 8)
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
-        cache.append(None, header_object(1)).await;
-        cache.append(None, header_object(2)).await;
-        // Act
-        let header = cache.header().await.unwrap();
-        // Assert: the first header survives (first-wins)
-        match header.as_ref() {
+        let _ = cache.append(Some(0), payload_object(b"first")).await;
+        let outcome = cache.append(Some(0), payload_object(b"second")).await;
+        // Assert: detected as malformed; the first object is kept untouched
+        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        let snapshot = cache.objects_snapshot().await;
+        assert_eq!(payload_of(&snapshot[0].1), Bytes::from_static(b"first"));
+    }
+
+    #[tokio::test]
+    async fn append_identical_header_twice_keeps_first() {
+        // Arrange: the same subgroup header arrives twice
+        let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
+        let first = cache.append(None, header_object(1)).await;
+        let second = cache.append(None, header_object(1)).await;
+        // Assert: first-wins, no malformed flag
+        assert_eq!(first, AppendOutcome::Appended);
+        assert_eq!(second, AppendOutcome::Duplicate);
+        assert!(cache.header().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn append_header_with_different_priority_is_malformed() {
+        // Arrange: a second header for the same subgroup with a different
+        // publisher priority (an immutable property, §2.5 condition 8)
+        let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
+        let _ = cache.append(None, header_object(1)).await;
+        let outcome = cache.append(None, header_object(2)).await;
+        // Assert: detected as malformed; the first header survives
+        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        match cache.header().await.unwrap().as_ref() {
             DataObject::SubgroupHeader(h) => assert_eq!(h.publisher_priority, 1),
             _ => panic!("expected SubgroupHeader"),
         }
@@ -301,9 +364,9 @@ mod tests {
     async fn object_from_or_wait_returns_exact_match() {
         // Arrange: objects at ids 0, 3, 5
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
-        cache.append(Some(0), payload_object(b"o0")).await;
-        cache.append(Some(3), payload_object(b"o3")).await;
-        cache.append(Some(5), payload_object(b"o5")).await;
+        let _ = cache.append(Some(0), payload_object(b"o0")).await;
+        let _ = cache.append(Some(3), payload_object(b"o3")).await;
+        let _ = cache.append(Some(5), payload_object(b"o5")).await;
         // Act: ask for exactly id 3
         let (id, _) = cache.object_from_or_wait(3).await.unwrap();
         // Assert: the exact id is returned (inclusive lower bound)
@@ -314,9 +377,9 @@ mod tests {
     async fn object_from_or_wait_skips_gap_to_next_id() {
         // Arrange: objects at ids 0, 3, 5 (no object at 1, 2, 4)
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
-        cache.append(Some(0), payload_object(b"o0")).await;
-        cache.append(Some(3), payload_object(b"o3")).await;
-        cache.append(Some(5), payload_object(b"o5")).await;
+        let _ = cache.append(Some(0), payload_object(b"o0")).await;
+        let _ = cache.append(Some(3), payload_object(b"o3")).await;
+        let _ = cache.append(Some(5), payload_object(b"o5")).await;
         // Act: ask for id 4, which has no object
         let (id, _) = cache.object_from_or_wait(4).await.unwrap();
         // Assert: the next available id (5) is returned across the gap
@@ -328,9 +391,9 @@ mod tests {
         // Arrange: object 0 at t=0, object 1 at t=6s, TTL=10s
         let ttl = Duration::from_secs(10);
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
-        cache.append(Some(0), payload_object(b"old")).await;
+        let _ = cache.append(Some(0), payload_object(b"old")).await;
         tokio::time::advance(Duration::from_secs(6)).await;
-        cache.append(Some(1), payload_object(b"new")).await;
+        let _ = cache.append(Some(1), payload_object(b"new")).await;
         // Act: at t=11s, object 0 is 11s old (>10), object 1 is 5s old (<=10)
         tokio::time::advance(Duration::from_secs(5)).await;
         cache.evict_expired_objects(ttl).await;
@@ -345,7 +408,7 @@ mod tests {
         // Arrange: object 0 at t=0, TTL=10s
         let ttl = Duration::from_secs(10);
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
-        cache.append(Some(0), payload_object(b"o")).await;
+        let _ = cache.append(Some(0), payload_object(b"o")).await;
         // Act: at exactly t=10s, age == TTL, which is not `> TTL`
         tokio::time::advance(Duration::from_secs(10)).await;
         cache.evict_expired_objects(ttl).await;
@@ -357,7 +420,7 @@ mod tests {
     async fn object_from_or_wait_returns_none_when_closed() {
         // Arrange: one object at id 0, then the group is closed
         let cache = GroupCache::new(SubgroupLifecycle::AwaitingCloseSignal);
-        cache.append(Some(0), payload_object(b"o0")).await;
+        let _ = cache.append(Some(0), payload_object(b"o0")).await;
         cache.mark_end_of_group();
         // Act: ask for id 1, beyond the last object, on a closed group
         let result = cache.object_from_or_wait(1).await;

--- a/relay/src/modules/relay/cache/store.rs
+++ b/relay/src/modules/relay/cache/store.rs
@@ -95,10 +95,10 @@ mod tests {
             let track = store.get_or_create(&key);
             let header = SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false);
             let message_type = header.message_type;
-            track
+            let _ = track
                 .append_stream_object(0, &subgroup, None, DataObject::SubgroupHeader(header))
                 .await;
-            track
+            let _ = track
                 .append_stream_object(
                     0,
                     &subgroup,

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -13,15 +13,12 @@ use crate::modules::{
     core::data_object::DataObject,
     relay::{
         cache::{
-            group_cache::{AppendOutcome, GroupCache, SubgroupLifecycle},
+            group_cache::{AppendStatus, GroupCache, SubgroupLifecycle, TrackMalformed},
             known_ranges::KnownRanges,
         },
         types::StreamSubgroupId,
     },
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TrackMalformed;
 
 pub(crate) struct TrackCache {
     stream_groups: RwLock<BTreeMap<u64, BTreeMap<StreamSubgroupId, Arc<GroupCache>>>>,
@@ -126,7 +123,7 @@ impl TrackCache {
         subgroup_id: &StreamSubgroupId,
         object_id: Option<u64>,
         object: DataObject,
-    ) -> AppendOutcome {
+    ) -> Result<(), TrackMalformed> {
         self.append_stream_object_with_lifecycle(
             group_id,
             subgroup_id,
@@ -143,19 +140,15 @@ impl TrackCache {
         subgroup_id: &StreamSubgroupId,
         object_id: Option<u64>,
         object: DataObject,
-    ) -> AppendOutcome {
-        let outcome = self
-            .append_stream_object_with_lifecycle(
-                group_id,
-                subgroup_id,
-                object_id,
-                object,
-                SubgroupLifecycle::AwaitingCloseSignal,
-            )
-            .await;
-        if outcome == AppendOutcome::MalformedTrack {
-            return outcome;
-        }
+    ) -> Result<(), TrackMalformed> {
+        self.append_stream_object_with_lifecycle(
+            group_id,
+            subgroup_id,
+            object_id,
+            object,
+            SubgroupLifecycle::AwaitingCloseSignal,
+        )
+        .await?;
         if let Some(object_id) = object_id {
             self.known_ranges.write().await.insert(
                 moqt::Location {
@@ -168,7 +161,7 @@ impl TrackCache {
                 },
             );
         }
-        outcome
+        Ok(())
     }
 
     async fn append_stream_object_with_lifecycle(
@@ -178,26 +171,26 @@ impl TrackCache {
         object_id: Option<u64>,
         object: DataObject,
         lifecycle: SubgroupLifecycle,
-    ) -> AppendOutcome {
+    ) -> Result<(), TrackMalformed> {
         if self.is_malformed() {
-            return AppendOutcome::MalformedTrack;
+            return Err(TrackMalformed);
         }
         let group = self
             .ensure_stream_subgroup(group_id, subgroup_id, lifecycle)
             .await;
-        let mut outcome = group.append(object_id, Arc::new(object)).await;
-        if outcome == AppendOutcome::Appended
+        let mut result = group.append(object_id, Arc::new(object)).await;
+        if result == Ok(AppendStatus::Inserted)
             && let Some(object_id) = object_id
             && self
                 .object_exists_in_other_subgroup(group_id, subgroup_id, object_id)
                 .await
         {
-            outcome = AppendOutcome::MalformedTrack;
+            result = Err(TrackMalformed);
         }
-        if outcome == AppendOutcome::MalformedTrack {
+        if result.is_err() {
             self.mark_malformed();
         }
-        outcome
+        result.map(|_| ())
     }
 
     /// §2.5 condition 8 across subgroups. Checked after the insert so racing
@@ -236,21 +229,21 @@ impl TrackCache {
         group_id: u64,
         object_id: Option<u64>,
         object: DataObject,
-    ) -> AppendOutcome {
+    ) -> Result<(), TrackMalformed> {
         if self.is_malformed() {
-            return AppendOutcome::MalformedTrack;
+            return Err(TrackMalformed);
         }
         // Datagrams have no subgroup header, so a resolved object_id is always expected.
         let Some(object_id) = object_id else {
             tracing::error!(group_id, "unexpected: datagram object without object_id");
-            return AppendOutcome::Duplicate;
+            return Ok(());
         };
         let group = self.ensure_datagram_group(group_id).await;
-        let outcome = group.append(Some(object_id), Arc::new(object)).await;
-        if outcome == AppendOutcome::MalformedTrack {
+        let result = group.append(Some(object_id), Arc::new(object)).await;
+        if result.is_err() {
             self.mark_malformed();
         }
-        outcome
+        result.map(|_| ())
     }
 
     pub(crate) async fn close_stream_subgroup(
@@ -2133,12 +2126,12 @@ mod tests {
             .await;
 
         // Assert: latched, and later appends are rejected
-        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        assert_eq!(outcome, Err(TrackMalformed));
         assert!(cache.is_malformed());
         let rejected = cache
             .append_live_stream_object(0, &even, Some(5), make_object(0))
             .await;
-        assert_eq!(rejected, AppendOutcome::MalformedTrack);
+        assert_eq!(rejected, Err(TrackMalformed));
     }
 
     #[tokio::test]
@@ -2159,7 +2152,7 @@ mod tests {
             .await;
 
         // Assert
-        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        assert_eq!(outcome, Err(TrackMalformed));
         assert!(cache.is_malformed());
     }
 
@@ -2198,7 +2191,7 @@ mod tests {
         let outcome = cache
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"b"))
             .await;
-        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        assert_eq!(outcome, Err(TrackMalformed));
 
         // Assert: the in-flight collection aborts instead of serving.
         let result = tokio::time::timeout(Duration::from_secs(5), fetch)

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -2128,7 +2128,8 @@ mod tests {
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"a"))
             .await;
 
-        // Act: the fetch consumes object 0, then waits for object 1
+        // Act: the fetch consumes object 0 and waits for object 1, then a
+        // conflicting duplicate latches the track mid-wait
         let fetch = tokio::spawn({
             let cache = cache.clone();
             async move {
@@ -2147,7 +2148,6 @@ mod tests {
             }
         });
         tokio::task::yield_now().await;
-        // A conflicting duplicate latches the track while the fetch waits
         let outcome = cache
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"b"))
             .await;

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -26,7 +26,6 @@ pub(crate) struct TrackCache {
     known_ranges: RwLock<KnownRanges>,
     live_ingest_count: AtomicUsize,
     eviction_generation: AtomicU64,
-    /// Sticky §2.5 Malformed Track latch; quarantines the track, not the session.
     malformed: AtomicBool,
     malformed_notify: Notify,
 }
@@ -61,7 +60,6 @@ impl TrackCache {
         self.malformed_notify.notify_waiters();
     }
 
-    /// Resolves once the track is marked malformed; pends forever otherwise.
     pub(crate) async fn malformed_track_detected(&self) {
         loop {
             let notified = self.malformed_notify.notified();
@@ -193,9 +191,6 @@ impl TrackCache {
         result.map(|_| ())
     }
 
-    /// §2.5 condition 8 across subgroups. Checked after the insert so racing
-    /// writers cannot both miss each other. Only explicit `Value` ids are
-    /// comparable; other key kinds may alias the same subgroup.
     async fn object_exists_in_other_subgroup(
         &self,
         group_id: u64,
@@ -675,8 +670,6 @@ impl TrackCache {
             .await
     }
 
-    /// Fails as soon as the malformed latch is observed, so an in-flight
-    /// fetch is reset instead of served (§2.5).
     pub(crate) async fn get_fetch_objects_with_group_order(
         &self,
         start: moqt::Location,
@@ -905,7 +898,6 @@ mod tests {
         // Arrange: one object at id 0 in group 0
         let cache = TrackCache::new();
         fill_group_with_ids(&cache, 0, &[0]).await;
-        // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: the only object's location is returned
         assert_eq!(loc.group_id, 0);
@@ -917,7 +909,6 @@ mod tests {
         // Arrange: sequential object_ids 0, 1, 2 in group 0
         let cache = TrackCache::new();
         fill_group_with_ids(&cache, 0, &[0, 1, 2]).await;
-        // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: the largest object_id is returned
         assert_eq!(loc.group_id, 0);
@@ -929,7 +920,6 @@ mod tests {
         // Arrange: gapped object_ids 5, 8 in group 0
         let cache = TrackCache::new();
         fill_group_with_ids(&cache, 0, &[5, 8]).await;
-        // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: the largest object_id is returned even with a gap
         assert_eq!(loc.group_id, 0);
@@ -942,7 +932,6 @@ mod tests {
         let cache = TrackCache::new();
         fill_group_with_ids(&cache, 0, &[0]).await;
         fill_group_with_ids(&cache, 1, &[0]).await;
-        // Act
         let loc = cache.largest_location().await.unwrap();
         // Assert: the latest group's location is returned
         assert_eq!(loc.group_id, 1);
@@ -974,7 +963,6 @@ mod tests {
         let _ = cache
             .append_stream_object(0, &subgroup, None, make_header(0))
             .await;
-        // Act
         cache.evict(ttl).await;
         // Assert: fetch-fill leftovers are reclaimed as soon as they are empty.
         assert!(!cache.has_stream_group(0).await);
@@ -992,11 +980,9 @@ mod tests {
             .append_live_stream_object(0, &subgroup, None, make_header(0))
             .await;
 
-        // Act
         tokio::time::advance(Duration::from_secs(100)).await;
         cache.evict(ttl).await;
 
-        // Assert
         assert!(cache.has_stream_group(0).await);
     }
 
@@ -1254,7 +1240,6 @@ mod tests {
             )
             .await;
 
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1339,36 +1324,29 @@ mod tests {
         cache.evict(ttl).await;
         cache.evict(ttl).await;
 
-        // Assert
         assert!(!cache.has_stream_group(0).await);
     }
 
     #[tokio::test(start_paused = true)]
     async fn eviction_generation_does_not_increment_when_nothing_removed() {
-        // Arrange
         let cache = TrackCache::new();
         let generation = cache.eviction_generation();
 
-        // Act
         cache.evict(Duration::from_secs(10)).await;
 
-        // Assert
         assert_eq!(cache.eviction_generation(), generation);
     }
 
     #[tokio::test(start_paused = true)]
     async fn eviction_generation_increments_when_objects_are_removed() {
-        // Arrange
         let ttl = Duration::from_secs(10);
         let cache = TrackCache::new();
         fill_group_with_ids(&cache, 0, &[0]).await;
         let generation = cache.eviction_generation();
 
-        // Act
         tokio::time::advance(Duration::from_secs(11)).await;
         cache.evict(ttl).await;
 
-        // Assert
         assert!(cache.eviction_generation() > generation);
     }
 
@@ -1381,7 +1359,6 @@ mod tests {
         fill_group_with_ids(&cache, 0, &[0, 1, 2]).await;
         fill_group_with_ids(&cache, 1, &[0, 1]).await;
 
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1416,7 +1393,6 @@ mod tests {
         fill_group_with_ids(&cache, 0, &[0, 1, 2]).await;
         fill_group_with_ids(&cache, 1, &[0, 1]).await;
 
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1430,7 +1406,6 @@ mod tests {
             )
             .await;
 
-        // Assert
         assert_eq!(resolution, FetchRangeResolution::NotCovered);
     }
 
@@ -1470,7 +1445,6 @@ mod tests {
         let cache = TrackCache::new();
         fill_group_with_ids(&cache, 0, &[0]).await;
 
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1497,7 +1471,6 @@ mod tests {
         cache.begin_live_ingest();
         cache.end_live_ingest();
 
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1641,7 +1614,6 @@ mod tests {
     async fn resolve_fetch_range_returns_not_covered_for_empty_cache() {
         // Arrange: empty cache
         let cache = TrackCache::new();
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1663,7 +1635,6 @@ mod tests {
         // Arrange: group 0 has exactly the requested object coverage.
         let cache = TrackCache::new();
         fill_group(&cache, 0, 3).await;
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1693,7 +1664,6 @@ mod tests {
         // Arrange: object 1 is not cached, but cache coverage starts before it.
         let cache = TrackCache::new();
         fill_group_with_ids(&cache, 0, &[0, 2]).await;
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1726,7 +1696,6 @@ mod tests {
         fill_group(&cache, 0, 1).await;
         cache.close_stream_subgroup(0, &subgroup).await;
         fill_group(&cache, 2, 1).await;
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1748,7 +1717,6 @@ mod tests {
         // Arrange: end.object_id == 0 requests the full group, but it is still open.
         let cache = TrackCache::new();
         fill_group(&cache, 0, 3).await;
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1780,7 +1748,6 @@ mod tests {
         let subgroup = StreamSubgroupId::Value(0);
         fill_group(&cache, 0, 3).await;
         cache.close_stream_subgroup(0, &subgroup).await;
-        // Act
         let resolution = cache
             .resolve_fetch_range(
                 moqt::Location {
@@ -1845,7 +1812,6 @@ mod tests {
             )
             .await;
 
-        // Act
         let objects = cache
             .get_fetch_objects(
                 moqt::Location {
@@ -1982,7 +1948,6 @@ mod tests {
         cache.close_stream_subgroup(0, &even).await;
         cache.close_stream_subgroup(0, &odd).await;
 
-        // Act
         let objects = cache
             .get_fetch_objects(
                 moqt::Location {
@@ -1997,7 +1962,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Assert
         assert_eq!(
             object_ids(&objects),
             vec![(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (0, 5)]
@@ -2006,12 +1970,10 @@ mod tests {
 
     #[tokio::test]
     async fn get_fetch_objects_descending_groups_keep_objects_ascending() {
-        // Arrange
         let cache = TrackCache::new();
         fill_closed_group_with_ids(&cache, 0, &[0, 1]).await;
         fill_closed_group_with_ids(&cache, 1, &[0, 1]).await;
 
-        // Act
         let objects = cache
             .get_fetch_objects_with_group_order(
                 moqt::Location {
@@ -2027,7 +1989,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Assert
         assert_eq!(object_ids(&objects), vec![(1, 0), (1, 1), (0, 0), (0, 1)]);
     }
 
@@ -2105,7 +2066,6 @@ mod tests {
 
     #[tokio::test]
     async fn same_object_in_two_subgroups_is_malformed() {
-        // Arrange: object 0 already lives in subgroup 0.
         let cache = TrackCache::new();
         let even = StreamSubgroupId::Value(0);
         let odd = StreamSubgroupId::Value(1);
@@ -2119,13 +2079,10 @@ mod tests {
             .append_live_stream_object(0, &odd, None, subgroup_header_for(1))
             .await;
 
-        // Act: the same object arrives under a different subgroup (identical
-        // payload; the subgroup itself is the immutable property)
         let outcome = cache
             .append_live_stream_object(0, &odd, Some(0), make_object(0))
             .await;
 
-        // Assert: latched, and later appends are rejected
         assert_eq!(outcome, Err(TrackMalformed));
         assert!(cache.is_malformed());
         let rejected = cache
@@ -2136,7 +2093,6 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_object_with_different_payload_latches_the_track() {
-        // Arrange
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
         let _ = cache
@@ -2146,19 +2102,16 @@ mod tests {
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"a"))
             .await;
 
-        // Act
         let outcome = cache
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"b"))
             .await;
 
-        // Assert
         assert_eq!(outcome, Err(TrackMalformed));
         assert!(cache.is_malformed());
     }
 
     #[tokio::test]
     async fn get_fetch_objects_aborts_when_track_goes_malformed() {
-        // Arrange: a live group whose tail the fetch will wait for
         let cache = Arc::new(TrackCache::new());
         let subgroup = StreamSubgroupId::Value(0);
         let _ = cache
@@ -2168,7 +2121,6 @@ mod tests {
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"a"))
             .await;
 
-        // Act: the fetch consumes object 0, then waits for object 1.
         let fetch = tokio::spawn({
             let cache = cache.clone();
             async move {
@@ -2187,13 +2139,11 @@ mod tests {
             }
         });
         tokio::task::yield_now().await;
-        // A conflicting duplicate latches the track while the fetch waits.
         let outcome = cache
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"b"))
             .await;
         assert_eq!(outcome, Err(TrackMalformed));
 
-        // Assert: the in-flight collection aborts instead of serving.
         let result = tokio::time::timeout(Duration::from_secs(5), fetch)
             .await
             .expect("fetch must abort once the track is malformed")

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -682,8 +682,8 @@ impl TrackCache {
             .await
     }
 
-    /// Fails with [`TrackMalformed`] as soon as the latch is observed, so an
-    /// in-flight fetch is reset instead of served (§2.5).
+    /// Fails as soon as the malformed latch is observed, so an in-flight
+    /// fetch is reset instead of served (§2.5).
     pub(crate) async fn get_fetch_objects_with_group_order(
         &self,
         start: moqt::Location,

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -2,23 +2,27 @@ use std::{
     collections::BTreeMap,
     sync::{
         Arc,
-        atomic::{AtomicU64, AtomicUsize, Ordering as AtomicOrdering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering as AtomicOrdering},
     },
     time::Duration,
 };
 
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 
 use crate::modules::{
     core::data_object::DataObject,
     relay::{
         cache::{
-            group_cache::{GroupCache, SubgroupLifecycle},
+            group_cache::{AppendOutcome, GroupCache, SubgroupLifecycle},
             known_ranges::KnownRanges,
         },
         types::StreamSubgroupId,
     },
 };
+
+/// Marker error: the track was latched malformed while serving from it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TrackMalformed;
 
 pub(crate) struct TrackCache {
     stream_groups: RwLock<BTreeMap<u64, BTreeMap<StreamSubgroupId, Arc<GroupCache>>>>,
@@ -26,6 +30,11 @@ pub(crate) struct TrackCache {
     known_ranges: RwLock<KnownRanges>,
     live_ingest_count: AtomicUsize,
     eviction_generation: AtomicU64,
+    /// Sticky Malformed Track latch (draft-14 §2.5). Once set the track is
+    /// quarantined: appends are rejected, fetch serving aborts, and egress
+    /// runners terminate their subscriptions. The session itself stays alive.
+    malformed: AtomicBool,
+    malformed_notify: Notify,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -44,6 +53,32 @@ impl TrackCache {
             known_ranges: RwLock::new(KnownRanges::default()),
             live_ingest_count: AtomicUsize::new(0),
             eviction_generation: AtomicU64::new(0),
+            malformed: AtomicBool::new(false),
+            malformed_notify: Notify::new(),
+        }
+    }
+
+    pub(crate) fn is_malformed(&self) -> bool {
+        self.malformed.load(AtomicOrdering::Acquire)
+    }
+
+    fn mark_malformed(&self) {
+        self.malformed.store(true, AtomicOrdering::Release);
+        self.malformed_notify.notify_waiters();
+    }
+
+    /// Resolves once the track is marked malformed; pends forever otherwise.
+    /// See `GroupCache::header_or_wait` for why the waiter is enabled before
+    /// the check.
+    pub(crate) async fn malformed_track_detected(&self) {
+        loop {
+            let notified = self.malformed_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.is_malformed() {
+                return;
+            }
+            notified.await;
         }
     }
 
@@ -96,11 +131,15 @@ impl TrackCache {
         subgroup_id: &StreamSubgroupId,
         object_id: Option<u64>,
         object: DataObject,
-    ) {
-        let group = self
-            .ensure_stream_subgroup(group_id, subgroup_id, SubgroupLifecycle::NoCloseSignal)
-            .await;
-        group.append(object_id, Arc::new(object)).await;
+    ) -> AppendOutcome {
+        self.append_stream_object_with_lifecycle(
+            group_id,
+            subgroup_id,
+            object_id,
+            object,
+            SubgroupLifecycle::NoCloseSignal,
+        )
+        .await
     }
 
     pub(crate) async fn append_live_stream_object(
@@ -109,15 +148,19 @@ impl TrackCache {
         subgroup_id: &StreamSubgroupId,
         object_id: Option<u64>,
         object: DataObject,
-    ) {
-        let group = self
-            .ensure_stream_subgroup(
+    ) -> AppendOutcome {
+        let outcome = self
+            .append_stream_object_with_lifecycle(
                 group_id,
                 subgroup_id,
+                object_id,
+                object,
                 SubgroupLifecycle::AwaitingCloseSignal,
             )
             .await;
-        group.append(object_id, Arc::new(object)).await;
+        if outcome == AppendOutcome::MalformedTrack {
+            return outcome;
+        }
         if let Some(object_id) = object_id {
             self.known_ranges.write().await.insert(
                 moqt::Location {
@@ -130,6 +173,70 @@ impl TrackCache {
                 },
             );
         }
+        outcome
+    }
+
+    async fn append_stream_object_with_lifecycle(
+        &self,
+        group_id: u64,
+        subgroup_id: &StreamSubgroupId,
+        object_id: Option<u64>,
+        object: DataObject,
+        lifecycle: SubgroupLifecycle,
+    ) -> AppendOutcome {
+        if self.is_malformed() {
+            return AppendOutcome::MalformedTrack;
+        }
+        let group = self
+            .ensure_stream_subgroup(group_id, subgroup_id, lifecycle)
+            .await;
+        let mut outcome = group.append(object_id, Arc::new(object)).await;
+        if outcome == AppendOutcome::Appended
+            && let Some(object_id) = object_id
+            && self
+                .object_exists_in_other_subgroup(group_id, subgroup_id, object_id)
+                .await
+        {
+            outcome = AppendOutcome::MalformedTrack;
+        }
+        if outcome == AppendOutcome::MalformedTrack {
+            self.mark_malformed();
+        }
+        outcome
+    }
+
+    /// §2.5 condition 8: the same (group, object) must not appear in two
+    /// different subgroups. Checked after the insert so two racing writers
+    /// cannot both miss the other's entry — the later one sees both.
+    /// Restricted to explicit `Value` subgroup ids: a `None` or
+    /// `FirstObjectIdDelta` key cannot be proven to denote a different
+    /// subgroup than a `Value` key of the same group.
+    async fn object_exists_in_other_subgroup(
+        &self,
+        group_id: u64,
+        subgroup_id: &StreamSubgroupId,
+        object_id: u64,
+    ) -> bool {
+        if !matches!(subgroup_id, StreamSubgroupId::Value(_)) {
+            return false;
+        }
+        let other_subgroups: Vec<Arc<GroupCache>> = {
+            let groups = self.stream_groups.read().await;
+            let Some(subgroups) = groups.get(&group_id) else {
+                return false;
+            };
+            subgroups
+                .iter()
+                .filter(|(key, _)| *key != subgroup_id && matches!(key, StreamSubgroupId::Value(_)))
+                .map(|(_, cache)| cache.clone())
+                .collect()
+        };
+        for other in other_subgroups {
+            if other.contains_object(object_id).await {
+                return true;
+            }
+        }
+        false
     }
 
     pub(crate) async fn append_datagram_object(
@@ -137,14 +244,21 @@ impl TrackCache {
         group_id: u64,
         object_id: Option<u64>,
         object: DataObject,
-    ) {
+    ) -> AppendOutcome {
+        if self.is_malformed() {
+            return AppendOutcome::MalformedTrack;
+        }
         // Datagrams have no subgroup header, so a resolved object_id is always expected.
         let Some(object_id) = object_id else {
             tracing::error!(group_id, "unexpected: datagram object without object_id");
-            return;
+            return AppendOutcome::Duplicate;
         };
         let group = self.ensure_datagram_group(group_id).await;
-        group.append(Some(object_id), Arc::new(object)).await;
+        let outcome = group.append(Some(object_id), Arc::new(object)).await;
+        if outcome == AppendOutcome::MalformedTrack {
+            self.mark_malformed();
+        }
+        outcome
     }
 
     pub(crate) async fn close_stream_subgroup(
@@ -571,17 +685,20 @@ impl TrackCache {
         &self,
         start: moqt::Location,
         end: moqt::Location,
-    ) -> Vec<moqt::FetchObjectField> {
+    ) -> Result<Vec<moqt::FetchObjectField>, TrackMalformed> {
         self.get_fetch_objects_with_group_order(start, end, moqt::GroupOrder::Ascending)
             .await
     }
 
+    /// Collects the requested range from the cache. Fails with
+    /// [`TrackMalformed`] as soon as the track's malformed latch is observed,
+    /// so an in-flight fetch can be reset instead of served (draft-14 §2.5).
     pub(crate) async fn get_fetch_objects_with_group_order(
         &self,
         start: moqt::Location,
         end: moqt::Location,
         group_order: moqt::GroupOrder,
-    ) -> Vec<moqt::FetchObjectField> {
+    ) -> Result<Vec<moqt::FetchObjectField>, TrackMalformed> {
         let mut groups_in_range: Vec<(u64, Vec<Arc<GroupCache>>)> = {
             // NOTE: Datagram objects are not included.
             let groups = self.stream_groups.read().await;
@@ -636,7 +753,11 @@ impl TrackCache {
 
             let mut group_objects = Vec::new();
             for cache in caches {
-                let Some(header) = cache.header_or_wait().await else {
+                let header = tokio::select! {
+                    header = cache.header_or_wait() => header,
+                    _ = self.malformed_track_detected() => return Err(TrackMalformed),
+                };
+                let Some(header) = header else {
                     continue; // closed before a header arrived
                 };
                 let (publisher_priority, subgroup_id) = match header.as_ref() {
@@ -651,6 +772,9 @@ impl TrackCache {
 
                 let mut next_object_id = start_object_id;
                 loop {
+                    if self.is_malformed() {
+                        return Err(TrackMalformed);
+                    }
                     if let Some(end_object_id) = end_exclusive
                         && next_object_id >= end_object_id
                     {
@@ -661,7 +785,10 @@ impl TrackCache {
                     let found = if in_known {
                         cache.first_object_from(next_object_id).await
                     } else {
-                        cache.object_from_or_wait(next_object_id).await
+                        tokio::select! {
+                            found = cache.object_from_or_wait(next_object_id) => found,
+                            _ = self.malformed_track_detected() => return Err(TrackMalformed),
+                        }
                     };
                     match found {
                         Some((current_object_id, object)) => {
@@ -695,7 +822,7 @@ impl TrackCache {
             group_objects.sort_by_key(|object| object.object_id);
             fetch_objects.extend(group_objects);
         }
-        fetch_objects
+        Ok(fetch_objects)
     }
 
     fn push_fetch_object(
@@ -782,7 +909,7 @@ mod tests {
         // Arrange: append a SubgroupHeader only, no SubgroupObject
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_stream_object(0, &subgroup, None, make_header(0))
             .await;
         // Act / Assert: a header is not an object, so None is returned
@@ -860,7 +987,7 @@ mod tests {
         let ttl = Duration::from_secs(10);
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_stream_object(0, &subgroup, None, make_header(0))
             .await;
         // Act
@@ -877,7 +1004,7 @@ mod tests {
         let ttl = Duration::from_secs(10);
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_live_stream_object(0, &subgroup, None, make_header(0))
             .await;
 
@@ -911,14 +1038,14 @@ mod tests {
         let ttl = Duration::from_secs(10);
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_stream_object(0, &subgroup, None, make_header(0))
             .await;
-        cache
+        let _ = cache
             .append_live_stream_object(0, &subgroup, Some(0), make_object(0))
             .await;
         tokio::time::advance(Duration::from_secs(6)).await;
-        cache
+        let _ = cache
             .append_live_stream_object(0, &subgroup, Some(1), make_object(0))
             .await;
 
@@ -1216,10 +1343,10 @@ mod tests {
         let ttl = Duration::from_secs(10);
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_stream_object(0, &subgroup, None, make_header(0))
             .await;
-        cache
+        let _ = cache
             .append_stream_object(0, &subgroup, Some(0), make_object(0))
             .await;
 
@@ -1409,10 +1536,10 @@ mod tests {
         // Arrange: datagrams are cached for delivery but cannot prove that gaps
         // are object non-existence.
         let cache = TrackCache::new();
-        cache
+        let _ = cache
             .append_datagram_object(0, Some(1), make_object(0))
             .await;
-        cache
+        let _ = cache
             .append_datagram_object(0, Some(3), make_object(0))
             .await;
         cache.close_datagram_group(0).await;
@@ -1512,11 +1639,11 @@ mod tests {
     // Fills a group with objects at the given (non-sequential) absolute object_ids.
     async fn fill_group_with_ids(cache: &TrackCache, group_id: u64, object_ids: &[u64]) {
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_live_stream_object(group_id, &subgroup, None, make_header(group_id))
             .await;
         for &id in object_ids {
-            cache
+            let _ = cache
                 .append_live_stream_object(group_id, &subgroup, Some(id), make_object(0))
                 .await;
         }
@@ -1711,7 +1838,8 @@ mod tests {
                     object_id: 3,
                 },
             )
-            .await;
+            .await
+            .unwrap();
         // Assert: 0,1,2 included; 3 (the End) excluded
         assert_eq!(object_ids(&objects), vec![(0, 0), (0, 1), (0, 2)]);
     }
@@ -1721,10 +1849,10 @@ mod tests {
         // Arrange: a status object carries positive knowledge about non-existence.
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_stream_object(0, &subgroup, None, make_header(0))
             .await;
-        cache
+        let _ = cache
             .append_stream_object(
                 0,
                 &subgroup,
@@ -1745,7 +1873,8 @@ mod tests {
                     object_id: 3,
                 },
             )
-            .await;
+            .await
+            .unwrap();
 
         // Assert: the status object is returned rather than filtered out.
         assert_eq!(object_ids(&objects), vec![(0, 2)]);
@@ -1772,7 +1901,8 @@ mod tests {
                     object_id: 0,
                 },
             )
-            .await;
+            .await
+            .unwrap();
         // Assert: all objects are included
         assert_eq!(
             object_ids(&objects),
@@ -1797,7 +1927,8 @@ mod tests {
                     object_id: 8,
                 },
             )
-            .await;
+            .await
+            .unwrap();
         // Assert: 0 skipped (< start), 8 excluded (>= end); 3 and 5 survive across the gaps
         assert_eq!(object_ids(&objects), vec![(0, 3), (0, 5)]);
     }
@@ -1820,7 +1951,8 @@ mod tests {
                     object_id: 3,
                 },
             )
-            .await;
+            .await
+            .unwrap();
         // Assert: g0 from object 2; g1 up to (not including) object 3
         assert_eq!(
             object_ids(&objects),
@@ -1834,10 +1966,10 @@ mod tests {
         let cache = TrackCache::new();
         let even = StreamSubgroupId::Value(0);
         let odd = StreamSubgroupId::Value(1);
-        cache
+        let _ = cache
             .append_stream_object(0, &even, None, make_header(0))
             .await;
-        cache
+        let _ = cache
             .append_stream_object(
                 0,
                 &odd,
@@ -1853,12 +1985,12 @@ mod tests {
             )
             .await;
         for object_id in [0, 2, 4] {
-            cache
+            let _ = cache
                 .append_stream_object(0, &even, Some(object_id), make_object(0))
                 .await;
         }
         for object_id in [1, 3, 5] {
-            cache
+            let _ = cache
                 .append_stream_object(0, &odd, Some(object_id), make_object(0))
                 .await;
         }
@@ -1878,7 +2010,8 @@ mod tests {
                     object_id: 6,
                 },
             )
-            .await;
+            .await
+            .unwrap();
 
         // Assert
         assert_eq!(
@@ -1907,7 +2040,8 @@ mod tests {
                 },
                 moqt::GroupOrder::Descending,
             )
-            .await;
+            .await
+            .unwrap();
 
         // Assert
         assert_eq!(object_ids(&objects), vec![(1, 0), (1, 1), (0, 0), (0, 1)]);
@@ -1919,7 +2053,7 @@ mod tests {
         // has already completed — the cross-stream reordering QUIC allows.
         let cache = Arc::new(TrackCache::new());
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_stream_object(0, &subgroup, None, make_header(0))
             .await;
         fill_closed_group(&cache, 1, 5).await;
@@ -1945,7 +2079,7 @@ mod tests {
         // Group 0's objects arrive after the fetch started, then the stream ends.
         tokio::task::yield_now().await;
         for id in 0..3u64 {
-            cache
+            let _ = cache
                 .append_stream_object(0, &subgroup, Some(id), make_object(0))
                 .await;
         }
@@ -1954,11 +2088,133 @@ mod tests {
         let objects = tokio::time::timeout(Duration::from_secs(5), fetch)
             .await
             .expect("fetch must complete once the in-flight group closes")
+            .unwrap()
             .unwrap();
         // Assert: the late group 0 objects are delivered, not silently dropped.
         assert_eq!(
             object_ids(&objects),
             vec![(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]
         );
+    }
+
+    fn make_object_with_payload(delta: u64, payload: &[u8]) -> DataObject {
+        let message_type =
+            SubgroupHeader::new(0, 0, SubgroupId::Value(0), 0, false, false).message_type;
+        DataObject::SubgroupObject(SubgroupObjectField {
+            message_type,
+            object_id_delta: delta,
+            extension_headers: ExtensionHeaders::default(),
+            subgroup_object: SubgroupObject::new_payload(Bytes::from(payload.to_vec())),
+        })
+    }
+
+    fn subgroup_header_for(subgroup_id: u64) -> DataObject {
+        DataObject::SubgroupHeader(SubgroupHeader::new(
+            0,
+            0,
+            SubgroupId::Value(subgroup_id),
+            0,
+            false,
+            false,
+        ))
+    }
+
+    #[tokio::test]
+    async fn same_object_in_two_subgroups_is_malformed() {
+        // Arrange: object 0 already lives in subgroup 0.
+        let cache = TrackCache::new();
+        let even = StreamSubgroupId::Value(0);
+        let odd = StreamSubgroupId::Value(1);
+        let _ = cache
+            .append_live_stream_object(0, &even, None, subgroup_header_for(0))
+            .await;
+        let _ = cache
+            .append_live_stream_object(0, &even, Some(0), make_object(0))
+            .await;
+        let _ = cache
+            .append_live_stream_object(0, &odd, None, subgroup_header_for(1))
+            .await;
+
+        // Act: the same object arrives again under a different subgroup — the
+        // subgroup is an immutable property, so this is §2.5 condition 8 even
+        // with an identical payload.
+        let outcome = cache
+            .append_live_stream_object(0, &odd, Some(0), make_object(0))
+            .await;
+
+        // Assert: detected, latched, and later appends are rejected.
+        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        assert!(cache.is_malformed());
+        let rejected = cache
+            .append_live_stream_object(0, &even, Some(5), make_object(0))
+            .await;
+        assert_eq!(rejected, AppendOutcome::MalformedTrack);
+    }
+
+    #[tokio::test]
+    async fn duplicate_object_with_different_payload_latches_the_track() {
+        // Arrange
+        let cache = TrackCache::new();
+        let subgroup = StreamSubgroupId::Value(0);
+        let _ = cache
+            .append_live_stream_object(0, &subgroup, None, make_header(0))
+            .await;
+        let _ = cache
+            .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"a"))
+            .await;
+
+        // Act
+        let outcome = cache
+            .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"b"))
+            .await;
+
+        // Assert
+        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+        assert!(cache.is_malformed());
+    }
+
+    #[tokio::test]
+    async fn get_fetch_objects_aborts_when_track_goes_malformed() {
+        // Arrange: a live group whose tail the fetch will wait for.
+        let cache = Arc::new(TrackCache::new());
+        let subgroup = StreamSubgroupId::Value(0);
+        let _ = cache
+            .append_live_stream_object(0, &subgroup, None, make_header(0))
+            .await;
+        let _ = cache
+            .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"a"))
+            .await;
+
+        // Act: the fetch consumes object 0, then waits for object 1.
+        let fetch = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                cache
+                    .get_fetch_objects(
+                        moqt::Location {
+                            group_id: 0,
+                            object_id: 0,
+                        },
+                        moqt::Location {
+                            group_id: 0,
+                            object_id: 3,
+                        },
+                    )
+                    .await
+            }
+        });
+        tokio::task::yield_now().await;
+        // A conflicting duplicate latches the track while the fetch waits.
+        let outcome = cache
+            .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"b"))
+            .await;
+        assert_eq!(outcome, AppendOutcome::MalformedTrack);
+
+        // Assert: the in-flight collection aborts instead of serving.
+        let result = tokio::time::timeout(Duration::from_secs(5), fetch)
+            .await
+            .expect("fetch must abort once the track is malformed")
+            .unwrap();
+        assert!(matches!(result, Err(TrackMalformed)));
     }
 }

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -20,7 +20,6 @@ use crate::modules::{
     },
 };
 
-/// Marker error: the track was latched malformed while serving from it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TrackMalformed;
 
@@ -30,9 +29,7 @@ pub(crate) struct TrackCache {
     known_ranges: RwLock<KnownRanges>,
     live_ingest_count: AtomicUsize,
     eviction_generation: AtomicU64,
-    /// Sticky Malformed Track latch (draft-14 §2.5). Once set the track is
-    /// quarantined: appends are rejected, fetch serving aborts, and egress
-    /// runners terminate their subscriptions. The session itself stays alive.
+    /// Sticky §2.5 Malformed Track latch; quarantines the track, not the session.
     malformed: AtomicBool,
     malformed_notify: Notify,
 }
@@ -68,8 +65,6 @@ impl TrackCache {
     }
 
     /// Resolves once the track is marked malformed; pends forever otherwise.
-    /// See `GroupCache::header_or_wait` for why the waiter is enabled before
-    /// the check.
     pub(crate) async fn malformed_track_detected(&self) {
         loop {
             let notified = self.malformed_notify.notified();
@@ -205,12 +200,9 @@ impl TrackCache {
         outcome
     }
 
-    /// §2.5 condition 8: the same (group, object) must not appear in two
-    /// different subgroups. Checked after the insert so two racing writers
-    /// cannot both miss the other's entry — the later one sees both.
-    /// Restricted to explicit `Value` subgroup ids: a `None` or
-    /// `FirstObjectIdDelta` key cannot be proven to denote a different
-    /// subgroup than a `Value` key of the same group.
+    /// §2.5 condition 8 across subgroups. Checked after the insert so racing
+    /// writers cannot both miss each other. Only explicit `Value` ids are
+    /// comparable; other key kinds may alias the same subgroup.
     async fn object_exists_in_other_subgroup(
         &self,
         group_id: u64,
@@ -690,9 +682,8 @@ impl TrackCache {
             .await
     }
 
-    /// Collects the requested range from the cache. Fails with
-    /// [`TrackMalformed`] as soon as the track's malformed latch is observed,
-    /// so an in-flight fetch can be reset instead of served (draft-14 §2.5).
+    /// Fails with [`TrackMalformed`] as soon as the latch is observed, so an
+    /// in-flight fetch is reset instead of served (§2.5).
     pub(crate) async fn get_fetch_objects_with_group_order(
         &self,
         start: moqt::Location,
@@ -2135,14 +2126,13 @@ mod tests {
             .append_live_stream_object(0, &odd, None, subgroup_header_for(1))
             .await;
 
-        // Act: the same object arrives again under a different subgroup — the
-        // subgroup is an immutable property, so this is §2.5 condition 8 even
-        // with an identical payload.
+        // Act: the same object arrives under a different subgroup (identical
+        // payload; the subgroup itself is the immutable property)
         let outcome = cache
             .append_live_stream_object(0, &odd, Some(0), make_object(0))
             .await;
 
-        // Assert: detected, latched, and later appends are rejected.
+        // Assert: latched, and later appends are rejected
         assert_eq!(outcome, AppendOutcome::MalformedTrack);
         assert!(cache.is_malformed());
         let rejected = cache
@@ -2175,7 +2165,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_fetch_objects_aborts_when_track_goes_malformed() {
-        // Arrange: a live group whose tail the fetch will wait for.
+        // Arrange: a live group whose tail the fetch will wait for
         let cache = Arc::new(TrackCache::new());
         let subgroup = StreamSubgroupId::Value(0);
         let _ = cache

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -2066,6 +2066,7 @@ mod tests {
 
     #[tokio::test]
     async fn same_object_in_two_subgroups_is_malformed() {
+        // Arrange: object 0 already lives in subgroup 0
         let cache = TrackCache::new();
         let even = StreamSubgroupId::Value(0);
         let odd = StreamSubgroupId::Value(1);
@@ -2079,10 +2080,12 @@ mod tests {
             .append_live_stream_object(0, &odd, None, subgroup_header_for(1))
             .await;
 
+        // Act: the same object arrives under a different subgroup
         let outcome = cache
             .append_live_stream_object(0, &odd, Some(0), make_object(0))
             .await;
 
+        // Assert: latched, and later appends are rejected
         assert_eq!(outcome, Err(TrackMalformed));
         assert!(cache.is_malformed());
         let rejected = cache
@@ -2093,6 +2096,7 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_object_with_different_payload_latches_the_track() {
+        // Arrange
         let cache = TrackCache::new();
         let subgroup = StreamSubgroupId::Value(0);
         let _ = cache
@@ -2102,16 +2106,19 @@ mod tests {
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"a"))
             .await;
 
+        // Act
         let outcome = cache
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"b"))
             .await;
 
+        // Assert
         assert_eq!(outcome, Err(TrackMalformed));
         assert!(cache.is_malformed());
     }
 
     #[tokio::test]
     async fn get_fetch_objects_aborts_when_track_goes_malformed() {
+        // Arrange: a live group whose tail the fetch will wait for
         let cache = Arc::new(TrackCache::new());
         let subgroup = StreamSubgroupId::Value(0);
         let _ = cache
@@ -2121,6 +2128,7 @@ mod tests {
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"a"))
             .await;
 
+        // Act: the fetch consumes object 0, then waits for object 1
         let fetch = tokio::spawn({
             let cache = cache.clone();
             async move {
@@ -2139,11 +2147,13 @@ mod tests {
             }
         });
         tokio::task::yield_now().await;
+        // A conflicting duplicate latches the track while the fetch waits
         let outcome = cache
             .append_live_stream_object(0, &subgroup, Some(0), make_object_with_payload(0, b"b"))
             .await;
         assert_eq!(outcome, Err(TrackMalformed));
 
+        // Assert: the in-flight collection aborts instead of serving
         let result = tokio::time::timeout(Duration::from_secs(5), fetch)
             .await
             .expect("fetch must abort once the track is malformed")

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -122,7 +122,7 @@ impl TrackCache {
         object_id: Option<u64>,
         object: DataObject,
     ) -> Result<(), TrackMalformed> {
-        self.append_stream_object_with_lifecycle(
+        self.append_to_stream_subgroup(
             group_id,
             subgroup_id,
             object_id,
@@ -139,7 +139,7 @@ impl TrackCache {
         object_id: Option<u64>,
         object: DataObject,
     ) -> Result<(), TrackMalformed> {
-        self.append_stream_object_with_lifecycle(
+        self.append_to_stream_subgroup(
             group_id,
             subgroup_id,
             object_id,
@@ -162,7 +162,7 @@ impl TrackCache {
         Ok(())
     }
 
-    async fn append_stream_object_with_lifecycle(
+    async fn append_to_stream_subgroup(
         &self,
         group_id: u64,
         subgroup_id: &StreamSubgroupId,

--- a/relay/src/modules/relay/egress/coordinator.rs
+++ b/relay/src/modules/relay/egress/coordinator.rs
@@ -171,8 +171,6 @@ impl EgressCoordinator {
                     return;
                 }
             }
-            // A FIN would assert full delivery; reset if the track went
-            // malformed after collection.
             if cache.is_malformed() {
                 if let Err(e) = sender.reset(FetchErrorCode::MalformedTrack as u64).await {
                     tracing::error!(?e, "failed to reset fetch stream");

--- a/relay/src/modules/relay/egress/coordinator.rs
+++ b/relay/src/modules/relay/egress/coordinator.rs
@@ -155,8 +155,6 @@ impl EgressCoordinator {
             {
                 Ok(objects) => objects,
                 Err(_) => {
-                    // §2.5: fetch streams of a malformed track are reset with
-                    // MALFORMED_TRACK instead of served.
                     tracing::warn!(
                         request_id = request.request_id,
                         "malformed track detected; resetting fetch stream"
@@ -173,8 +171,8 @@ impl EgressCoordinator {
                     return;
                 }
             }
-            // A FIN asserts the whole range was delivered; if the track went
-            // malformed after collection, reset instead (§2.5).
+            // A FIN would assert full delivery; reset if the track went
+            // malformed after collection.
             if cache.is_malformed() {
                 if let Err(e) = sender.reset(FetchErrorCode::MalformedTrack as u64).await {
                     tracing::error!(?e, "failed to reset fetch stream");

--- a/relay/src/modules/relay/egress/coordinator.rs
+++ b/relay/src/modules/relay/egress/coordinator.rs
@@ -8,6 +8,7 @@ use tracing::{Instrument, Span};
 
 use crate::modules::{
     core::subscription::DownstreamSubscription,
+    enums::FetchErrorCode,
     relay::{
         cache::{store::TrackCacheStore, track_cache::TrackCache},
         egress::runner::EgressRunner,
@@ -144,18 +145,41 @@ impl EgressCoordinator {
                     return;
                 }
             };
-            let objects = cache
+            let objects = match cache
                 .get_fetch_objects_with_group_order(
                     request.start_location,
                     request.end_location,
                     request.group_order,
                 )
-                .await;
+                .await
+            {
+                Ok(objects) => objects,
+                Err(_) => {
+                    // §2.5: fetch streams of a malformed track are reset with
+                    // MALFORMED_TRACK instead of served.
+                    tracing::warn!(
+                        request_id = request.request_id,
+                        "malformed track detected; resetting fetch stream"
+                    );
+                    if let Err(e) = sender.reset(FetchErrorCode::MalformedTrack as u64).await {
+                        tracing::error!(?e, "failed to reset fetch stream");
+                    }
+                    return;
+                }
+            };
             for object in objects {
                 if let Err(e) = sender.send(object).await {
                     tracing::error!(?e, "failed to send fetch object");
                     return;
                 }
+            }
+            // A FIN asserts the whole range was delivered; if the track went
+            // malformed after collection, reset instead (§2.5).
+            if cache.is_malformed() {
+                if let Err(e) = sender.reset(FetchErrorCode::MalformedTrack as u64).await {
+                    tracing::error!(?e, "failed to reset fetch stream");
+                }
+                return;
             }
             if let Err(e) = sender.close().await {
                 tracing::error!(?e, "failed to close fetch stream");

--- a/relay/src/modules/relay/egress/group_sender.rs
+++ b/relay/src/modules/relay/egress/group_sender.rs
@@ -25,8 +25,7 @@ pub(crate) struct GroupSender {
     publisher: Arc<dyn Publisher>,
     downstream_subscription: DownstreamSubscription,
     receiver: mpsc::Receiver<GroupSendTask>,
-    /// Streams opened for this subscription, reported in PUBLISH_DONE's
-    /// Stream Count (§9.12).
+    /// Reported as PUBLISH_DONE Stream Count (§9.12).
     opened_stream_count: Arc<AtomicU64>,
 }
 

--- a/relay/src/modules/relay/egress/group_sender.rs
+++ b/relay/src/modules/relay/egress/group_sender.rs
@@ -25,7 +25,6 @@ pub(crate) struct GroupSender {
     publisher: Arc<dyn Publisher>,
     downstream_subscription: DownstreamSubscription,
     receiver: mpsc::Receiver<GroupSendTask>,
-    /// Reported as PUBLISH_DONE Stream Count (§9.12).
     opened_stream_count: Arc<AtomicU64>,
 }
 

--- a/relay/src/modules/relay/egress/group_sender.rs
+++ b/relay/src/modules/relay/egress/group_sender.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use tokio::{sync::mpsc, task::JoinSet};
 use tracing::{Instrument, Span};
@@ -19,18 +22,22 @@ use super::scheduler::GroupSendTask;
 pub(crate) struct GroupSender {
     track_key: TrackKey,
     cache: Arc<TrackCache>,
-    publisher: Box<dyn Publisher>,
+    publisher: Arc<dyn Publisher>,
     downstream_subscription: DownstreamSubscription,
     receiver: mpsc::Receiver<GroupSendTask>,
+    /// Streams opened for this subscription, reported in PUBLISH_DONE's
+    /// Stream Count (§9.12).
+    opened_stream_count: Arc<AtomicU64>,
 }
 
 impl GroupSender {
     pub(crate) fn new(
         track_key: TrackKey,
         cache: Arc<TrackCache>,
-        publisher: Box<dyn Publisher>,
+        publisher: Arc<dyn Publisher>,
         downstream_subscription: DownstreamSubscription,
         receiver: mpsc::Receiver<GroupSendTask>,
+        opened_stream_count: Arc<AtomicU64>,
     ) -> Self {
         Self {
             track_key,
@@ -38,6 +45,7 @@ impl GroupSender {
             publisher,
             downstream_subscription,
             receiver,
+            opened_stream_count,
         }
     }
 
@@ -78,6 +86,7 @@ impl GroupSender {
                             .await
                             {
                                 Ok(sender) => {
+                                    self.opened_stream_count.fetch_add(1, Ordering::AcqRel);
                                     joinset.spawn(Self::send_stream_task(
                                         track_alias,
                                         group_id,

--- a/relay/src/modules/relay/egress/runner.rs
+++ b/relay/src/modules/relay/egress/runner.rs
@@ -5,9 +5,10 @@ use std::sync::{
 
 use tokio::sync::{broadcast, mpsc, oneshot};
 
+use moqt::wire::publish_done_status_code;
+
 use crate::modules::{
     core::{publisher::Publisher, subscription::DownstreamSubscription},
-    enums::PublishDoneStatusCode,
     relay::{cache::track_cache::TrackCache, notifications::track_event::TrackEvent},
     types::TrackKey,
 };
@@ -82,9 +83,8 @@ impl EgressRunner {
         tokio::select! {
             _ = async { tokio::join!(scheduler.run(), group_sender.run()) } => {}
             _ = self.cache.malformed_track_detected() => {
-                // Reaching this arm drops the futures above, aborting every
-                // send task: all data streams close before PUBLISH_DONE goes
-                // out, the order §9.12 requires.
+                // This arm drops the futures above, closing all data streams
+                // before PUBLISH_DONE goes out (§9.12 ordering).
                 let stream_count = opened_stream_count.load(Ordering::Acquire);
                 Self::send_malformed_publish_done(
                     publisher.as_ref(),
@@ -112,7 +112,7 @@ impl EgressRunner {
         if let Err(error) = publisher
             .send_publish_done(
                 request_id,
-                PublishDoneStatusCode::MalformedTrack as u64,
+                publish_done_status_code::MALFORMED_TRACK,
                 stream_count,
                 "malformed track".to_string(),
             )

--- a/relay/src/modules/relay/egress/runner.rs
+++ b/relay/src/modules/relay/egress/runner.rs
@@ -50,7 +50,6 @@ impl EgressRunner {
         let publisher: Arc<dyn Publisher> = Arc::from(self.publisher);
         let request_id = self.downstream_subscription.request_id();
 
-        // Detection can race the subscribe sequence's own malformed check.
         if self.cache.is_malformed() {
             let _ = self.ready_sender.send(Ok(()));
             Self::send_malformed_publish_done(publisher.as_ref(), &self.track_key, request_id, 0)
@@ -83,8 +82,6 @@ impl EgressRunner {
         tokio::select! {
             _ = async { tokio::join!(scheduler.run(), group_sender.run()) } => {}
             _ = self.cache.malformed_track_detected() => {
-                // This arm drops the futures above, closing all data streams
-                // before PUBLISH_DONE goes out (§9.12 ordering).
                 let stream_count = opened_stream_count.load(Ordering::Acquire);
                 Self::send_malformed_publish_done(
                     publisher.as_ref(),

--- a/relay/src/modules/relay/egress/runner.rs
+++ b/relay/src/modules/relay/egress/runner.rs
@@ -49,9 +49,7 @@ impl EgressRunner {
         let publisher: Arc<dyn Publisher> = Arc::from(self.publisher);
         let request_id = self.downstream_subscription.request_id();
 
-        // The subscribe sequence rejects known-malformed tracks, but detection
-        // can race it. Answer readiness (so SUBSCRIBE_OK goes out) and
-        // terminate immediately; no streams were opened yet (Stream Count 0).
+        // Detection can race the subscribe sequence's own malformed check.
         if self.cache.is_malformed() {
             let _ = self.ready_sender.send(Ok(()));
             Self::send_malformed_publish_done(publisher.as_ref(), &self.track_key, request_id, 0)
@@ -84,14 +82,9 @@ impl EgressRunner {
         tokio::select! {
             _ = async { tokio::join!(scheduler.run(), group_sender.run()) } => {}
             _ = self.cache.malformed_track_detected() => {
-                // §2.5: a relay MUST immediately terminate downstream
-                // subscriptions of a malformed track with PUBLISH_DONE.
-                // Dropping the scheduler and sender futures above aborts every
-                // per-group send task, closing all data streams before the
-                // control message goes out (§9.12 requires that ordering).
-                // The count is taken at stream-open time, so it is exact even
-                // though the send tasks were just aborted (a datagram track
-                // stays at 0, as §9.12 requires).
+                // Reaching this arm drops the futures above, aborting every
+                // send task: all data streams close before PUBLISH_DONE goes
+                // out, the order §9.12 requires.
                 let stream_count = opened_stream_count.load(Ordering::Acquire);
                 Self::send_malformed_publish_done(
                     publisher.as_ref(),

--- a/relay/src/modules/relay/egress/runner.rs
+++ b/relay/src/modules/relay/egress/runner.rs
@@ -1,9 +1,13 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::modules::{
     core::{publisher::Publisher, subscription::DownstreamSubscription},
+    enums::PublishDoneStatusCode,
     relay::{cache::track_cache::TrackCache, notifications::track_event::TrackEvent},
     types::TrackKey,
 };
@@ -42,8 +46,21 @@ impl EgressRunner {
     }
 
     pub(crate) async fn run(self) -> anyhow::Result<()> {
-        let (sender, receiver) = mpsc::channel(64);
+        let publisher: Arc<dyn Publisher> = Arc::from(self.publisher);
+        let request_id = self.downstream_subscription.request_id();
 
+        // The subscribe sequence rejects known-malformed tracks, but detection
+        // can race it. Answer readiness (so SUBSCRIBE_OK goes out) and
+        // terminate immediately; no streams were opened yet (Stream Count 0).
+        if self.cache.is_malformed() {
+            let _ = self.ready_sender.send(Ok(()));
+            Self::send_malformed_publish_done(publisher.as_ref(), &self.track_key, request_id, 0)
+                .await;
+            return Ok(());
+        }
+
+        let (sender, receiver) = mpsc::channel(64);
+        let opened_stream_count = Arc::new(AtomicU64::new(0));
         let filter_type = self.downstream_subscription.filter_type();
         let group_order = self.downstream_subscription.group_order();
         let scheduler = EgressScheduler::new(
@@ -56,14 +73,64 @@ impl EgressRunner {
             self.largest_location,
         );
         let group_sender = GroupSender::new(
-            self.track_key,
-            self.cache,
-            self.publisher,
+            self.track_key.clone(),
+            self.cache.clone(),
+            publisher.clone(),
             self.downstream_subscription,
             receiver,
+            opened_stream_count.clone(),
         );
 
-        tokio::join!(scheduler.run(), group_sender.run());
+        tokio::select! {
+            _ = async { tokio::join!(scheduler.run(), group_sender.run()) } => {}
+            _ = self.cache.malformed_track_detected() => {
+                // §2.5: a relay MUST immediately terminate downstream
+                // subscriptions of a malformed track with PUBLISH_DONE.
+                // Dropping the scheduler and sender futures above aborts every
+                // per-group send task, closing all data streams before the
+                // control message goes out (§9.12 requires that ordering).
+                // The count is taken at stream-open time, so it is exact even
+                // though the send tasks were just aborted (a datagram track
+                // stays at 0, as §9.12 requires).
+                let stream_count = opened_stream_count.load(Ordering::Acquire);
+                Self::send_malformed_publish_done(
+                    publisher.as_ref(),
+                    &self.track_key,
+                    request_id,
+                    stream_count,
+                )
+                .await;
+            }
+        }
         Ok(())
+    }
+
+    async fn send_malformed_publish_done(
+        publisher: &dyn Publisher,
+        track_key: &TrackKey,
+        request_id: u64,
+        stream_count: u64,
+    ) {
+        tracing::warn!(
+            %track_key,
+            request_id,
+            "malformed track detected; terminating downstream subscription"
+        );
+        if let Err(error) = publisher
+            .send_publish_done(
+                request_id,
+                PublishDoneStatusCode::MalformedTrack as u64,
+                stream_count,
+                "malformed track".to_string(),
+            )
+            .await
+        {
+            tracing::error!(
+                ?error,
+                %track_key,
+                request_id,
+                "failed to send PUBLISH_DONE for malformed track"
+            );
+        }
     }
 }

--- a/relay/src/modules/relay/egress/scheduler.rs
+++ b/relay/src/modules/relay/egress/scheduler.rs
@@ -341,7 +341,7 @@ mod tests {
     ) {
         let object_id = object.resolve_absolute_object_id(*prev_object_id);
         *prev_object_id = object_id;
-        cache
+        let _ = cache
             .append_stream_object(group_id, subgroup, object_id, object)
             .await;
     }

--- a/relay/src/modules/relay/ingress/datagram_reader.rs
+++ b/relay/src/modules/relay/ingress/datagram_reader.rs
@@ -8,7 +8,7 @@ use tokio::{
 use crate::modules::{
     core::data_receiver::datagram_receiver::DatagramReceiver,
     relay::{
-        cache::{group_cache::AppendOutcome, store::TrackCacheStore},
+        cache::store::TrackCacheStore,
         notifications::{track_event::TrackEvent, track_notifier::ObjectNotifyProducerMap},
     },
     types::{SessionId, TrackKey},
@@ -140,10 +140,10 @@ impl DatagramReader {
                     }
                     let object_id = object.resolve_absolute_object_id(prev_object_id);
                     prev_object_id = object_id;
-                    let outcome = cache
+                    let result = cache
                         .append_datagram_object(group_id, object_id, object)
                         .await;
-                    if outcome == AppendOutcome::MalformedTrack {
+                    if result.is_err() {
                         tracing::warn!(
                             %track_key,
                             group_id,

--- a/relay/src/modules/relay/ingress/datagram_reader.rs
+++ b/relay/src/modules/relay/ingress/datagram_reader.rs
@@ -8,7 +8,7 @@ use tokio::{
 use crate::modules::{
     core::data_receiver::datagram_receiver::DatagramReceiver,
     relay::{
-        cache::store::TrackCacheStore,
+        cache::{group_cache::AppendOutcome, store::TrackCacheStore},
         notifications::{track_event::TrackEvent, track_notifier::ObjectNotifyProducerMap},
     },
     types::{SessionId, TrackKey},
@@ -140,9 +140,19 @@ impl DatagramReader {
                     }
                     let object_id = object.resolve_absolute_object_id(prev_object_id);
                     prev_object_id = object_id;
-                    cache
+                    let outcome = cache
                         .append_datagram_object(group_id, object_id, object)
                         .await;
+                    if outcome == AppendOutcome::MalformedTrack {
+                        tracing::warn!(
+                            %track_key,
+                            group_id,
+                            "malformed track detected; stopping datagram ingest"
+                        );
+                        cache.close_datagram_group(group_id).await;
+                        cache.end_live_ingest();
+                        return;
+                    }
                 }
                 Err(_) => {
                     // Ensure the last group is closed before exiting.

--- a/relay/src/modules/relay/ingress/fetch_ingest.rs
+++ b/relay/src/modules/relay/ingress/fetch_ingest.rs
@@ -4,8 +4,9 @@ use tokio::task::JoinHandle;
 
 use crate::modules::{
     core::data_object::DataObject,
+    enums::FetchErrorCode,
     relay::{
-        cache::{duration::duration_from_env, track_cache::TrackCache},
+        cache::{duration::duration_from_env, group_cache::AppendOutcome, track_cache::TrackCache},
         egress::coordinator::{EgressCommand, EgressFetchRequest},
         types::StreamSubgroupId,
     },
@@ -47,15 +48,24 @@ impl FetchIngest {
     ) -> Self {
         let downstream_subscriber_session_id = start.downstream_subscriber_session_id;
         let request_id = start.request_id;
+        let cache = start.cache.clone();
         let join_handle = tokio::spawn(async move {
             if let Err(error) = Self::run_inner(session_repo.clone(), &egress_sender, start).await {
                 // Expected request-scoped failures (timeout, upstream reset):
                 // log the chain without anyhow's captured backtrace.
                 tracing::error!(error = %format!("{error:#}"), "fetch ingest failed");
+                // §2.5: a fetch stream of a malformed track must be reset
+                // with MALFORMED_TRACK rather than a generic error.
+                let error_code = if cache.is_malformed() {
+                    FetchErrorCode::MalformedTrack as u64
+                } else {
+                    DATA_STREAM_INTERNAL_ERROR
+                };
                 Self::reset_downstream_fetch(
                     session_repo,
                     downstream_subscriber_session_id,
                     request_id,
+                    error_code,
                 )
                 .await;
             }
@@ -180,7 +190,7 @@ impl FetchIngest {
             }
         };
 
-        cache
+        let header_outcome = cache
             .append_stream_object(
                 object.group_id,
                 &subgroup_id,
@@ -188,7 +198,14 @@ impl FetchIngest {
                 DataObject::SubgroupHeader(header),
             )
             .await;
-        cache
+        if header_outcome == AppendOutcome::MalformedTrack {
+            anyhow::bail!(
+                "malformed track detected during fetch fill (group {}, subgroup {})",
+                object.group_id,
+                object.subgroup_id
+            );
+        }
+        let object_outcome = cache
             .append_stream_object(
                 object.group_id,
                 &subgroup_id,
@@ -201,6 +218,13 @@ impl FetchIngest {
                 }),
             )
             .await;
+        if object_outcome == AppendOutcome::MalformedTrack {
+            anyhow::bail!(
+                "malformed track detected during fetch fill (group {}, object {})",
+                object.group_id,
+                object.object_id
+            );
+        }
         previous_object_ids.insert(key, object.object_id);
         Ok(())
     }
@@ -216,6 +240,7 @@ impl FetchIngest {
         session_repo: Arc<tokio::sync::Mutex<SessionRepository>>,
         downstream_subscriber_session_id: SessionId,
         request_id: u64,
+        error_code: u64,
     ) {
         let publisher = {
             let session_repo = session_repo.lock().await;
@@ -228,7 +253,7 @@ impl FetchIngest {
         // was delivered, so failure after FETCH_OK must be signaled with RESET_STREAM.
         match publisher.new_fetch_sender(request_id).await {
             Ok(sender) => {
-                if let Err(error) = sender.reset(DATA_STREAM_INTERNAL_ERROR).await {
+                if let Err(error) = sender.reset(error_code).await {
                     tracing::error!(error = %format!("{error:#}"), "failed to reset downstream fetch stream");
                 }
             }
@@ -297,6 +322,49 @@ mod tests {
 
         // Assert: only a completed FETCH known range may cover this historical gap.
         assert_eq!(resolution, FetchRangeResolution::NotCovered);
+    }
+
+    #[tokio::test]
+    async fn conflicting_fetch_object_fails_the_fill_and_latches_the_track() {
+        // Arrange: a fill stored the object once.
+        let cache = Arc::new(TrackCache::new());
+        let mut first_fill = HashMap::new();
+        FetchIngest::append_fetch_object(
+            cache.clone(),
+            FetchObjectField::new(
+                0,
+                0,
+                0,
+                0,
+                ExtensionHeaders::default(),
+                FetchObject::Payload(Bytes::from_static(b"a")),
+            ),
+            &mut first_fill,
+        )
+        .await
+        .unwrap();
+
+        // Act: a second fill delivers the same object with another payload
+        // (§2.5 condition 8).
+        let mut second_fill = HashMap::new();
+        let result = FetchIngest::append_fetch_object(
+            cache.clone(),
+            FetchObjectField::new(
+                0,
+                0,
+                0,
+                0,
+                ExtensionHeaders::default(),
+                FetchObject::Payload(Bytes::from_static(b"b")),
+            ),
+            &mut second_fill,
+        )
+        .await;
+
+        // Assert: the fill fails (its downstream fetch gets reset) and the
+        // track is quarantined.
+        assert!(result.is_err());
+        assert!(cache.is_malformed());
     }
 
     #[tokio::test]

--- a/relay/src/modules/relay/ingress/fetch_ingest.rs
+++ b/relay/src/modules/relay/ingress/fetch_ingest.rs
@@ -324,7 +324,6 @@ mod tests {
 
     #[tokio::test]
     async fn conflicting_fetch_object_fails_the_fill_and_latches_the_track() {
-        // Arrange: a fill stored the object once
         let cache = Arc::new(TrackCache::new());
         let mut first_fill = HashMap::new();
         FetchIngest::append_fetch_object(
@@ -342,7 +341,6 @@ mod tests {
         .await
         .unwrap();
 
-        // Act: a second fill delivers the same object with another payload
         let mut second_fill = HashMap::new();
         let result = FetchIngest::append_fetch_object(
             cache.clone(),
@@ -358,7 +356,6 @@ mod tests {
         )
         .await;
 
-        // Assert: the fill fails and the track is quarantined
         assert!(result.is_err());
         assert!(cache.is_malformed());
     }

--- a/relay/src/modules/relay/ingress/fetch_ingest.rs
+++ b/relay/src/modules/relay/ingress/fetch_ingest.rs
@@ -324,6 +324,7 @@ mod tests {
 
     #[tokio::test]
     async fn conflicting_fetch_object_fails_the_fill_and_latches_the_track() {
+        // Arrange: a fill stored the object once
         let cache = Arc::new(TrackCache::new());
         let mut first_fill = HashMap::new();
         FetchIngest::append_fetch_object(
@@ -341,6 +342,7 @@ mod tests {
         .await
         .unwrap();
 
+        // Act: a second fill delivers the same object with another payload
         let mut second_fill = HashMap::new();
         let result = FetchIngest::append_fetch_object(
             cache.clone(),
@@ -356,6 +358,7 @@ mod tests {
         )
         .await;
 
+        // Assert: the fill fails and the track is quarantined
         assert!(result.is_err());
         assert!(cache.is_malformed());
     }

--- a/relay/src/modules/relay/ingress/fetch_ingest.rs
+++ b/relay/src/modules/relay/ingress/fetch_ingest.rs
@@ -6,7 +6,7 @@ use crate::modules::{
     core::data_object::DataObject,
     enums::FetchErrorCode,
     relay::{
-        cache::{duration::duration_from_env, group_cache::AppendOutcome, track_cache::TrackCache},
+        cache::{duration::duration_from_env, track_cache::TrackCache},
         egress::coordinator::{EgressCommand, EgressFetchRequest},
         types::StreamSubgroupId,
     },
@@ -188,7 +188,7 @@ impl FetchIngest {
             }
         };
 
-        let header_outcome = cache
+        let header_result = cache
             .append_stream_object(
                 object.group_id,
                 &subgroup_id,
@@ -196,14 +196,14 @@ impl FetchIngest {
                 DataObject::SubgroupHeader(header),
             )
             .await;
-        if header_outcome == AppendOutcome::MalformedTrack {
+        if header_result.is_err() {
             anyhow::bail!(
                 "malformed track detected during fetch fill (group {}, subgroup {})",
                 object.group_id,
                 object.subgroup_id
             );
         }
-        let object_outcome = cache
+        let object_result = cache
             .append_stream_object(
                 object.group_id,
                 &subgroup_id,
@@ -216,7 +216,7 @@ impl FetchIngest {
                 }),
             )
             .await;
-        if object_outcome == AppendOutcome::MalformedTrack {
+        if object_result.is_err() {
             anyhow::bail!(
                 "malformed track detected during fetch fill (group {}, object {})",
                 object.group_id,

--- a/relay/src/modules/relay/ingress/fetch_ingest.rs
+++ b/relay/src/modules/relay/ingress/fetch_ingest.rs
@@ -54,8 +54,6 @@ impl FetchIngest {
                 // Expected request-scoped failures (timeout, upstream reset):
                 // log the chain without anyhow's captured backtrace.
                 tracing::error!(error = %format!("{error:#}"), "fetch ingest failed");
-                // §2.5: a fetch stream of a malformed track must be reset
-                // with MALFORMED_TRACK rather than a generic error.
                 let error_code = if cache.is_malformed() {
                     FetchErrorCode::MalformedTrack as u64
                 } else {
@@ -326,7 +324,7 @@ mod tests {
 
     #[tokio::test]
     async fn conflicting_fetch_object_fails_the_fill_and_latches_the_track() {
-        // Arrange: a fill stored the object once.
+        // Arrange: a fill stored the object once
         let cache = Arc::new(TrackCache::new());
         let mut first_fill = HashMap::new();
         FetchIngest::append_fetch_object(
@@ -345,7 +343,6 @@ mod tests {
         .unwrap();
 
         // Act: a second fill delivers the same object with another payload
-        // (§2.5 condition 8).
         let mut second_fill = HashMap::new();
         let result = FetchIngest::append_fetch_object(
             cache.clone(),
@@ -361,8 +358,7 @@ mod tests {
         )
         .await;
 
-        // Assert: the fill fails (its downstream fetch gets reset) and the
-        // track is quarantined.
+        // Assert: the fill fails and the track is quarantined
         assert!(result.is_err());
         assert!(cache.is_malformed());
     }

--- a/relay/src/modules/relay/ingress/stream_reader.rs
+++ b/relay/src/modules/relay/ingress/stream_reader.rs
@@ -10,7 +10,7 @@ use tracing::{Instrument, Span};
 use crate::modules::{
     core::{data_object::DataObject, data_receiver::stream_receiver::StreamReceiver},
     relay::{
-        cache::store::TrackCacheStore,
+        cache::{group_cache::AppendOutcome, store::TrackCacheStore},
         notifications::{track_event::TrackEvent, track_notifier::ObjectNotifyProducerMap},
         types::StreamSubgroupId,
     },
@@ -103,7 +103,7 @@ impl StreamReader {
                     prev_object_id = None;
                     span.record("group_id", group_id);
                     span.record("subgroup_id", tracing::field::debug(&subgroup_id));
-                    cache
+                    let outcome = cache
                         .append_live_stream_object(
                             group_id,
                             &subgroup_id,
@@ -111,6 +111,13 @@ impl StreamReader {
                             DataObject::SubgroupHeader(header),
                         )
                         .await;
+                    if outcome == AppendOutcome::MalformedTrack {
+                        span.record("end_reason", "malformed_track");
+                        tracing::warn!(%track_key, group_id, "malformed track detected; stopping stream ingest");
+                        cache.close_stream_subgroup(group_id, &subgroup_id).await;
+                        let _ = notify.send(TrackEvent::EndOfGroup);
+                        return;
+                    }
                     let _ = notify.send(TrackEvent::StreamOpened {
                         group_id,
                         subgroup_id: subgroup_id.clone(),
@@ -135,9 +142,23 @@ impl StreamReader {
                     };
                     let object_id = object.resolve_absolute_object_id(prev_object_id);
                     prev_object_id = object_id;
-                    cache
+                    let outcome = cache
                         .append_live_stream_object(group_id, &subgroup_id, object_id, object)
                         .await;
+                    if outcome == AppendOutcome::MalformedTrack {
+                        span.record("end_reason", "malformed_track");
+                        tracing::warn!(
+                            %track_key,
+                            group_id,
+                            object_id,
+                            "malformed track detected; stopping stream ingest"
+                        );
+                        if has_subgroup {
+                            cache.close_stream_subgroup(group_id, &subgroup_id).await;
+                            let _ = notify.send(TrackEvent::EndOfGroup);
+                        }
+                        return;
+                    }
                     if let Some(end_reason) = end_reason {
                         span.record("end_reason", end_reason);
                         cache.close_stream_subgroup(group_id, &subgroup_id).await;

--- a/relay/src/modules/relay/ingress/stream_reader.rs
+++ b/relay/src/modules/relay/ingress/stream_reader.rs
@@ -10,7 +10,7 @@ use tracing::{Instrument, Span};
 use crate::modules::{
     core::{data_object::DataObject, data_receiver::stream_receiver::StreamReceiver},
     relay::{
-        cache::{group_cache::AppendOutcome, store::TrackCacheStore},
+        cache::store::TrackCacheStore,
         notifications::{track_event::TrackEvent, track_notifier::ObjectNotifyProducerMap},
         types::StreamSubgroupId,
     },
@@ -103,7 +103,7 @@ impl StreamReader {
                     prev_object_id = None;
                     span.record("group_id", group_id);
                     span.record("subgroup_id", tracing::field::debug(&subgroup_id));
-                    let outcome = cache
+                    let result = cache
                         .append_live_stream_object(
                             group_id,
                             &subgroup_id,
@@ -111,7 +111,7 @@ impl StreamReader {
                             DataObject::SubgroupHeader(header),
                         )
                         .await;
-                    if outcome == AppendOutcome::MalformedTrack {
+                    if result.is_err() {
                         span.record("end_reason", "malformed_track");
                         tracing::warn!(%track_key, group_id, "malformed track detected; stopping stream ingest");
                         cache.close_stream_subgroup(group_id, &subgroup_id).await;
@@ -142,10 +142,10 @@ impl StreamReader {
                     };
                     let object_id = object.resolve_absolute_object_id(prev_object_id);
                     prev_object_id = object_id;
-                    let outcome = cache
+                    let result = cache
                         .append_live_stream_object(group_id, &subgroup_id, object_id, object)
                         .await;
-                    if outcome == AppendOutcome::MalformedTrack {
+                    if result.is_err() {
                         span.record("end_reason", "malformed_track");
                         tracing::warn!(
                             %track_key,

--- a/relay/src/modules/relay/tests.rs
+++ b/relay/src/modules/relay/tests.rs
@@ -1,2 +1,3 @@
 mod data_plane;
 mod harness;
+mod malformed_track;

--- a/relay/src/modules/relay/tests/harness.rs
+++ b/relay/src/modules/relay/tests/harness.rs
@@ -18,9 +18,14 @@ use crate::modules::{
 mod fixtures;
 mod mocks;
 
+pub(crate) use self::fixtures::data_object::ordered_payload;
+
 use self::{
-    fixtures::{data_object::ordered_payload, subscription::make_largest_object_subscription},
-    mocks::{downstream_client::MockPublisher, upstream_client::UpstreamSubgroupStream},
+    fixtures::subscription::make_largest_object_subscription,
+    mocks::{
+        downstream_client::{MockPublisher, SentPublishDone},
+        upstream_client::UpstreamSubgroupStream,
+    },
 };
 
 pub(crate) const OBJECT_COUNT: usize = 50;
@@ -38,7 +43,26 @@ pub(crate) struct RelayHarness {
 
 pub(crate) struct EgressRunnerHandle {
     sent: mpsc::UnboundedReceiver<Option<DataObject>>,
+    publish_done: mpsc::UnboundedReceiver<SentPublishDone>,
     join_handle: tokio::task::JoinHandle<()>,
+}
+
+impl EgressRunnerHandle {
+    /// Waits for the runner to send PUBLISH_DONE downstream.
+    pub(crate) async fn expect_publish_done(&mut self) -> SentPublishDone {
+        tokio::time::timeout(RECV_TIMEOUT, self.publish_done.recv())
+            .await
+            .expect("egress should send PUBLISH_DONE")
+            .expect("egress dropped its publisher before PUBLISH_DONE")
+    }
+
+    /// Asserts no PUBLISH_DONE was sent so far (non-blocking).
+    pub(crate) fn assert_no_publish_done(&mut self) {
+        assert!(
+            self.publish_done.try_recv().is_err(),
+            "no PUBLISH_DONE should have been sent"
+        );
+    }
 }
 
 impl Drop for EgressRunnerHandle {
@@ -85,7 +109,7 @@ impl RelayHarness {
         &self,
         largest_location: Option<moqt::Location>,
     ) -> EgressRunnerHandle {
-        let (publisher, sent) = MockPublisher::channel();
+        let (publisher, observers) = MockPublisher::channel();
         let (ready_sender, ready_receiver) = oneshot::channel();
         let runner = EgressRunner::new(
             self.track_key.clone(),
@@ -104,7 +128,19 @@ impl RelayHarness {
             .expect("egress runner should signal readiness")
             .expect("egress readiness should not be dropped")
             .expect("egress runner should start");
-        EgressRunnerHandle { sent, join_handle }
+        EgressRunnerHandle {
+            sent: observers.sent,
+            publish_done: observers.publish_done,
+            join_handle,
+        }
+    }
+
+    /// Waits until the track's malformed latch is set.
+    pub(crate) async fn wait_track_malformed(&self) {
+        let cache = self.cache_store.get_or_create(&self.track_key);
+        tokio::time::timeout(RECV_TIMEOUT, cache.malformed_track_detected())
+            .await
+            .expect("track should be marked malformed");
     }
 
     pub(crate) async fn wait_largest_location(&self, expected: moqt::Location) -> moqt::Location {

--- a/relay/src/modules/relay/tests/harness.rs
+++ b/relay/src/modules/relay/tests/harness.rs
@@ -48,7 +48,6 @@ pub(crate) struct EgressRunnerHandle {
 }
 
 impl EgressRunnerHandle {
-    /// Waits for the runner to send PUBLISH_DONE downstream.
     pub(crate) async fn expect_publish_done(&mut self) -> SentPublishDone {
         tokio::time::timeout(RECV_TIMEOUT, self.publish_done.recv())
             .await
@@ -56,7 +55,6 @@ impl EgressRunnerHandle {
             .expect("egress dropped its publisher before PUBLISH_DONE")
     }
 
-    /// Asserts no PUBLISH_DONE was sent so far (non-blocking).
     pub(crate) fn assert_no_publish_done(&mut self) {
         assert!(
             self.publish_done.try_recv().is_err(),
@@ -135,7 +133,6 @@ impl RelayHarness {
         }
     }
 
-    /// Waits until the track's malformed latch is set.
     pub(crate) async fn wait_track_malformed(&self) {
         let cache = self.cache_store.get_or_create(&self.track_key);
         tokio::time::timeout(RECV_TIMEOUT, cache.malformed_track_detected())

--- a/relay/src/modules/relay/tests/harness/mocks/downstream_client.rs
+++ b/relay/src/modules/relay/tests/harness/mocks/downstream_client.rs
@@ -41,14 +41,39 @@ impl StreamSenderFactory for MockStreamSenderFactory {
     }
 }
 
+/// A PUBLISH_DONE observed by the mock downstream publisher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SentPublishDone {
+    pub(crate) request_id: u64,
+    pub(crate) status_code: u64,
+    pub(crate) stream_count: u64,
+    pub(crate) error_reason: String,
+}
+
 pub(crate) struct MockPublisher {
     sent: mpsc::UnboundedSender<Option<DataObject>>,
+    publish_done: mpsc::UnboundedSender<SentPublishDone>,
+}
+
+pub(crate) struct MockPublisherObservers {
+    pub(crate) sent: mpsc::UnboundedReceiver<Option<DataObject>>,
+    pub(crate) publish_done: mpsc::UnboundedReceiver<SentPublishDone>,
 }
 
 impl MockPublisher {
-    pub(crate) fn channel() -> (Self, mpsc::UnboundedReceiver<Option<DataObject>>) {
+    pub(crate) fn channel() -> (Self, MockPublisherObservers) {
         let (sender, receiver) = mpsc::unbounded_channel();
-        (Self { sent: sender }, receiver)
+        let (publish_done_sender, publish_done_receiver) = mpsc::unbounded_channel();
+        (
+            Self {
+                sent: sender,
+                publish_done: publish_done_sender,
+            },
+            MockPublisherObservers {
+                sent: receiver,
+                publish_done: publish_done_receiver,
+            },
+        )
     }
 }
 
@@ -68,6 +93,23 @@ impl Publisher for MockPublisher {
         _track_name: String,
     ) -> anyhow::Result<DownstreamSubscription> {
         unreachable!("not used by the egress path under test")
+    }
+
+    async fn send_publish_done(
+        &self,
+        request_id: u64,
+        status_code: u64,
+        stream_count: u64,
+        error_reason: String,
+    ) -> anyhow::Result<()> {
+        self.publish_done
+            .send(SentPublishDone {
+                request_id,
+                status_code,
+                stream_count,
+                error_reason,
+            })
+            .map_err(|_| anyhow::anyhow!("test side dropped"))
     }
 
     fn new_stream_factory(

--- a/relay/src/modules/relay/tests/harness/mocks/downstream_client.rs
+++ b/relay/src/modules/relay/tests/harness/mocks/downstream_client.rs
@@ -41,7 +41,6 @@ impl StreamSenderFactory for MockStreamSenderFactory {
     }
 }
 
-/// A PUBLISH_DONE observed by the mock downstream publisher.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SentPublishDone {
     pub(crate) request_id: u64,

--- a/relay/src/modules/relay/tests/harness/mocks/upstream_client.rs
+++ b/relay/src/modules/relay/tests/harness/mocks/upstream_client.rs
@@ -38,9 +38,15 @@ impl UpstreamSubgroupStream {
     }
 
     pub(crate) fn object(&self, index: usize) {
+        self.object_with_payload(index, ordered_payload(index));
+    }
+
+    /// Sends the object at `index` with an arbitrary payload, for duplicate /
+    /// malformed-track scenarios.
+    pub(crate) fn object_with_payload(&self, index: usize, payload: bytes::Bytes) {
         let delta = if index == 0 { 0 } else { 1 };
         self.sender
-            .send(Ok(Some(make_payload_object(delta, ordered_payload(index)))))
+            .send(Ok(Some(make_payload_object(delta, payload))))
             .expect("ingress should be reading this stream");
     }
 

--- a/relay/src/modules/relay/tests/harness/mocks/upstream_client.rs
+++ b/relay/src/modules/relay/tests/harness/mocks/upstream_client.rs
@@ -41,8 +41,6 @@ impl UpstreamSubgroupStream {
         self.object_with_payload(index, ordered_payload(index));
     }
 
-    /// Sends the object at `index` with an arbitrary payload, for duplicate /
-    /// malformed-track scenarios.
     pub(crate) fn object_with_payload(&self, index: usize, payload: bytes::Bytes) {
         let delta = if index == 0 { 0 } else { 1 };
         self.sender

--- a/relay/src/modules/relay/tests/malformed_track.rs
+++ b/relay/src/modules/relay/tests/malformed_track.rs
@@ -1,6 +1,4 @@
-//! Integration tests for draft-14 §2.5 Malformed Tracks, condition 8:
-//! "The same Object is received more than once with different Payload or
-//! other immutable properties."
+//! Integration tests for draft-14 §2.5 Malformed Tracks, condition 8.
 
 use bytes::Bytes;
 
@@ -28,8 +26,7 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     let harness = RelayHarness::new();
     let mut egress = harness.start_egress(None).await;
 
-    // A second stream re-delivers object 0 of the same (group, subgroup)
-    // with a different payload — §2.5 condition 8.
+    // Act: a second stream re-delivers object 0 with a different payload.
     let first_stream = harness.open_upstream_stream().await;
     first_stream.header(0);
     first_stream.object(0);
@@ -37,8 +34,7 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     second_stream.header(0);
     second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
 
-    // The relay must terminate the downstream subscription with PUBLISH_DONE
-    // carrying MALFORMED_TRACK, keeping the session itself alive.
+    // Assert: the subscription ends with PUBLISH_DONE(MALFORMED_TRACK).
     let publish_done = egress.expect_publish_done().await;
     assert_eq!(
         publish_done.status_code,
@@ -47,10 +43,9 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     assert_eq!(publish_done.request_id, 0);
 }
 
+// Cascading topologies legitimately deliver the same object via several paths.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn identical_duplicate_from_second_stream_is_not_malformed() {
-    // Cascading topologies legitimately deliver the same object via several
-    // paths; a byte-identical duplicate must be deduped, not flagged.
     let harness = RelayHarness::new();
     let mut egress = harness.start_egress(None).await;
 
@@ -60,9 +55,8 @@ async fn identical_duplicate_from_second_stream_is_not_malformed() {
     let second_stream = harness.open_upstream_stream().await;
     second_stream.header(0);
     second_stream.object(0);
-    // The two streams share one subgroup entry, so close it only after the
-    // last object is cached: a FIN racing ahead of a late append (processed by
-    // the other stream's reader task) would cut delivery short.
+    // The streams share one subgroup entry: FIN only after the last object is
+    // cached, or a racing close cuts delivery short.
     first_stream.object(1);
     harness
         .wait_largest_location(moqt::Location {
@@ -85,7 +79,7 @@ async fn identical_duplicate_from_second_stream_is_not_malformed() {
 async fn subscription_started_after_detection_is_terminated_immediately() {
     let harness = RelayHarness::new();
 
-    // Latch the track first, without any downstream subscriber attached.
+    // Arrange: latch the track before any downstream subscriber attaches.
     let first_stream = harness.open_upstream_stream().await;
     first_stream.header(0);
     first_stream.object(0);
@@ -94,8 +88,7 @@ async fn subscription_started_after_detection_is_terminated_immediately() {
     second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
     harness.wait_track_malformed().await;
 
-    // A runner started on the quarantined track terminates right away with
-    // Stream Count 0: it never opened a data stream.
+    // Assert: the runner terminates right away, with Stream Count 0.
     let mut egress = harness.start_egress(None).await;
     let publish_done = egress.expect_publish_done().await;
     assert_eq!(

--- a/relay/src/modules/relay/tests/malformed_track.rs
+++ b/relay/src/modules/relay/tests/malformed_track.rs
@@ -88,9 +88,10 @@ async fn subscription_started_after_detection_is_terminated_immediately() {
     second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
     harness.wait_track_malformed().await;
 
-    // Act / Assert: the runner terminates right away, with Stream Count 0
+    // Act
     let mut egress = harness.start_egress(None).await;
     let publish_done = egress.expect_publish_done().await;
+    // Assert: the runner terminates right away, with Stream Count 0
     assert_eq!(
         publish_done.status_code,
         publish_done_status_code::MALFORMED_TRACK

--- a/relay/src/modules/relay/tests/malformed_track.rs
+++ b/relay/src/modules/relay/tests/malformed_track.rs
@@ -1,0 +1,106 @@
+//! Integration tests for draft-14 §2.5 Malformed Tracks, condition 8:
+//! "The same Object is received more than once with different Payload or
+//! other immutable properties."
+
+use bytes::Bytes;
+
+use crate::modules::{
+    core::data_object::DataObject,
+    enums::PublishDoneStatusCode,
+    relay::tests::harness::{RelayHarness, ordered_payload, receive_objects_until_close},
+};
+
+fn payloads_of(objects: &[DataObject]) -> Vec<Bytes> {
+    objects
+        .iter()
+        .filter_map(|object| match object {
+            DataObject::SubgroupObject(field) => match &field.subgroup_object {
+                moqt::SubgroupObject::Payload { data, .. } => Some(data.clone()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn duplicate_object_with_different_payload_terminates_subscription() {
+    let harness = RelayHarness::new();
+    let mut egress = harness.start_egress(None).await;
+
+    // A second stream re-delivers object 0 of the same (group, subgroup)
+    // with a different payload — §2.5 condition 8.
+    let first_stream = harness.open_upstream_stream().await;
+    first_stream.header(0);
+    first_stream.object(0);
+    let second_stream = harness.open_upstream_stream().await;
+    second_stream.header(0);
+    second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
+
+    // The relay must terminate the downstream subscription with PUBLISH_DONE
+    // carrying MALFORMED_TRACK, keeping the session itself alive.
+    let publish_done = egress.expect_publish_done().await;
+    assert_eq!(
+        publish_done.status_code,
+        PublishDoneStatusCode::MalformedTrack as u64
+    );
+    assert_eq!(publish_done.request_id, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn identical_duplicate_from_second_stream_is_not_malformed() {
+    // Cascading topologies legitimately deliver the same object via several
+    // paths; a byte-identical duplicate must be deduped, not flagged.
+    let harness = RelayHarness::new();
+    let mut egress = harness.start_egress(None).await;
+
+    let first_stream = harness.open_upstream_stream().await;
+    first_stream.header(0);
+    first_stream.object(0);
+    let second_stream = harness.open_upstream_stream().await;
+    second_stream.header(0);
+    second_stream.object(0);
+    // The two streams share one subgroup entry, so close it only after the
+    // last object is cached: a FIN racing ahead of a late append (processed by
+    // the other stream's reader task) would cut delivery short.
+    first_stream.object(1);
+    harness
+        .wait_largest_location(moqt::Location {
+            group_id: 0,
+            object_id: 1,
+        })
+        .await;
+    first_stream.fin();
+    second_stream.fin();
+
+    let objects = receive_objects_until_close(&mut egress).await;
+    assert_eq!(
+        payloads_of(&objects),
+        vec![ordered_payload(0), ordered_payload(1)]
+    );
+    egress.assert_no_publish_done();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn subscription_started_after_detection_is_terminated_immediately() {
+    let harness = RelayHarness::new();
+
+    // Latch the track first, without any downstream subscriber attached.
+    let first_stream = harness.open_upstream_stream().await;
+    first_stream.header(0);
+    first_stream.object(0);
+    let second_stream = harness.open_upstream_stream().await;
+    second_stream.header(0);
+    second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
+    harness.wait_track_malformed().await;
+
+    // A runner started on the quarantined track terminates right away with
+    // Stream Count 0: it never opened a data stream.
+    let mut egress = harness.start_egress(None).await;
+    let publish_done = egress.expect_publish_done().await;
+    assert_eq!(
+        publish_done.status_code,
+        PublishDoneStatusCode::MalformedTrack as u64
+    );
+    assert_eq!(publish_done.stream_count, 0);
+}

--- a/relay/src/modules/relay/tests/malformed_track.rs
+++ b/relay/src/modules/relay/tests/malformed_track.rs
@@ -22,9 +22,11 @@ fn payloads_of(objects: &[DataObject]) -> Vec<Bytes> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn duplicate_object_with_different_payload_terminates_subscription() {
+    // Arrange
     let harness = RelayHarness::new();
     let mut egress = harness.start_egress(None).await;
 
+    // Act: a second stream re-delivers object 0 with a different payload
     let first_stream = harness.open_upstream_stream().await;
     first_stream.header(0);
     first_stream.object(0);
@@ -32,6 +34,7 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     second_stream.header(0);
     second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
 
+    // Assert: the subscription ends with PUBLISH_DONE(MALFORMED_TRACK)
     let publish_done = egress.expect_publish_done().await;
     assert_eq!(
         publish_done.status_code,
@@ -42,9 +45,11 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn identical_duplicate_from_second_stream_is_not_malformed() {
+    // Arrange
     let harness = RelayHarness::new();
     let mut egress = harness.start_egress(None).await;
 
+    // Act: a second stream re-delivers object 0 with an identical payload
     let first_stream = harness.open_upstream_stream().await;
     first_stream.header(0);
     first_stream.object(0);
@@ -61,6 +66,7 @@ async fn identical_duplicate_from_second_stream_is_not_malformed() {
     first_stream.fin();
     second_stream.fin();
 
+    // Assert: deduplicated delivery, no PUBLISH_DONE
     let objects = receive_objects_until_close(&mut egress).await;
     assert_eq!(
         payloads_of(&objects),
@@ -71,6 +77,7 @@ async fn identical_duplicate_from_second_stream_is_not_malformed() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn subscription_started_after_detection_is_terminated_immediately() {
+    // Arrange: latch the track before any downstream subscriber attaches
     let harness = RelayHarness::new();
 
     let first_stream = harness.open_upstream_stream().await;
@@ -81,6 +88,7 @@ async fn subscription_started_after_detection_is_terminated_immediately() {
     second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
     harness.wait_track_malformed().await;
 
+    // Act / Assert: the runner terminates right away, with Stream Count 0
     let mut egress = harness.start_egress(None).await;
     let publish_done = egress.expect_publish_done().await;
     assert_eq!(

--- a/relay/src/modules/relay/tests/malformed_track.rs
+++ b/relay/src/modules/relay/tests/malformed_track.rs
@@ -1,5 +1,3 @@
-//! Integration tests for draft-14 §2.5 Malformed Tracks, condition 8.
-
 use bytes::Bytes;
 
 use moqt::wire::publish_done_status_code;
@@ -27,7 +25,6 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     let harness = RelayHarness::new();
     let mut egress = harness.start_egress(None).await;
 
-    // Act: a second stream re-delivers object 0 with a different payload.
     let first_stream = harness.open_upstream_stream().await;
     first_stream.header(0);
     first_stream.object(0);
@@ -35,7 +32,6 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     second_stream.header(0);
     second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
 
-    // Assert: the subscription ends with PUBLISH_DONE(MALFORMED_TRACK).
     let publish_done = egress.expect_publish_done().await;
     assert_eq!(
         publish_done.status_code,
@@ -44,7 +40,6 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     assert_eq!(publish_done.request_id, 0);
 }
 
-// Cascading topologies legitimately deliver the same object via several paths.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn identical_duplicate_from_second_stream_is_not_malformed() {
     let harness = RelayHarness::new();
@@ -56,8 +51,6 @@ async fn identical_duplicate_from_second_stream_is_not_malformed() {
     let second_stream = harness.open_upstream_stream().await;
     second_stream.header(0);
     second_stream.object(0);
-    // The streams share one subgroup entry: FIN only after the last object is
-    // cached, or a racing close cuts delivery short.
     first_stream.object(1);
     harness
         .wait_largest_location(moqt::Location {
@@ -80,7 +73,6 @@ async fn identical_duplicate_from_second_stream_is_not_malformed() {
 async fn subscription_started_after_detection_is_terminated_immediately() {
     let harness = RelayHarness::new();
 
-    // Arrange: latch the track before any downstream subscriber attaches.
     let first_stream = harness.open_upstream_stream().await;
     first_stream.header(0);
     first_stream.object(0);
@@ -89,7 +81,6 @@ async fn subscription_started_after_detection_is_terminated_immediately() {
     second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
     harness.wait_track_malformed().await;
 
-    // Assert: the runner terminates right away, with Stream Count 0.
     let mut egress = harness.start_egress(None).await;
     let publish_done = egress.expect_publish_done().await;
     assert_eq!(

--- a/relay/src/modules/relay/tests/malformed_track.rs
+++ b/relay/src/modules/relay/tests/malformed_track.rs
@@ -2,9 +2,10 @@
 
 use bytes::Bytes;
 
+use moqt::wire::publish_done_status_code;
+
 use crate::modules::{
     core::data_object::DataObject,
-    enums::PublishDoneStatusCode,
     relay::tests::harness::{RelayHarness, ordered_payload, receive_objects_until_close},
 };
 
@@ -38,7 +39,7 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     let publish_done = egress.expect_publish_done().await;
     assert_eq!(
         publish_done.status_code,
-        PublishDoneStatusCode::MalformedTrack as u64
+        publish_done_status_code::MALFORMED_TRACK
     );
     assert_eq!(publish_done.request_id, 0);
 }
@@ -93,7 +94,7 @@ async fn subscription_started_after_detection_is_terminated_immediately() {
     let publish_done = egress.expect_publish_done().await;
     assert_eq!(
         publish_done.status_code,
-        PublishDoneStatusCode::MalformedTrack as u64
+        publish_done_status_code::MALFORMED_TRACK
     );
     assert_eq!(publish_done.stream_count, 0);
 }

--- a/relay/src/modules/sequences/fetch.rs
+++ b/relay/src/modules/sequences/fetch.rs
@@ -138,8 +138,6 @@ impl Fetch {
             }
         };
 
-        // §2.5: a malformed track is quarantined; answer FETCH_ERROR
-        // MALFORMED_TRACK instead of serving or forwarding upstream.
         if cache_store
             .get(&target.track_key)
             .is_some_and(|cache| cache.is_malformed())

--- a/relay/src/modules/sequences/fetch.rs
+++ b/relay/src/modules/sequences/fetch.rs
@@ -75,6 +75,7 @@ enum FetchError {
     NoObjectsPublished,
     InvalidRange,
     NoObjects,
+    MalformedTrack,
 }
 
 impl FetchError {
@@ -85,6 +86,7 @@ impl FetchError {
             Self::NoObjectsPublished => FetchErrorCode::InvalidRange,
             Self::InvalidRange => FetchErrorCode::InvalidRange,
             Self::NoObjects => FetchErrorCode::NoObjects,
+            Self::MalformedTrack => FetchErrorCode::MalformedTrack,
         }
     }
 
@@ -95,6 +97,7 @@ impl FetchError {
             Self::NoObjectsPublished => "No objects published",
             Self::InvalidRange => "Invalid fetch range",
             Self::NoObjects => "No objects in fetch range",
+            Self::MalformedTrack => "Malformed track",
         }
     }
 }
@@ -134,6 +137,19 @@ impl Fetch {
                 return;
             }
         };
+
+        // §2.5: a malformed track is quarantined; answer FETCH_ERROR
+        // MALFORMED_TRACK instead of serving or forwarding upstream.
+        if cache_store
+            .get(&target.track_key)
+            .is_some_and(|cache| cache.is_malformed())
+        {
+            let err = FetchError::MalformedTrack;
+            let _ = handler
+                .error(err.code() as u64, err.reason().to_string())
+                .await;
+            return;
+        }
 
         let source = match self.resolve_fetch_source(&target, cache_store).await {
             Ok(source) => source,
@@ -628,11 +644,11 @@ mod tests {
     ) {
         let subgroup = StreamSubgroupId::Value(0);
         let cache = cache_store.get_or_create(track_key);
-        cache
+        let _ = cache
             .append_live_stream_object(group_id, &subgroup, None, make_header(group_id))
             .await;
         for &object_id in object_ids {
-            cache
+            let _ = cache
                 .append_live_stream_object(group_id, &subgroup, Some(object_id), make_object())
                 .await;
         }
@@ -860,7 +876,7 @@ mod tests {
         fill_group_with_ids(&cache_store, &track_key, 0, &[0]).await;
         let subgroup = StreamSubgroupId::Value(0);
         let cache = cache_store.get_or_create(&track_key);
-        cache
+        let _ = cache
             .append_stream_object(1, &subgroup, None, make_header(1))
             .await;
         cache.close_stream_subgroup(1, &subgroup).await;

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -444,7 +444,6 @@ impl Subscribe {
         cache_store: &Arc<TrackCacheStore>,
         handler: &dyn SubscribeHandler,
     ) {
-        // §9.9 has no malformed-track code; TRACK_DOES_NOT_EXIST is closest.
         if cache_store
             .get(&active_upstream.track_key)
             .is_some_and(|cache| cache.is_malformed())

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -444,9 +444,7 @@ impl Subscribe {
         cache_store: &Arc<TrackCacheStore>,
         handler: &dyn SubscribeHandler,
     ) {
-        // §2.5: a malformed track is quarantined, so new subscriptions to it
-        // are rejected. SUBSCRIBE_ERROR has no malformed-track code (§9.9);
-        // TRACK_DOES_NOT_EXIST ("not available at the publisher") is closest.
+        // §9.9 has no malformed-track code; TRACK_DOES_NOT_EXIST is closest.
         if cache_store
             .get(&active_upstream.track_key)
             .is_some_and(|cache| cache.is_malformed())

--- a/relay/src/modules/sequences/subscribe.rs
+++ b/relay/src/modules/sequences/subscribe.rs
@@ -444,6 +444,23 @@ impl Subscribe {
         cache_store: &Arc<TrackCacheStore>,
         handler: &dyn SubscribeHandler,
     ) {
+        // §2.5: a malformed track is quarantined, so new subscriptions to it
+        // are rejected. SUBSCRIBE_ERROR has no malformed-track code (§9.9);
+        // TRACK_DOES_NOT_EXIST ("not available at the publisher") is closest.
+        if cache_store
+            .get(&active_upstream.track_key)
+            .is_some_and(|cache| cache.is_malformed())
+        {
+            let _ = self
+                .response_error(
+                    handler,
+                    SubscribeErrorCode::TrackDoesNotExist as u64,
+                    "malformed track".to_string(),
+                )
+                .await;
+            return;
+        }
+
         let subscriber_track_alias = handler.allocate_track_alias();
 
         // Determined here so the Largest Location advertised in SUBSCRIBE_OK
@@ -618,10 +635,10 @@ mod tests {
     // Append a single object (id 0) to `group_id` so the cache reports it as content.
     async fn append_one_object(cache: &TrackCache, group_id: u64) {
         let subgroup = StreamSubgroupId::Value(0);
-        cache
+        let _ = cache
             .append_live_stream_object(group_id, &subgroup, None, make_header())
             .await;
-        cache
+        let _ = cache
             .append_live_stream_object(group_id, &subgroup, Some(0), make_object())
             .await;
     }

--- a/tests/object-dedup-e2e/src/main.rs
+++ b/tests/object-dedup-e2e/src/main.rs
@@ -1,8 +1,12 @@
 //! Manual e2e for per-object dedup when the same track is published twice.
 //!
 //!   1. alice publishes group 0 (o0..o4) on a track, then disconnects.
-//!   2. alice publishes the same Full Track Name and group 0 again.
+//!   2. alice publishes the same Full Track Name and group 0 again with
+//!      identical payloads.
 //!   3. bob FETCHes the whole of group 0 and must receive exactly o0..o4.
+//!   4. alice publishes group 0 once more with *different* payloads; the relay
+//!      must quarantine the track (draft-14 §2.5 condition 8) and answer bob's
+//!      next FETCH with FETCH_ERROR MALFORMED_TRACK (0x9).
 //!
 //! Without dedup the relay appends the second group 0 after the first, so the
 //! fetch returns 10 objects (each object id 0..4 twice) and the assertion fails.
@@ -52,17 +56,26 @@ fn unique_track_name() -> String {
     format!("data-{}", nanos)
 }
 
-async fn send_group(factory: &StreamDataSenderFactory<QUIC>, attempt: &str) -> anyhow::Result<()> {
+/// Deterministic per-object payload: republishing the same objects must be
+/// byte-identical, otherwise the relay treats the track as malformed
+/// (draft-14 §2.5 condition 8) instead of deduplicating.
+fn object_payload(obj_id: u64) -> String {
+    format!("alice:g{}:o{}", GROUP_ID, obj_id)
+}
+
+async fn send_group(
+    factory: &StreamDataSenderFactory<QUIC>,
+    attempt: &str,
+    payload_of: impl Fn(u64) -> String,
+) -> anyhow::Result<()> {
     let sender = factory.next().await?;
     let header = sender.create_header(GROUP_ID, SubgroupId::None, PUBLISHER_PRIORITY, false, false);
     let mut stream = sender.send_header(header).await?;
     for obj_id in 0..OBJECTS_PER_GROUP {
-        // Tag the payload with the publish attempt so the duplication is visible.
-        let payload = format!("alice:{}:g{}:o{}", attempt, GROUP_ID, obj_id);
         let obj = stream.create_object_field(
             0,
             ExtensionHeaders::default(),
-            SubgroupObject::new_payload(payload.into()),
+            SubgroupObject::new_payload(payload_of(obj_id).into()),
         );
         stream.send(obj).await?;
         tracing::info!("[alice:{}] sent g{}:o{}", attempt, GROUP_ID, obj_id);
@@ -73,7 +86,11 @@ async fn send_group(factory: &StreamDataSenderFactory<QUIC>, attempt: &str) -> a
 /// Connects, PUBLISHes the track, sends group 0, then drops the session
 /// (disconnect). The trailing sleep lets the relay ingest the objects and, on
 /// return, tear the session down before the next publish.
-async fn publish_once(track_name: &str, attempt: &str) -> anyhow::Result<()> {
+async fn publish_once(
+    track_name: &str,
+    attempt: &str,
+    payload_of: impl Fn(u64) -> String,
+) -> anyhow::Result<()> {
     let session = new_session().await?;
     let publisher = session.publisher();
     let subscription = publisher
@@ -85,7 +102,7 @@ async fn publish_once(track_name: &str, attempt: &str) -> anyhow::Result<()> {
         .await?;
     tracing::info!("[alice:{}] publish ok", attempt);
     let factory = publisher.create_stream(&subscription);
-    send_group(&factory, attempt).await?;
+    send_group(&factory, attempt, payload_of).await?;
     tracing::info!(
         "[alice:{}] group sent; waiting for relay to ingest",
         attempt
@@ -143,13 +160,13 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("[main] track = {}/{}", NAMESPACE, track_name);
 
     // 1. alice publishes group 0, then disconnects.
-    publish_once(&track_name, "1st").await?;
+    publish_once(&track_name, "1st", object_payload).await?;
     // Let the relay finish tearing down alice's ingress so the single-writer
     // guard is cleared before the same track is published again.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // 2. alice publishes the *same* group 0 again.
-    publish_once(&track_name, "2nd").await?;
+    // 2. alice publishes the *same* group 0 again with identical payloads.
+    publish_once(&track_name, "2nd", object_payload).await?;
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // 3. bob fetches the whole of group 0. End object_id 0 means "entire group",
@@ -183,7 +200,51 @@ async fn main() -> anyhow::Result<()> {
         received.len(),
         received
     );
-
     tracing::info!("[bob] OK: group 0 deduplicated to o0..o4");
+
+    // 4. alice republishes group 0 with *different* payloads: the same objects
+    // with different content make the track malformed (draft-14 §2.5
+    // condition 8), so the relay must quarantine it and reject further FETCHes
+    // with MALFORMED_TRACK (0x9).
+    // The relay stops reading the stream at the first conflicting object, so
+    // alice's remaining sends may fail; only the detection matters here.
+    if let Err(error) = publish_once(&track_name, "conflict", |obj_id| {
+        format!("alice:conflict:g{}:o{}", GROUP_ID, obj_id)
+    })
+    .await
+    {
+        tracing::info!("[alice:conflict] publish ended early (expected): {error:#}");
+    }
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let session = new_session().await?;
+    let mut subscriber = session.subscriber();
+    let fetch_result = run_fetch(
+        &mut subscriber,
+        &track_name,
+        Location {
+            group_id: GROUP_ID,
+            object_id: 0,
+        },
+        Location {
+            group_id: GROUP_ID,
+            object_id: 0,
+        },
+    )
+    .await;
+    let error = match fetch_result {
+        Err(error) => error,
+        Ok(received) => anyhow::bail!(
+            "fetch on a malformed track must fail, but returned {} objects: {:?}",
+            received.len(),
+            received
+        ),
+    };
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("code 9"),
+        "fetch on a malformed track must fail with MALFORMED_TRACK (0x9); got: {message}"
+    );
+    tracing::info!("[bob] OK: conflicting republish is rejected as a malformed track");
     Ok(())
 }

--- a/tests/object-dedup-e2e/src/main.rs
+++ b/tests/object-dedup-e2e/src/main.rs
@@ -1,11 +1,8 @@
 //! Manual e2e for per-object dedup when the same track is published twice.
 //!
 //!   1. alice publishes group 0 (o0..o4) on a track, then disconnects.
-//!   2. alice publishes the same Full Track Name and group 0 again with
-//!      identical payloads.
+//!   2. alice publishes the same Full Track Name and group 0 again.
 //!   3. bob FETCHes the whole of group 0 and must receive exactly o0..o4.
-//!   4. alice publishes group 0 once more with *different* payloads; the relay
-//!      must reject bob's next FETCH with MALFORMED_TRACK (§2.5 condition 8).
 //!
 //! Without dedup the relay appends the second group 0 after the first, so the
 //! fetch returns 10 objects (each object id 0..4 twice) and the assertion fails.
@@ -55,8 +52,6 @@ fn unique_track_name() -> String {
     format!("data-{}", nanos)
 }
 
-/// Byte-identical across republishes, or the relay treats the track as
-/// malformed (§2.5 condition 8) instead of deduplicating.
 fn object_payload(obj_id: u64) -> String {
     format!("alice:g{}:o{}", GROUP_ID, obj_id)
 }
@@ -163,7 +158,7 @@ async fn main() -> anyhow::Result<()> {
     // guard is cleared before the same track is published again.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // 2. alice publishes the *same* group 0 again with identical payloads.
+    // 2. alice publishes the *same* group 0 again.
     publish_once(&track_name, "2nd", object_payload).await?;
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -200,9 +195,6 @@ async fn main() -> anyhow::Result<()> {
     );
     tracing::info!("[bob] OK: group 0 deduplicated to o0..o4");
 
-    // 4. alice republishes group 0 with *different* payloads. The relay stops
-    // reading at the first conflicting object, so alice's remaining sends may
-    // fail; only the detection matters here.
     if let Err(error) = publish_once(&track_name, "conflict", |obj_id| {
         format!("alice:conflict:g{}:o{}", GROUP_ID, obj_id)
     })

--- a/tests/object-dedup-e2e/src/main.rs
+++ b/tests/object-dedup-e2e/src/main.rs
@@ -5,8 +5,7 @@
 //!      identical payloads.
 //!   3. bob FETCHes the whole of group 0 and must receive exactly o0..o4.
 //!   4. alice publishes group 0 once more with *different* payloads; the relay
-//!      must quarantine the track (draft-14 §2.5 condition 8) and answer bob's
-//!      next FETCH with FETCH_ERROR MALFORMED_TRACK (0x9).
+//!      must reject bob's next FETCH with MALFORMED_TRACK (§2.5 condition 8).
 //!
 //! Without dedup the relay appends the second group 0 after the first, so the
 //! fetch returns 10 objects (each object id 0..4 twice) and the assertion fails.
@@ -56,9 +55,8 @@ fn unique_track_name() -> String {
     format!("data-{}", nanos)
 }
 
-/// Deterministic per-object payload: republishing the same objects must be
-/// byte-identical, otherwise the relay treats the track as malformed
-/// (draft-14 §2.5 condition 8) instead of deduplicating.
+/// Republished objects must be byte-identical, or the relay treats the track
+/// as malformed (§2.5 condition 8) instead of deduplicating.
 fn object_payload(obj_id: u64) -> String {
     format!("alice:g{}:o{}", GROUP_ID, obj_id)
 }
@@ -202,12 +200,9 @@ async fn main() -> anyhow::Result<()> {
     );
     tracing::info!("[bob] OK: group 0 deduplicated to o0..o4");
 
-    // 4. alice republishes group 0 with *different* payloads: the same objects
-    // with different content make the track malformed (draft-14 §2.5
-    // condition 8), so the relay must quarantine it and reject further FETCHes
-    // with MALFORMED_TRACK (0x9).
-    // The relay stops reading the stream at the first conflicting object, so
-    // alice's remaining sends may fail; only the detection matters here.
+    // 4. alice republishes group 0 with *different* payloads. The relay stops
+    // reading at the first conflicting object, so alice's remaining sends may
+    // fail; only the detection matters here.
     if let Err(error) = publish_once(&track_name, "conflict", |obj_id| {
         format!("alice:conflict:g{}:o{}", GROUP_ID, obj_id)
     })

--- a/tests/object-dedup-e2e/src/main.rs
+++ b/tests/object-dedup-e2e/src/main.rs
@@ -55,8 +55,8 @@ fn unique_track_name() -> String {
     format!("data-{}", nanos)
 }
 
-/// Republished objects must be byte-identical, or the relay treats the track
-/// as malformed (§2.5 condition 8) instead of deduplicating.
+/// Byte-identical across republishes, or the relay treats the track as
+/// malformed (§2.5 condition 8) instead of deduplicating.
 fn object_payload(obj_id: u64) -> String {
     format!("alice:g{}:o{}", GROUP_ID, obj_id)
 }


### PR DESCRIPTION
## 概要
relayは同一Objectの内容違い再受信（draft-14 §2.5 条件8）を検出せずfirst-winsで捨てており、仕様がMUSTとする下流への通知を行っていなかった。キャッシュ層で検出してトラック単位に隔離し、下流subscriptionをPUBLISH_DONE(MALFORMED_TRACK)で終了、fetchストリームをリセットする。

## やったこと
- GroupCache/TrackCacheで重複受信時に不変プロパティを比較し（payload・extension headers・publisher priority・subgroup跨ぎ）、stickyなmalformedラッチでappend拒否・fetch中断
- EgressRunnerがラッチを監視し、全データストリームclose後にPUBLISH_DONE(MALFORMED_TRACK)を送出。fetchストリームは0x9でリセットし、隔離後の新規SUBSCRIBE/FETCHは拒否
- 仕様違反だった既存箇所を修正：object-dedup E2E（内容違いの再publish）とサンプルアプリのgroup採番（0起点→時刻シード）

## やらないこと
検出時の上流側クリーンアップ（UNSUBSCRIBE/FETCH_CANCEL・ingest停止）、subscriber側のPUBLISH_DONE処理、§2.5 条件1〜7の検出

## 影響範囲
relay（検出・隔離の追加）、moqt（PUBLISH_DONE送信APIとDatagramFieldアクセサの追加のみで既存APIに破壊なし）、wasm/examples（group ID採番が0起点から時刻シードに変わる）

## テスト
- cargo test（relay/moqt）、clippy、fmt すべてパス
- object-dedup E2E（malformed検証フェーズを追加）をローカルdocker構成で通過、CIのE2Eワークフローを5回re-runし全ジョブ成功

## 備考
§2.5の「fetchストリームをMALFORMED_TRACKでリセット」はRESET_STREAMコード表に該当コードがないため、FETCH_ERROR表の0x9を使用。SUBSCRIBE_ERRORにはmalformed用コードがないためTRACK_DOES_NOT_EXISTで拒否