### PR TITLE
docs: エージェント共通ルールを .agents/rules に分割し、コメント規約と冗長な記述を整理する

### DIFF
--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -9,6 +9,10 @@ Shared coding style rules for all agents (Claude Code, Codex). Read this before 
 
 ## Comments
 - Keep comments to a minimum. Code that needs a comment to be readable should usually be renamed or restructured instead.
+- A comment in the code body may carry only information that satisfies both conditions:
+  1. It cannot be reconstructed from the code itself.
+  2. It affects current behavior right now.
+- Consequences of that rule: do not leave change history, past implementations, migration notes, review discussion, TODO speculation, or plans for future work in the code body. Such context belongs in the commit message, the pull request, or an architecture document.
 - Write a comment only for the non-obvious *why* — an invariant, a specification constraint, a workaround, or a deliberate trade-off. Do not restate what the code already says.
 - Exceptions where comments are still required: the invariant behind `panic!`/`unreachable!` and the meaning of abbreviations in type declarations.
 - In test code, the `// Arrange` / `// Act` / `// Assert` phase-separator comments are always allowed even though they only label the phase. See `testing.md`.

--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -1,26 +1,21 @@
 # Coding Style Rules
 
-Shared coding style rules for all agents (Claude Code, Codex). Read this before writing or modifying implementation code.
+Shared by all agents (Claude Code, Codex).
 
 ## Implementation Principles
-- Follow YAGNI. Implement only what the current requirement needs.
-- Do not add configuration options, abstraction layers, generic parameters, or extension points for anticipated future needs. Add them when a second concrete use case appears.
+- Follow YAGNI: implement only what the current requirement needs. Do not add configuration options, abstraction layers, generic parameters, or extension points for anticipated future needs — add them when a second concrete use case appears.
 - Prefer the smallest change that satisfies the requirement over a larger refactor, unless the task explicitly asks for the refactor.
 
 ## Comments
 - Keep comments to a minimum. Code that needs a comment to be readable should usually be renamed or restructured instead.
-- A comment in the code body may carry only information that satisfies both conditions:
-  1. It cannot be reconstructed from the code itself.
-  2. It affects current behavior right now.
-- Consequences of that rule: do not leave change history, past implementations, migration notes, review discussion, TODO speculation, or plans for future work in the code body. Such context belongs in the commit message, the pull request, or an architecture document.
-- Write a comment only for the non-obvious *why* — an invariant, a specification constraint, a workaround, or a deliberate trade-off. Do not restate what the code already says.
-- Exceptions where comments are still required: the invariant behind `panic!`/`unreachable!` and the meaning of abbreviations in type declarations.
-- In test code, the `// Arrange` / `// Act` / `// Assert` phase-separator comments are always allowed even though they only label the phase. See `testing.md`.
+- A comment may stay in the code body only if it both cannot be reconstructed from the code and affects current behavior — in practice, the non-obvious *why*: an invariant, a specification constraint, a workaround, or a deliberate trade-off.
+- Change history, past implementations, migration notes, review discussion, TODO speculation, and plans for future work therefore do not belong in the code body. Put them in the commit message, the pull request, or an architecture document.
+- A comment is required in three cases: the invariant behind `panic!`/`unreachable!`, the meaning of abbreviations in type declarations, and the `// Arrange` / `// Act` / `// Assert` labels in tests (see `testing.md`).
 
 ## Naming
 - Follow the naming conventions of the implementation language (e.g. `snake_case` for Rust, `camelCase` for TypeScript).
 - Names must represent the target concept clearly.
-- Abbreviations are allowed, but when used in type declarations, document the meaning in a code-level doc comment.
+- Abbreviations are allowed.
 - Channel-related variables must be named using the `xxx_sender` or `yyy_receiver` pattern.
 
 ## Error Handling
@@ -28,16 +23,14 @@ Shared coding style rules for all agents (Claude Code, Codex). Read this before 
 - Use `std::io::Result` only when explicitly instructed.
 - For recoverable failures, do not use `panic!`/`unwrap`; return `Result` instead.
 - `panic!`/`unwrap` is allowed during initialization/startup only when the process cannot continue safely.
-- `panic!`/`unreachable!` is allowed for proven unreachable states only; in this case, add a comment that explains the invariant.
+- `panic!`/`unreachable!` is allowed for proven unreachable states only.
 - Choose `bool` / `Option` / `Result` in this order:
   1. If the caller needs the failure reason or recovery action, use `Result`.
   2. Otherwise, if a value may be absent as a normal case, use `Option`.
   3. Otherwise, use `bool` for pure yes/no semantics.
-- Use `Option` only when `None` is an expected and non-error state.
 - If the return state may expand beyond true/false in the future, prefer a dedicated enum over `bool`.
 
 ## Async / Tasks
-- No special naming convention for async functions.
 - Background tasks must be encapsulated in a dedicated struct that owns the `JoinHandle`.
 - The struct's constructor `run()` spawns the task and returns `Self`.
 - If the task needs to receive commands, store an `mpsc::Sender` alongside the `JoinHandle` (actor pattern).
@@ -54,7 +47,7 @@ Shared coding style rules for all agents (Claude Code, Codex). Read this before 
 
 ## Module Structure
 - Split modules and structs based on SOLID principles with functional cohesion.
-- Keep each file under 300 lines. If a file exceeds this, consider splitting it.
+- Keep each file under 300 lines.
 - When creating a directory module, use a same-name `.rs` file (e.g. `foo.rs` + `foo/`) instead of `foo/mod.rs`.
 
 ## Visibility
@@ -65,12 +58,12 @@ Shared coding style rules for all agents (Claude Code, Codex). Read this before 
 
 ## Dependencies
 - Minimize the number of external crates. Prefer existing dependencies over adding new ones.
-- When adding a new crate, create an Architecture Decision Record (ADR) under `architecture_decision_record/${package_name}/` at the repository root. Use the target package's `name` value in `Cargo.toml` as `${package_name}` (e.g. `architecture_decision_record/media-streaming-format/tokio-util.md` for `shared/media-streaming-format`). Each ADR must be a separate Markdown file named after the crate. The ADR must include:
+- When adding a new crate, create an Architecture Decision Record (ADR) at `architecture_decision_record/${package_name}/<crate>.md`, where `${package_name}` is the package's `name` in `Cargo.toml` (e.g. `architecture_decision_record/media-streaming-format/tokio-util.md`). The ADR must cover:
   1. What — the crate being added and its purpose.
   2. Context — the problem or requirement that motivates the addition.
   3. Alternatives — other crates or approaches considered, with trade-offs.
   4. Decision — the final choice and rationale.
-- If you are unsure about ADR writing style or structure, refer to `architecture_decision_record/example/000_jwt_authentication.md` as a reference.
+- For ADR style, see `architecture_decision_record/example/000_jwt_authentication.md`.
 
 ## Unsafe
 - `unsafe` is prohibited in principle.

--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -10,7 +10,8 @@ Shared coding style rules for all agents (Claude Code, Codex). Read this before 
 ## Comments
 - Keep comments to a minimum. Code that needs a comment to be readable should usually be renamed or restructured instead.
 - Write a comment only for the non-obvious *why* — an invariant, a specification constraint, a workaround, or a deliberate trade-off. Do not restate what the code already says.
-- Exceptions where comments are still required: the invariant behind `panic!`/`unreachable!`, the meaning of abbreviations in type declarations, and the Act / Assert comments in tests.
+- Exceptions where comments are still required: the invariant behind `panic!`/`unreachable!` and the meaning of abbreviations in type declarations.
+- In test code, the `// Arrange` / `// Act` / `// Assert` phase-separator comments are always allowed even though they only label the phase. See `testing.md`.
 
 ## Naming
 - Follow the naming conventions of the implementation language (e.g. `snake_case` for Rust, `camelCase` for TypeScript).

--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -1,0 +1,72 @@
+# Coding Style Rules
+
+Shared coding style rules for all agents (Claude Code, Codex). Read this before writing or modifying implementation code.
+
+## Implementation Principles
+- Follow YAGNI. Implement only what the current requirement needs.
+- Do not add configuration options, abstraction layers, generic parameters, or extension points for anticipated future needs. Add them when a second concrete use case appears.
+- Prefer the smallest change that satisfies the requirement over a larger refactor, unless the task explicitly asks for the refactor.
+
+## Comments
+- Keep comments to a minimum. Code that needs a comment to be readable should usually be renamed or restructured instead.
+- Write a comment only for the non-obvious *why* — an invariant, a specification constraint, a workaround, or a deliberate trade-off. Do not restate what the code already says.
+- Exceptions where comments are still required: the invariant behind `panic!`/`unreachable!`, the meaning of abbreviations in type declarations, and the Act / Assert comments in tests.
+
+## Naming
+- Follow the naming conventions of the implementation language (e.g. `snake_case` for Rust, `camelCase` for TypeScript).
+- Names must represent the target concept clearly.
+- Abbreviations are allowed, but when used in type declarations, document the meaning in a code-level doc comment.
+- Channel-related variables must be named using the `xxx_sender` or `yyy_receiver` pattern.
+
+## Error Handling
+- Use `anyhow::Result` by default.
+- Use `std::io::Result` only when explicitly instructed.
+- For recoverable failures, do not use `panic!`/`unwrap`; return `Result` instead.
+- `panic!`/`unwrap` is allowed during initialization/startup only when the process cannot continue safely.
+- `panic!`/`unreachable!` is allowed for proven unreachable states only; in this case, add a comment that explains the invariant.
+- Choose `bool` / `Option` / `Result` in this order:
+  1. If the caller needs the failure reason or recovery action, use `Result`.
+  2. Otherwise, if a value may be absent as a normal case, use `Option`.
+  3. Otherwise, use `bool` for pure yes/no semantics.
+- Use `Option` only when `None` is an expected and non-error state.
+- If the return state may expand beyond true/false in the future, prefer a dedicated enum over `bool`.
+
+## Async / Tasks
+- No special naming convention for async functions.
+- Background tasks must be encapsulated in a dedicated struct that owns the `JoinHandle`.
+- The struct's constructor `run()` spawns the task and returns `Self`.
+- If the task needs to receive commands, store an `mpsc::Sender` alongside the `JoinHandle` (actor pattern).
+- Place each task file in the directory whose responsibility the task fulfills, not necessarily where it is spawned.
+  - Example: `moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs`
+
+## Async Primitives
+- In async code, use `tokio` equivalents over `std` for synchronization, file I/O, and time operations.
+- `std::sync::Mutex` is acceptable only when the lock is never held across an `.await` point.
+
+## Imports
+- Use standard `use` declarations. Do not write full paths inline unless disambiguation is needed.
+- When the same type name exists in both `std` and `tokio` within one file, qualify with the module path (e.g. `std::sync::Mutex`) instead of creating aliases.
+
+## Module Structure
+- Split modules and structs based on SOLID principles with functional cohesion.
+- Keep each file under 300 lines. If a file exceeds this, consider splitting it.
+- When creating a directory module, use a same-name `.rs` file (e.g. `foo.rs` + `foo/`) instead of `foo/mod.rs`.
+
+## Visibility
+- `pub` — only for items exported outside the crate.
+- `pub(crate)` — for items shared within the crate.
+- `pub(super)` — for items accessed only from the parent module.
+- Private (no modifier) — everything else.
+
+## Dependencies
+- Minimize the number of external crates. Prefer existing dependencies over adding new ones.
+- When adding a new crate, create an Architecture Decision Record (ADR) under `architecture_decision_record/${package_name}/` at the repository root. Use the target package's `name` value in `Cargo.toml` as `${package_name}` (e.g. `architecture_decision_record/media-streaming-format/tokio-util.md` for `shared/media-streaming-format`). Each ADR must be a separate Markdown file named after the crate. The ADR must include:
+  1. What — the crate being added and its purpose.
+  2. Context — the problem or requirement that motivates the addition.
+  3. Alternatives — other crates or approaches considered, with trade-offs.
+  4. Decision — the final choice and rationale.
+- If you are unsure about ADR writing style or structure, refer to `architecture_decision_record/example/000_jwt_authentication.md` as a reference.
+
+## Unsafe
+- `unsafe` is prohibited in principle.
+- Allowed only when the compiler explicitly requires it or when interfacing with FFI.

--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -7,9 +7,9 @@ Shared by all agents (Claude Code, Codex).
 - Prefer the smallest change that satisfies the requirement over a larger refactor, unless the task explicitly asks for the refactor.
 
 ## Comments
-- Keep comments to a minimum. Code that needs a comment to be readable should usually be renamed or restructured instead.
-- A comment may stay in the code body only if it both cannot be reconstructed from the code and affects current behavior — in practice, the non-obvious *why*: an invariant, a specification constraint, a workaround, or a deliberate trade-off.
-- Change history, past implementations, migration notes, review discussion, TODO speculation, and plans for future work therefore do not belong in the code body. Put them in the commit message, the pull request, or an architecture document.
+- Write a comment only for what cannot be derived from the code and affects current behavior: an invariant, a specification constraint, a workaround, or a deliberate trade-off.
+- If a comment is needed to make the code readable, rename or restructure the code instead of adding the comment.
+- Change history, past implementations, migration notes, review discussion, TODO speculation, and plans for future work do not belong in the code body. Put them in the commit message, the pull request, or an architecture document.
 - A comment is required in three cases: the invariant behind `panic!`/`unreachable!`, the meaning of abbreviations in type declarations, and the `// Arrange` / `// Act` / `// Assert` labels in tests (see `testing.md`).
 
 ## Naming

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -5,6 +5,6 @@ Shared by all agents (Claude Code, Codex).
 - Write unit tests inside the target module using `#[cfg(test)] mod tests`.
 - Structure every test using the Arrange / Act / Assert pattern.
 - Extract Arrange-phase setup into shared utility files; do not duplicate setup across test files.
-- Label the phases with `// Arrange`, `// Act`, and `// Assert`. These are exempt from the minimal-comment rule in `coding-style.md` and are allowed even when they only name the phase.
+- Label the phases with `// Arrange`, `// Act`, and `// Assert`. They are an explicit exception to the comment rule in `coding-style.md`: they are allowed even though they only name the phase.
 - When the flow or the expected result is not obvious, append the explanation to the label instead of adding a separate comment line: `// Assert: only session 1 state is removed; other publishers in the namespace survive`.
 - `// Act / Assert` is acceptable as one label when both are a single expression.

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -2,10 +2,25 @@
 
 Shared testing rules for all agents (Claude Code, Codex). Read this before writing or modifying test code.
 
+## Placement and Structure
 - Write unit tests inside the target module using `#[cfg(test)] mod tests`.
-- Structure test code using the Arrange / Act / Assert pattern.
+- Structure every test using the Arrange / Act / Assert pattern.
 - Extract Arrange-phase setup into shared utility files; do not duplicate setup across test files.
+
+## Phase Comments
+- The "keep comments to a minimum" rule in `coding-style.md` does not apply to phase separators: `// Arrange`, `// Act`, and `// Assert` comments are always allowed, even when they only label the phase.
 - In the Act and Assert phases, add comments at an appropriate granularity so the test intent and verification points are easy to scan.
 - If the flow of operations or the expected result is not immediately obvious, do not leave the Act and Assert phases without comments.
+- When a phase needs explanation, append it to the label instead of adding a separate comment line:
+
+  ```rust
+  // Arrange: register the namespace and track alias for the session
+  // Act: remove all state associated with session 1
+  // Assert: only session 1 state is removed; other publishers in the namespace survive
+  ```
+
+- When Act and Assert are a single expression, `// Act / Assert` is acceptable as one label.
+
+## Maintenance
 - When modifying tests, confirm that shared Arrange utilities still have reusable responsibilities and scope, and that the comments in Act and Assert remain sufficiently descriptive.
 - After making changes, run `cargo test -p <package_name>` for the affected package to verify no regressions.

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -1,26 +1,10 @@
 # Testing Rules
 
-Shared testing rules for all agents (Claude Code, Codex). Read this before writing or modifying test code.
+Shared by all agents (Claude Code, Codex).
 
-## Placement and Structure
 - Write unit tests inside the target module using `#[cfg(test)] mod tests`.
 - Structure every test using the Arrange / Act / Assert pattern.
 - Extract Arrange-phase setup into shared utility files; do not duplicate setup across test files.
-
-## Phase Comments
-- The "keep comments to a minimum" rule in `coding-style.md` does not apply to phase separators: `// Arrange`, `// Act`, and `// Assert` comments are always allowed, even when they only label the phase.
-- In the Act and Assert phases, add comments at an appropriate granularity so the test intent and verification points are easy to scan.
-- If the flow of operations or the expected result is not immediately obvious, do not leave the Act and Assert phases without comments.
-- When a phase needs explanation, append it to the label instead of adding a separate comment line:
-
-  ```rust
-  // Arrange: register the namespace and track alias for the session
-  // Act: remove all state associated with session 1
-  // Assert: only session 1 state is removed; other publishers in the namespace survive
-  ```
-
-- When Act and Assert are a single expression, `// Act / Assert` is acceptable as one label.
-
-## Maintenance
-- When modifying tests, confirm that shared Arrange utilities still have reusable responsibilities and scope, and that the comments in Act and Assert remain sufficiently descriptive.
-- After making changes, run `cargo test -p <package_name>` for the affected package to verify no regressions.
+- Label the phases with `// Arrange`, `// Act`, and `// Assert`. These are exempt from the minimal-comment rule in `coding-style.md` and are allowed even when they only name the phase.
+- When the flow or the expected result is not obvious, append the explanation to the label instead of adding a separate comment line: `// Assert: only session 1 state is removed; other publishers in the namespace survive`.
+- `// Act / Assert` is acceptable as one label when both are a single expression.

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -1,0 +1,11 @@
+# Testing Rules
+
+Shared testing rules for all agents (Claude Code, Codex). Read this before writing or modifying test code.
+
+- Write unit tests inside the target module using `#[cfg(test)] mod tests`.
+- Structure test code using the Arrange / Act / Assert pattern.
+- Extract Arrange-phase setup into shared utility files; do not duplicate setup across test files.
+- In the Act and Assert phases, add comments at an appropriate granularity so the test intent and verification points are easy to scan.
+- If the flow of operations or the expected result is not immediately obvious, do not leave the Act and Assert phases without comments.
+- When modifying tests, confirm that shared Arrange utilities still have reusable responsibilities and scope, and that the comments in Act and Assert remain sufficiently descriptive.
+- After making changes, run `cargo test -p <package_name>` for the affected package to verify no regressions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Application and integration components (draft reference is normally not required
 - After making changes, run `cargo test -p <package_name>` for the affected package to verify no regressions.
 
 ## 6. Testing Guidelines
-- Testing rules are shared by all agents and live in `.agents/rules/testing.md`. If the file contents are not already in your context, read the file before your first code edit.
+- Testing rules are shared by all agents and live in `.agents/rules/testing.md`. Unit tests are colocated with the implementation via `#[cfg(test)] mod tests`, so these rules apply to ordinary source edits as well. If the file contents are not already in your context, read the file before your first code edit.
 
 @.agents/rules/testing.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,6 @@
 
 ## 2. Project Scope
 - This repository implements Media over QUIC Transport (MoQT), a low-latency, QUIC-based application-layer transport protocol.
-- The project is organized around the following components.
 
 Library components (draft-governed):
 
@@ -29,19 +28,15 @@ Application and integration components (draft reference is normally not required
 - `moqt` is the central crate — all other crates depend on it. Changes to `moqt` affect the entire workspace.
 
 ### Architecture Documents
-- Architecture documents live under `architecture_decision_record/${package_name}/architecture.md`:
-  - `architecture_decision_record/moqt/architecture.md` — `moqt` crate architecture
-  - `architecture_decision_record/relay/architecture.md` — `relay` crate architecture
+- Architecture documents live at `architecture_decision_record/${package_name}/architecture.md` (currently `moqt` and `relay`).
 - Before making structural changes to a component (module layout, layering, task/channel topology), read its architecture document first.
 - When a change alters the design intent, module boundaries, runtime flow, or key invariants described in an architecture document, update that document in the same change.
 
 ## 3. Specifications
-- MoQT-related specifications are stored in the `spec` directory.
 - For library components listed in the draft-governed table above, use only the draft listed in `Related Draft` as the authoritative specification. Do not consult other drafts unless the task explicitly requires them.
 - For application and integration components, draft lookup is not required unless the task explicitly asks for specification-level alignment.
 - Do not read the entire draft. Search for the relevant section heading or keyword to locate the needed content.
 - When implementation details are unclear, consult the relevant draft before answering questions or making code changes.
-  - For definitions shared by clients and servers, verify the draft text carefully and implement behavior accordingly.
 - When the draft uses MUST, SHOULD, or MAY (RFC 2119 keywords), ask the user how far to implement before proceeding.
 - If ambiguity remains after consulting both the specification and this document, ask the user for clarification rather than guessing.
 
@@ -68,7 +63,6 @@ Application and integration components (draft reference is normally not required
 
 ## 7. Logging
 Always use the `tracing` crate for log output (e.g. `tracing::info!`, `tracing::debug!`).
-Follow the log level guidelines below.
 
 | Level | Role | Example Events |
 | --- | --- | --- |
@@ -84,6 +78,5 @@ Follow the log level guidelines below.
   - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`
   - Scope: use the component name (`moqt`, `relay`, `wasm`, `live-ingest`, `onvif`, `msf`, `packages`)
 - One commit per logical change. If the description requires "and", split into multiple commits.
-- PR titles must be written in Japanese and clearly describe what was changed.
-- PR descriptions must be written in Japanese and follow `.github/pull_request_template.md`.
+- PR titles and descriptions must be written in Japanese; descriptions follow `.github/pull_request_template.md`.
 - When creating a pull request, follow the skill in `.agents/skills/create-pull-request/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,75 +46,9 @@ Application and integration components (draft reference is normally not required
 - If ambiguity remains after consulting both the specification and this document, ask the user for clarification rather than guessing.
 
 ## 4. Coding Style
+- Coding style rules are shared by all agents and live in `.agents/rules/coding-style.md`. They apply to every code change. If the file contents are not already in your context, read the file before your first code edit.
 
-### Implementation Principles
-- Follow YAGNI. Implement only what the current requirement needs.
-- Do not add configuration options, abstraction layers, generic parameters, or extension points for anticipated future needs. Add them when a second concrete use case appears.
-- Prefer the smallest change that satisfies the requirement over a larger refactor, unless the task explicitly asks for the refactor.
-
-### Comments
-- Keep comments to a minimum. Code that needs a comment to be readable should usually be renamed or restructured instead.
-- Write a comment only for the non-obvious *why* — an invariant, a specification constraint, a workaround, or a deliberate trade-off. Do not restate what the code already says.
-- Exceptions where comments are still required: the invariant behind `panic!`/`unreachable!`, the meaning of abbreviations in type declarations, and the Act / Assert comments in tests.
-
-### Naming
-- Follow the naming conventions of the implementation language (e.g. `snake_case` for Rust, `camelCase` for TypeScript).
-- Names must represent the target concept clearly.
-- Abbreviations are allowed, but when used in type declarations, document the meaning in a code-level doc comment.
-- Channel-related variables must be named using the `xxx_sender` or `yyy_receiver` pattern.
-
-### Error Handling
-- Use `anyhow::Result` by default.
-- Use `std::io::Result` only when explicitly instructed.
-- For recoverable failures, do not use `panic!`/`unwrap`; return `Result` instead.
-- `panic!`/`unwrap` is allowed during initialization/startup only when the process cannot continue safely.
-- `panic!`/`unreachable!` is allowed for proven unreachable states only; in this case, add a comment that explains the invariant.
-- Choose `bool` / `Option` / `Result` in this order:
-  1. If the caller needs the failure reason or recovery action, use `Result`.
-  2. Otherwise, if a value may be absent as a normal case, use `Option`.
-  3. Otherwise, use `bool` for pure yes/no semantics.
-- Use `Option` only when `None` is an expected and non-error state.
-- If the return state may expand beyond true/false in the future, prefer a dedicated enum over `bool`.
-
-### Async / Tasks
-- No special naming convention for async functions.
-- Background tasks must be encapsulated in a dedicated struct that owns the `JoinHandle`.
-- The struct's constructor `run()` spawns the task and returns `Self`.
-- If the task needs to receive commands, store an `mpsc::Sender` alongside the `JoinHandle` (actor pattern).
-- Place each task file in the directory whose responsibility the task fulfills, not necessarily where it is spawned.
-  - Example: `moqt/src/modules/moqt/runtime/tasks/control_message_receive_task.rs`
-
-### Async Primitives
-- In async code, use `tokio` equivalents over `std` for synchronization, file I/O, and time operations.
-- `std::sync::Mutex` is acceptable only when the lock is never held across an `.await` point.
-
-### Imports
-- Use standard `use` declarations. Do not write full paths inline unless disambiguation is needed.
-- When the same type name exists in both `std` and `tokio` within one file, qualify with the module path (e.g. `std::sync::Mutex`) instead of creating aliases.
-
-### Module Structure
-- Split modules and structs based on SOLID principles with functional cohesion.
-- Keep each file under 300 lines. If a file exceeds this, consider splitting it.
-- When creating a directory module, use a same-name `.rs` file (e.g. `foo.rs` + `foo/`) instead of `foo/mod.rs`.
-
-### Visibility
-- `pub` — only for items exported outside the crate.
-- `pub(crate)` — for items shared within the crate.
-- `pub(super)` — for items accessed only from the parent module.
-- Private (no modifier) — everything else.
-
-### Dependencies
-- Minimize the number of external crates. Prefer existing dependencies over adding new ones.
-- When adding a new crate, create an Architecture Decision Record (ADR) under `architecture_decision_record/${package_name}/` at the repository root. Use the target package's `name` value in `Cargo.toml` as `${package_name}` (e.g. `architecture_decision_record/media-streaming-format/tokio-util.md` for `shared/media-streaming-format`). Each ADR must be a separate Markdown file named after the crate. The ADR must include:
-  1. What — the crate being added and its purpose.
-  2. Context — the problem or requirement that motivates the addition.
-  3. Alternatives — other crates or approaches considered, with trade-offs.
-  4. Decision — the final choice and rationale.
-- If you are unsure about ADR writing style or structure, refer to `architecture_decision_record/example/000_jwt_authentication.md` as a reference.
-
-### Unsafe
-- `unsafe` is prohibited in principle.
-- Allowed only when the compiler explicitly requires it or when interfacing with FFI.
+@.agents/rules/coding-style.md
 
 ## 5. Commands
 - Build: `cargo build`
@@ -128,12 +62,9 @@ Application and integration components (draft reference is normally not required
 - After making changes, run `cargo test -p <package_name>` for the affected package to verify no regressions.
 
 ## 6. Testing Guidelines
-- Write unit tests inside the target module using `#[cfg(test)] mod tests`.
-- Structure test code using the Arrange / Act / Assert pattern.
-- Extract Arrange-phase setup into shared utility files; do not duplicate setup across test files.
-- In the Act and Assert phases, add comments at an appropriate granularity so the test intent and verification points are easy to scan.
-- If the flow of operations or the expected result is not immediately obvious, do not leave the Act and Assert phases without comments.
-- When modifying tests, confirm that shared Arrange utilities still have reusable responsibilities and scope, and that the comments in Act and Assert remain sufficiently descriptive.
+- Testing rules are shared by all agents and live in `.agents/rules/testing.md`. If the file contents are not already in your context, read the file before your first code edit.
+
+@.agents/rules/testing.md
 
 ## 7. Logging
 Always use the `tracing` crate for log output (e.g. `tracing::info!`, `tracing::debug!`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Application and integration components (draft reference is normally not required
 - If ambiguity remains after consulting both the specification and this document, ask the user for clarification rather than guessing.
 
 ## 4. Coding Style
-- Coding style rules are shared by all agents and live in `.agents/rules/coding-style.md`. They apply to every code change. If the file contents are not already in your context, read the file before your first code edit.
+- Coding style rules live in `.agents/rules/coding-style.md`, shared by all agents. If it is not already in your context, read it before your first code edit.
 
 @.agents/rules/coding-style.md
 
@@ -62,7 +62,7 @@ Application and integration components (draft reference is normally not required
 - After making changes, run `cargo test -p <package_name>` for the affected package to verify no regressions.
 
 ## 6. Testing Guidelines
-- Testing rules are shared by all agents and live in `.agents/rules/testing.md`. Unit tests are colocated with the implementation via `#[cfg(test)] mod tests`, so these rules apply to ordinary source edits as well. If the file contents are not already in your context, read the file before your first code edit.
+- Testing rules live in `.agents/rules/testing.md`, shared by all agents. Unit tests are colocated with the implementation, so read it before your first code edit as well.
 
 @.agents/rules/testing.md
 


### PR DESCRIPTION
## 概要
AGENTS.md のコーディング規約とテスト規約を `.agents/rules/` 配下に分割し、Claude Code と Codex が同じファイルを参照する形にしました。AGENTS.md は 158 行から 82 行になりました。

## やったこと
- `.agents/rules/coding-style.md` と `.agents/rules/testing.md` を新設し、AGENTS.md の §4 / §6 は指示文と import 行に置換
- コメント規約を「コードから導き出せず、かつ今の動作に関わる情報のみ」に変更し、テストの `// Arrange` / `// Act` / `// Assert` ラベルを明示的な例外として追加
- 表の直前の前置き、同じ義務の二重記載、「特別な規約はない」とだけ述べる項目など、冗長な記述を削除

## やらないこと
- 既存のコードやコメントを新しい規約に合わせて修正すること。

## テスト
- ドキュメントのみの変更のため、`cargo test` は実行していません。

## 備考
- Codex には import 構文がないため、`.agents/rules/*.md` は AGENTS.md の指示文に従って読み込まれます。
