### PR TITLE
docs: コーディング規約に「Root Cause First」と「Refactor As You Go」を追加

### DIFF
--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -6,6 +6,18 @@ Shared by all agents (Claude Code, Codex).
 - Follow YAGNI: implement only what the current requirement needs. Do not add configuration options, abstraction layers, generic parameters, or extension points for anticipated future needs — add them when a second concrete use case appears.
 - Prefer the smallest change that satisfies the requirement over a larger refactor, unless the task explicitly asks for the refactor.
 
+## Root Cause First
+- Before fixing a bug, reproduce it and explain the mechanism. A fix that adds a retry, sleep, widened timeout, defensive check, or call-site special case without a stated mechanism is a symptom patch, not a fix.
+- If the mechanism lives in a lower layer, fix it there rather than working around it in the caller. The workaround becomes load-bearing and hides the bug from the next caller.
+
+## Refactor As You Go
+A change isn't done when it works; it's done when it's the shape you'd want to maintain. Spend the extra cycles:
+
+- A function with 4+ args, or a call site passing the same 3+ values into multiple functions, is a struct waiting to happen. Same for repeated tuples returned across modules. Make the change as part of the same task rather than leaving a TODO.
+- Prefer extending an existing primitive over adding a parallel one-off, and generalizing a helper over copying it. If a fix needs the same edit in N places, reshape so it's one place first, then fix.
+- When a task can be solved by patching around an awkward internal shape or by fixing the shape, fix the shape as part of the same task. Don't preserve an awkward shape just to avoid churn — this applies to internal code as well as public APIs.
+- When a fix requires a refactor, open the refactor as its own PR first, then stack the fix that builds on it as a stacked PR on top of the refactor PR — do not mix the two in one PR.
+
 ## Comments
 - Write a comment only for what cannot be derived from the code and affects current behavior: an invariant, a specification constraint, a workaround, or a deliberate trade-off.
 - If a comment is needed to make the code readable, rename or restructure the code instead of adding the comment.


### PR DESCRIPTION
## 概要
バグ修正と実装の進め方に関する原則が規約に存在しなかったため、症状パッチ（根本原因を特定しないretry/sleep/防御的チェックの追加）や、awkwardな内部構造を温存したままの回避的修正を防ぐ規約を追加する。

## やったこと
- `.agents/rules/coding-style.md` に「Root Cause First」（再現とメカニズム説明を修正の前提にする、下層に原因があれば下層で直す）と「Refactor As You Go」（4引数以上は構造体化、ヘルパーは複製せず一般化、形の修正は同一タスク内で行う）の2セクションを追加
- リファクタが必要な修正は、リファクタを先行PRとして出し、修正はその上にstacked PRとして積むルールを追加

## 備考
原文の3点目にあった「Public API Scrutinyルール」への参照は、このファイルに該当セクションが存在しないため自己完結する文言に調整した。また既存文言の「same PR」は、stacked PRルールと矛盾しないよう「same task」に調整した