### PR TITLE
docs: バグ修正・リファクタ規約を独立見出しからImplementation Principlesに統合

### DIFF
--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -5,17 +5,12 @@ Shared by all agents (Claude Code, Codex).
 ## Implementation Principles
 - Follow YAGNI: implement only what the current requirement needs. Do not add configuration options, abstraction layers, generic parameters, or extension points for anticipated future needs — add them when a second concrete use case appears.
 - Prefer the smallest change that satisfies the requirement over a larger refactor, unless the task explicitly asks for the refactor.
-
-## Root Cause First
-- Before fixing a bug, reproduce it and explain the mechanism. A fix that adds a retry, sleep, widened timeout, defensive check, or call-site special case without a stated mechanism is a symptom patch, not a fix.
-- If the mechanism lives in a lower layer, fix it there rather than working around it in the caller. The workaround becomes load-bearing and hides the bug from the next caller.
-
-## Refactor As You Go
-A change isn't done when it works; it's done when it's the shape you'd want to maintain. Spend the extra cycles:
-
-- A function with 4+ args, or a call site passing the same 3+ values into multiple functions, is a struct waiting to happen. Same for repeated tuples returned across modules. Make the change as part of the same task rather than leaving a TODO.
-- Prefer extending an existing primitive over adding a parallel one-off, and generalizing a helper over copying it. If a fix needs the same edit in N places, reshape so it's one place first, then fix.
-- When a task can be solved by patching around an awkward internal shape or by fixing the shape, fix the shape as part of the same task. Don't preserve an awkward shape just to avoid churn — this applies to internal code as well as public APIs.
+- Before fixing a bug, investigate the cause first: reproduce it and explain the mechanism. A retry, sleep, widened timeout, defensive check, or call-site special case without a stated mechanism is a symptom patch, not a fix.
+- If the cause lies in a lower layer (typically the `moqt` crate), fix it there instead of working around it in the caller. The workaround becomes load-bearing and hides the bug from the next caller.
+- Refactor, as part of the same task rather than leaving a TODO, when any of the following applies:
+  - A function takes 4+ arguments, a call site passes the same 3+ values into multiple functions, or the same tuple is returned across modules — introduce a struct.
+  - A fix needs the same edit in N places — reshape so it is one place first, then fix. Prefer extending an existing primitive over adding a parallel one-off, and generalizing a helper over copying it.
+  - The task can be solved either by patching around an awkward internal shape or by fixing the shape — fix the shape. Do not preserve an awkward shape just to avoid churn; this applies to internal code as well as public APIs.
 - When a fix requires a refactor, open the refactor as its own PR first, then stack the fix that builds on it as a stacked PR on top of the refactor PR — do not mix the two in one PR.
 
 ## Comments


### PR DESCRIPTION
## 概要
#329 で追加した規約は独立見出し（Root Cause First / Refactor As You Go）になっていたが、YAGNI等と同じ一般的な実装原則であるため、Implementation Principlesの箇条書きに統合し文面を再構成する。

## 関連タスク
#329

## やったこと
- 2つの見出しを削除し、Implementation Principlesへ統合
- stacked PRルール（リファクタ先行PR→修正を積む）は文面を維持したまま同セクションへ移動