### PR TITLE
docs: コメントは原則禁止とし、削除のためのリファクタリング実施を規約に明文化する

### DIFF
--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -14,10 +14,11 @@ Shared by all agents (Claude Code, Codex).
 - When a fix requires a refactor, open the refactor as its own PR first, then stack the fix that builds on it as a stacked PR on top of the refactor PR — do not mix the two in one PR.
 
 ## Comments
-- Write a comment only for what cannot be derived from the code and affects current behavior: an invariant, a specification constraint, a workaround, or a deliberate trade-off.
-- If a comment is needed to make the code readable, rename or restructure the code instead of adding the comment.
+- Do not write comments. Before adding or keeping one, apply this test: can the reader derive the information from the code itself (names, types, control flow, test names)? If yes, the comment is prohibited — this applies to all code, not only tests: production code, mocks, and doc comments alike. A doc comment that restates the item's name or signature fails the test.
+- When code seems to need a comment, make the code convey the information instead — rename the function or variable, split the function, or restructure — and then delete the comment. This refactoring is part of the change that removes the comment; do not keep a comment to avoid the refactoring.
+- The only information that may stay as a comment is what code cannot express: an invariant, a specification constraint, a workaround, or a deliberate trade-off that affects current behavior.
 - Change history, past implementations, migration notes, review discussion, TODO speculation, and plans for future work do not belong in the code body. Put them in the commit message, the pull request, or an architecture document.
-- A comment is required in three cases: the invariant behind `panic!`/`unreachable!`, the meaning of abbreviations in type declarations, and the `// Arrange` / `// Act` / `// Assert` labels in tests (see `testing.md`).
+- A comment is required in three cases only: the invariant behind `panic!`/`unreachable!`, the meaning of abbreviations in type declarations, and the bare `// Arrange` / `// Act` / `// Assert` labels in tests (see `testing.md`).
 
 ## Naming
 - Follow the naming conventions of the implementation language (e.g. `snake_case` for Rust, `camelCase` for TypeScript).

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -6,5 +6,5 @@ Shared by all agents (Claude Code, Codex).
 - Structure every test using the Arrange / Act / Assert pattern.
 - Extract Arrange-phase setup into shared utility files; do not duplicate setup across test files.
 - Label the phases with `// Arrange`, `// Act`, and `// Assert`. They are an explicit exception to the comment rule in `coding-style.md`: they are allowed even though they only name the phase.
-- When the flow or the expected result is not obvious, append the explanation to the label instead of adding a separate comment line: `// Assert: only session 1 state is removed; other publishers in the namespace survive`.
+- Append an explanation to a label only when it cannot be derived from the test name, the helper names, or the assertions — never restate them. Prefer renaming the test or extracting a named helper so the bare label suffices; when an explanation is still needed, put it on the label instead of a separate comment line: `// Assert: only session 1 state is removed; other publishers in the namespace survive`.
 - `// Act / Assert` is acceptable as one label when both are a single expression.


### PR DESCRIPTION
## 概要
「非自明なwhyのみ書く」という現行規約でもエージェントがコメントを過剰に付与しがちだったため、規約のデフォルトを「コメント禁止」に反転する。

## やったこと
- coding-style.md: コメント可否を「コードから導出できるか」の判定手順として記述し、テスト以外（本体・モック・docコメント）にも適用されることを明記
- coding-style.md: コメントが必要に見える場合はリネーム・関数分割等のリファクタリングでコメントなしで伝わるコードにしてから削除し、そのリファクタリングはコメント削除と同一変更に含めると明記
- testing.md: Arrange/Act/Assertラベルへの説明追記を「テスト名・helper名・assertから導出できない場合のみ」に制限し、テスト名変更やhelper抽出を優先すると明記

## 影響範囲
規約ドキュメントのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
