### PR TITLE
fix(relay): egress が subgroup 途中から配送を始めたときに object id がずれる問題を修正

### DIFF
--- a/relay/src/modules/core/data_object.rs
+++ b/relay/src/modules/core/data_object.rs
@@ -34,6 +34,23 @@ impl DataObject {
         }
     }
 
+    pub(crate) fn with_stream_object_id_delta(
+        self,
+        prev_object_id: Option<u64>,
+        object_id: u64,
+    ) -> Self {
+        match self {
+            Self::SubgroupObject(mut field) => {
+                field.object_id_delta = match prev_object_id {
+                    None => object_id,
+                    Some(prev) => object_id.saturating_sub(prev.saturating_add(1)),
+                };
+                Self::SubgroupObject(field)
+            }
+            other => other,
+        }
+    }
+
     /// Resolves the absolute object_id of this object within its ingest stream.
     /// `prev_object_id` is the resolved object_id of the previous object on the same
     /// stream (`None` at the start of a subgroup or right after its header).
@@ -129,6 +146,20 @@ mod tests {
                 payload: Bytes::from_static(payload),
             },
         ))
+    }
+
+    #[test]
+    fn stream_object_id_delta_round_trips_through_resolution() {
+        // Arrange: an object cached at id 7 is the first one sent after the header,
+        // then id 9 follows it (one object skipped in between)
+        let first = subgroup_object(0, b"a").with_stream_object_id_delta(None, 7);
+        let second = subgroup_object(0, b"b").with_stream_object_id_delta(Some(7), 9);
+        // Act
+        let first_id = first.resolve_absolute_object_id(None);
+        let second_id = second.resolve_absolute_object_id(first_id);
+        // Assert
+        assert_eq!(first_id, Some(7));
+        assert_eq!(second_id, Some(9));
     }
 
     #[test]

--- a/relay/src/modules/relay/egress/group_sender.rs
+++ b/relay/src/modules/relay/egress/group_sender.rs
@@ -175,10 +175,14 @@ impl GroupSender {
         }
 
         let mut cursor = object_id;
+        let mut prev_sent_object_id = None;
         while let Some((id, object)) = cache
             .stream_object_from_or_wait(group_id, &subgroup_id, cursor)
             .await
         {
+            let object = (*object)
+                .clone()
+                .with_stream_object_id_delta(prev_sent_object_id, id);
             tracing::debug!(
                 track_key = %track_key,
                 track_alias,
@@ -187,7 +191,7 @@ impl GroupSender {
                 object_id = id,
                 "egress sending subgroup object"
             );
-            if sender.send_object((*object).clone()).await.is_err() {
+            if sender.send_object(object).await.is_err() {
                 span.record("object_count", object_count);
                 span.record("end_reason", "send_object_failed");
                 tracing::error!(
@@ -201,6 +205,7 @@ impl GroupSender {
                 return;
             }
             object_count += 1;
+            prev_sent_object_id = Some(id);
             cursor = id + 1;
         }
         span.record("object_count", object_count);

--- a/relay/src/modules/relay/tests/data_plane.rs
+++ b/relay/src/modules/relay/tests/data_plane.rs
@@ -1,5 +1,6 @@
 use super::harness::{
     OBJECT_COUNT, RelayHarness, assert_full_ordered_delivery, receive_objects_until_close,
+    resolve_downstream_object_ids,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -67,4 +68,33 @@ async fn egress_started_with_pre_subscribe_snapshot_delivers_head_objects_cached
 
     let objects = receive_objects_until_close(&mut egress).await;
     assert_full_ordered_delivery(&objects);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn egress_started_mid_subgroup_delivers_absolute_object_ids() {
+    const LARGEST_OBJECT_ID_AT_SUBSCRIBE: usize = 9;
+
+    let harness = RelayHarness::new();
+    let upstream_stream = harness.open_upstream_stream().await;
+    upstream_stream.header(0);
+    for index in 0..=LARGEST_OBJECT_ID_AT_SUBSCRIBE {
+        upstream_stream.object(index);
+    }
+    let largest = harness
+        .wait_largest_location(moqt::Location {
+            group_id: 0,
+            object_id: LARGEST_OBJECT_ID_AT_SUBSCRIBE as u64,
+        })
+        .await;
+
+    let mut egress = harness.start_egress(Some(largest)).await;
+    for index in LARGEST_OBJECT_ID_AT_SUBSCRIBE + 1..OBJECT_COUNT {
+        upstream_stream.object(index);
+    }
+    upstream_stream.fin();
+
+    let objects = receive_objects_until_close(&mut egress).await;
+    let expected: Vec<u64> =
+        (LARGEST_OBJECT_ID_AT_SUBSCRIBE as u64 + 1..OBJECT_COUNT as u64).collect();
+    assert_eq!(resolve_downstream_object_ids(&objects), expected);
 }

--- a/relay/src/modules/relay/tests/harness.rs
+++ b/relay/src/modules/relay/tests/harness.rs
@@ -228,3 +228,18 @@ pub(crate) fn assert_full_ordered_delivery(objects: &[DataObject]) {
     );
     assert_eq!(payloads, expected, "objects must arrive in publish order");
 }
+
+pub(crate) fn resolve_downstream_object_ids(objects: &[DataObject]) -> Vec<u64> {
+    let mut prev_object_id = None;
+    objects
+        .iter()
+        .filter_map(|object| {
+            let object_id = object.resolve_absolute_object_id(prev_object_id);
+            prev_object_id = object_id;
+            match object {
+                DataObject::SubgroupObject(_) => object_id,
+                _ => None,
+            }
+        })
+        .collect()
+}

--- a/relay/src/modules/relay/tests/harness/mocks/upstream_client.rs
+++ b/relay/src/modules/relay/tests/harness/mocks/upstream_client.rs
@@ -38,13 +38,12 @@ impl UpstreamSubgroupStream {
     }
 
     pub(crate) fn object(&self, index: usize) {
-        self.object_with_payload(index, ordered_payload(index));
+        self.object_with_payload(ordered_payload(index));
     }
 
-    pub(crate) fn object_with_payload(&self, index: usize, payload: bytes::Bytes) {
-        let delta = if index == 0 { 0 } else { 1 };
+    pub(crate) fn object_with_payload(&self, payload: bytes::Bytes) {
         self.sender
-            .send(Ok(Some(make_payload_object(delta, payload))))
+            .send(Ok(Some(make_payload_object(0, payload))))
             .expect("ingress should be reading this stream");
     }
 

--- a/relay/src/modules/relay/tests/malformed_track.rs
+++ b/relay/src/modules/relay/tests/malformed_track.rs
@@ -35,7 +35,7 @@ async fn duplicate_object_with_different_payload_terminates_subscription() {
     first_stream.object(0);
     let second_stream = harness.open_upstream_stream().await;
     second_stream.header(0);
-    second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
+    second_stream.object_with_payload(Bytes::from_static(b"conflicting"));
 
     // Assert: the subscription ends with PUBLISH_DONE(MALFORMED_TRACK)
     let publish_done = egress.expect_publish_done().await;
@@ -88,7 +88,7 @@ async fn subscription_started_after_detection_is_terminated_immediately() {
     first_stream.object(0);
     let second_stream = harness.open_upstream_stream().await;
     second_stream.header(0);
-    second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
+    second_stream.object_with_payload(Bytes::from_static(b"conflicting"));
     harness.wait_track_malformed().await;
 
     // Act
@@ -113,7 +113,7 @@ async fn detection_reports_the_publisher_session_and_track() {
     first_stream.object(0);
     let second_stream = harness.open_upstream_stream().await;
     second_stream.header(0);
-    second_stream.object_with_payload(0, Bytes::from_static(b"conflicting"));
+    second_stream.object_with_payload(Bytes::from_static(b"conflicting"));
 
     // Assert: the appender reports the detection for upstream teardown.
     let event = harness.expect_malformed_track_detected().await;


### PR DESCRIPTION
## 概要
`GroupSender` は上流ストリームから受けた `object_id_delta` をそのまま下流へ送っていました。受信側は header 直後の object の delta を絶対 id と解釈するため、Largest Object フィルタで `{G, largest+1}` から配送を始めると下流の object id が先頭からずれていました（上流の 10, 11, 12 が 0, 1, 2 になる）。

## やったこと
- 下流 stream ごとに直前に送った object id を持ち、キャッシュ上の絶対 id から delta を再計算して送る
- test fixture `UpstreamSubgroupStream::object(index)` が 2 個目以降 delta=1 を送っており object id が 0, 2, 4… になっていたのを index == object id になるよう修正

## 影響範囲
`relay` のみ。

## テスト
- `cargo test -p relay`: 新規 `egress_started_mid_subgroup_delivers_absolute_object_ids` が修正前に fail（ids が 1, 3, 5… になる）、修正後に pass
- `cargo clippy --all-targets`, `cargo fmt --check`: 警告なし
- Docker E2E（fetch / cache-eviction / object-dedup / cascading-relay / multiple-publishers）: この上に stacked した 2 PR を含む状態で全 PASS
