### PR TITLE
fix(relay): evict 済み object の位置を live ingest が既知として再主張しないようにする

### DIFF
--- a/architecture_decision_record/relay/architecture.md
+++ b/architecture_decision_record/relay/architecture.md
@@ -190,14 +190,14 @@ from `TrackCache` over a new uni stream.
   semantics). One `Notify` per track wakes every waiter on insert, open and
   close; waiters re-check the ledger under a single read guard, so there is no
   check-order race between "object present" and "subgroup closed".
-- Knowledge: each open group keeps the largest object id live ingest has seen
-  (`LiveGroup`), so a live subgroup insert registers only from that frontier
-  (the group head for the first object) to the object, and closing the last
-  open stream subgroup registers only the remaining tail of the group — an
-  evicted position is never re-claimed as known (§9.2.1.3 "their state becomes
-  unknown"). Fetch fills register their requested range only at `Fetch::End`
-  (guarded by the eviction generation counter); datagram objects register
-  nothing.
+- Knowledge: a live subgroup insert registers only the received position
+  (§10.4.2: ids skipped by a non-zero delta cannot be inferred). Each open
+  group keeps the largest object id live ingest has seen (`LiveGroup`), and
+  closing the last open stream subgroup registers only the tail after it, so
+  an evicted position is never re-claimed as known (§9.2.1.3 "their state
+  becomes unknown") and a skipped id stays undecided. Fetch fills register
+  their requested range only at `Fetch::End` (guarded by the eviction
+  generation counter); datagram objects register nothing.
 - `next_subgroup_object_or_wait(key, from)` (live egress) returns the next object of that
   subgroup or `None` once the subgroup is no longer open; a subgroup that was
   never opened (fetch-fill only) therefore never blocks. `fetch_objects` walks

--- a/architecture_decision_record/relay/architecture.md
+++ b/architecture_decision_record/relay/architecture.md
@@ -190,10 +190,14 @@ from `TrackCache` over a new uni stream.
   semantics). One `Notify` per track wakes every waiter on insert, open and
   close; waiters re-check the ledger under a single read guard, so there is no
   check-order race between "object present" and "subgroup closed".
-- Knowledge: a live subgroup insert registers `[{G,0}, {G,id+1})`; closing the
-  last open stream subgroup of a group registers the whole group; fetch fills
-  register their requested range only at `Fetch::End` (guarded by the eviction
-  generation counter); datagram objects register nothing.
+- Knowledge: each open group keeps the largest object id live ingest has seen
+  (`LiveGroup`), so a live subgroup insert registers only from that frontier
+  (the group head for the first object) to the object, and closing the last
+  open stream subgroup registers only the remaining tail of the group — an
+  evicted position is never re-claimed as known (§9.2.1.3 "their state becomes
+  unknown"). Fetch fills register their requested range only at `Fetch::End`
+  (guarded by the eviction generation counter); datagram objects register
+  nothing.
 - `next_subgroup_object_or_wait(key, from)` (live egress) returns the next object of that
   subgroup or `None` once the subgroup is no longer open; a subgroup that was
   never opened (fetch-fill only) therefore never blocks. `fetch_objects` walks

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -132,9 +132,7 @@ impl TrackCache {
                 }
             };
             if result.is_ok() && registers_knowledge {
-                ledger
-                    .known_ranges
-                    .insert(location(at.group_id, 0), after(at));
+                ledger.register_live_object(at);
             }
             result
         };
@@ -649,6 +647,51 @@ mod tests {
         tokio::time::advance(Duration::from_secs(11)).await;
         cache.evict(ttl);
         assert_eq!(cache.eviction_generation(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn live_insert_after_eviction_does_not_reclaim_the_hole() {
+        // Arrange: object 0 of an open group expired and was evicted
+        let ttl = Duration::from_secs(10);
+        let cache = TrackCache::new();
+        let open = open_group(&cache, 0, &[0]);
+        tokio::time::advance(Duration::from_secs(11)).await;
+        cache.evict(ttl);
+        // Act: the group keeps going
+        let _ = open.insert(stream_object(0, 1));
+        // Assert: the evicted position stays unknown (§9.2.1.3), the new one is known
+        assert!(!cache.covers(location(0, 0), location(0, 1)));
+        assert!(cache.covers(location(0, 1), location(0, 2)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn closing_a_group_after_eviction_claims_only_the_tail() {
+        // Arrange
+        let ttl = Duration::from_secs(10);
+        let cache = TrackCache::new();
+        let open = open_group(&cache, 0, &[0, 1]);
+        tokio::time::advance(Duration::from_secs(11)).await;
+        cache.evict(ttl);
+        // Act
+        drop(open);
+        // Assert: "no more objects after 1" is known, positions 0 and 1 are not
+        assert!(!cache.covers(location(0, 0), location(0, 2)));
+        assert!(cache.covers(location(0, 2), location(0, 0)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reordered_lower_object_id_does_not_reclaim_the_evicted_frontier() {
+        // Arrange: object 5 arrived first (claiming 0..=4 as skipped) and was later evicted
+        let ttl = Duration::from_secs(10);
+        let cache = TrackCache::new();
+        let open = open_group(&cache, 0, &[5]);
+        tokio::time::advance(Duration::from_secs(11)).await;
+        cache.evict(ttl);
+        // Act: a lower id from another subgroup arrives afterwards
+        let _ = open.insert(stream_object_in_subgroup(0, 1, 2));
+        // Assert: its own position is known again, the evicted object's is not
+        assert!(cache.covers(location(0, 2), location(0, 3)));
+        assert!(!cache.covers(location(0, 5), location(0, 6)));
     }
 }
 

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -474,14 +474,24 @@ mod tests {
     }
 
     #[test]
-    fn live_insert_registers_knowledge_from_the_group_head() {
+    fn live_insert_registers_only_the_received_position() {
         // Arrange
         let cache = TrackCache::new();
         // Act
         let _ = cache.insert_live(stream_object(3, 2));
-        // Assert
-        assert!(cache.covers(location(3, 0), location(3, 3)));
-        assert!(!cache.covers(location(3, 0), location(3, 4)));
+        // Assert: §10.4.2 — the skipped ids 0 and 1 stay undecided
+        assert!(cache.covers(location(3, 2), location(3, 3)));
+        assert!(!cache.covers(location(3, 0), location(3, 3)));
+    }
+
+    #[test]
+    fn closing_the_group_decides_the_tail_but_not_a_skipped_id() {
+        // Arrange: object 1 was never received
+        let cache = TrackCache::new();
+        insert_closed_group(&cache, 0, &[0, 2]);
+        // Act / Assert: everything after the largest seen object is known absent
+        assert!(cache.covers(location(0, 3), location(0, 0)));
+        assert!(!cache.covers(location(0, 1), location(0, 2)));
     }
 
     #[test]
@@ -752,13 +762,18 @@ mod fetch_tests {
     }
 
     #[test]
-    fn resolve_fetch_range_accepts_gapped_objects_with_known_coverage() {
-        // Arrange: object 1 is not cached, but cache coverage starts before it
+    fn resolve_fetch_range_is_not_covered_across_a_skipped_object_id() {
+        // Arrange: object 1 was skipped by the publisher, so its existence is
+        // undecided (§10.4.2) and the relay must not FIN a range spanning it
         let cache = TrackCache::new();
         let _open = open_group(&cache, 0, &[0, 2]);
-        // Act / Assert: coverage, not local object-id contiguity, decides servability
+        // Act / Assert
         assert_eq!(
             cache.resolve_fetch_range(location(0, 0), location(0, 3)),
+            FetchRangeResolution::NotCovered
+        );
+        assert_eq!(
+            cache.resolve_fetch_range(location(0, 2), location(0, 3)),
             FetchRangeResolution::Serve {
                 end_location: location(0, 3)
             }

--- a/relay/src/modules/relay/cache/track_cache/ledger.rs
+++ b/relay/src/modules/relay/cache/track_cache/ledger.rs
@@ -57,16 +57,12 @@ impl Ledger {
             .flat_map(|live| live.open_subgroups.keys().copied())
     }
 
+    /// A live object proves only its own position (draft-14 §10.4.2: the ids
+    /// skipped by a non-zero delta cannot be inferred); the rest of the group is
+    /// decided when its last subgroup closes.
     pub(super) fn register_live_object(&mut self, location: moqt::Location) {
-        let live = self.live_groups.get_mut(&location.group_id);
-        let frontier = live
-            .as_ref()
-            .map_or(super::location(location.group_id, 0), |live| {
-                live.knowledge_frontier(location.group_id)
-            });
-        let start = frontier.min(location);
-        self.known_ranges.insert(start, after(location));
-        if let Some(live) = live {
+        self.known_ranges.insert(location, after(location));
+        if let Some(live) = self.live_groups.get_mut(&location.group_id) {
             live.largest_seen_object_id = Some(
                 live.largest_seen_object_id
                     .map_or(location.object_id, |seen| seen.max(location.object_id)),

--- a/relay/src/modules/relay/cache/track_cache/ledger.rs
+++ b/relay/src/modules/relay/cache/track_cache/ledger.rs
@@ -14,7 +14,7 @@ use super::{after, location};
 #[derive(Default)]
 pub(super) struct LiveGroup {
     pub(super) open_subgroups: HashMap<SubgroupKey, usize>,
-    pub(super) largest_seen_object_id: Option<u64>,
+    pub(super) knowledge_frontier: u64,
 }
 
 impl LiveGroup {
@@ -22,17 +22,6 @@ impl LiveGroup {
         self.open_subgroups
             .keys()
             .any(|key| matches!(key, SubgroupKey::Stream { .. }))
-    }
-
-    /// First position live ingest has not yet decided: the group head, or just
-    /// past the largest object seen. Positions below it that were evicted must
-    /// stay unknown, so no later claim may start before this.
-    pub(super) fn knowledge_frontier(&self, group_id: u64) -> moqt::Location {
-        location(
-            group_id,
-            self.largest_seen_object_id
-                .map_or(0, |object_id| object_id.saturating_add(1)),
-        )
     }
 }
 
@@ -63,10 +52,9 @@ impl Ledger {
     pub(super) fn register_live_object(&mut self, location: moqt::Location) {
         self.known_ranges.insert(location, after(location));
         if let Some(live) = self.live_groups.get_mut(&location.group_id) {
-            live.largest_seen_object_id = Some(
-                live.largest_seen_object_id
-                    .map_or(location.object_id, |seen| seen.max(location.object_id)),
-            );
+            live.knowledge_frontier = live
+                .knowledge_frontier
+                .max(location.object_id.saturating_add(1));
         }
     }
 

--- a/relay/src/modules/relay/cache/track_cache/ledger.rs
+++ b/relay/src/modules/relay/cache/track_cache/ledger.rs
@@ -8,16 +8,72 @@ use crate::modules::relay::{
     types::SubgroupKey,
 };
 
-use super::location;
+use super::{after, location};
+
+/// What live ingest has told us about a group whose subgroups are still open.
+#[derive(Default)]
+pub(super) struct LiveGroup {
+    pub(super) open_subgroups: HashMap<SubgroupKey, usize>,
+    pub(super) largest_seen_object_id: Option<u64>,
+}
+
+impl LiveGroup {
+    pub(super) fn has_open_stream(&self) -> bool {
+        self.open_subgroups
+            .keys()
+            .any(|key| matches!(key, SubgroupKey::Stream { .. }))
+    }
+
+    /// First position live ingest has not yet decided: the group head, or just
+    /// past the largest object seen. Positions below it that were evicted must
+    /// stay unknown, so no later claim may start before this.
+    pub(super) fn knowledge_frontier(&self, group_id: u64) -> moqt::Location {
+        location(
+            group_id,
+            self.largest_seen_object_id
+                .map_or(0, |object_id| object_id.saturating_add(1)),
+        )
+    }
+}
 
 #[derive(Default)]
 pub(super) struct Ledger {
     pub(super) objects: BTreeMap<moqt::Location, Arc<CachedObject>>,
-    pub(super) open_subgroups: HashMap<SubgroupKey, usize>,
+    pub(super) live_groups: HashMap<u64, LiveGroup>,
     pub(super) known_ranges: KnownRanges,
 }
 
 impl Ledger {
+    pub(super) fn is_open(&self, key: SubgroupKey) -> bool {
+        self.live_groups
+            .get(&key.group_id())
+            .is_some_and(|live| live.open_subgroups.contains_key(&key))
+    }
+
+    fn open_keys_in_group(&self, group_id: u64) -> impl Iterator<Item = SubgroupKey> {
+        self.live_groups
+            .get(&group_id)
+            .into_iter()
+            .flat_map(|live| live.open_subgroups.keys().copied())
+    }
+
+    pub(super) fn register_live_object(&mut self, location: moqt::Location) {
+        let live = self.live_groups.get_mut(&location.group_id);
+        let frontier = live
+            .as_ref()
+            .map_or(super::location(location.group_id, 0), |live| {
+                live.knowledge_frontier(location.group_id)
+            });
+        let start = frontier.min(location);
+        self.known_ranges.insert(start, after(location));
+        if let Some(live) = live {
+            live.largest_seen_object_id = Some(
+                live.largest_seen_object_id
+                    .map_or(location.object_id, |seen| seen.max(location.object_id)),
+            );
+        }
+    }
+
     pub(super) fn group_objects(
         &self,
         group_id: u64,
@@ -47,15 +103,7 @@ impl Ledger {
     }
 
     pub(super) fn has_open_subgroup_in_group(&self, group_id: u64) -> bool {
-        self.open_subgroups
-            .keys()
-            .any(|key| key.group_id() == group_id)
-    }
-
-    pub(super) fn has_open_stream_in_group(&self, group_id: u64) -> bool {
-        self.open_subgroups
-            .keys()
-            .any(|key| matches!(key, SubgroupKey::Stream { group_id: g, .. } if *g == group_id))
+        self.live_groups.contains_key(&group_id)
     }
 
     pub(super) fn has_group(&self, group_id: u64) -> bool {
@@ -72,11 +120,7 @@ impl Ledger {
             .group_objects(group_id, 0)
             .map(|object| object.subgroup_key())
             .collect();
-        keys.extend(
-            self.open_subgroups
-                .keys()
-                .filter(|key| key.group_id() == group_id),
-        );
+        keys.extend(self.open_keys_in_group(group_id));
         keys
     }
 
@@ -87,9 +131,8 @@ impl Ledger {
             .map(|(location, _)| location.group_id)
             .collect();
         groups.extend(
-            self.open_subgroups
+            self.live_groups
                 .keys()
-                .map(|key| key.group_id())
                 .filter(|group_id| (first_group_id..=last_group_id).contains(group_id)),
         );
         groups.into_iter().collect()

--- a/relay/src/modules/relay/cache/track_cache/open_subgroup.rs
+++ b/relay/src/modules/relay/cache/track_cache/open_subgroup.rs
@@ -60,9 +60,10 @@ impl TrackCache {
             // subgroup for the group is assumed: the rest of the group becomes
             // known, from the live frontier so evicted positions stay unknown.
             if matches!(key, SubgroupKey::Stream { .. }) && !live.has_open_stream() {
-                ledger
-                    .known_ranges
-                    .insert(live.knowledge_frontier(group_id), location(group_id, 0));
+                ledger.known_ranges.insert(
+                    location(group_id, live.knowledge_frontier),
+                    location(group_id, 0),
+                );
             }
             if live.open_subgroups.is_empty() {
                 ledger.live_groups.remove(&group_id);

--- a/relay/src/modules/relay/cache/track_cache/open_subgroup.rs
+++ b/relay/src/modules/relay/cache/track_cache/open_subgroup.rs
@@ -28,30 +28,44 @@ impl Drop for OpenSubgroupGuard<'_> {
 
 impl TrackCache {
     pub(crate) fn open_subgroup(&self, key: SubgroupKey) -> OpenSubgroupGuard<'_> {
-        *self.write().open_subgroups.entry(key).or_default() += 1;
+        *self
+            .write()
+            .live_groups
+            .entry(key.group_id())
+            .or_default()
+            .open_subgroups
+            .entry(key)
+            .or_default() += 1;
         self.notify.notify_waiters();
         OpenSubgroupGuard { cache: self, key }
     }
 
     fn close_subgroup(&self, key: SubgroupKey) {
         {
-            let mut ledger = self.write();
-            let Some(open_count) = ledger.open_subgroups.get_mut(&key) else {
+            let mut guard = self.write();
+            let ledger: &mut Ledger = &mut guard;
+            let group_id = key.group_id();
+            let Some(live) = ledger.live_groups.get_mut(&group_id) else {
+                return;
+            };
+            let Some(open_count) = live.open_subgroups.get_mut(&key) else {
                 return;
             };
             *open_count -= 1;
             if *open_count > 0 {
                 return;
             }
-            ledger.open_subgroups.remove(&key);
+            live.open_subgroups.remove(&key);
             // Once every live subgroup stream of the group has closed, no later
-            // subgroup for the group is assumed: the whole group becomes known.
-            if let SubgroupKey::Stream { group_id, .. } = key
-                && !ledger.has_open_stream_in_group(group_id)
-            {
+            // subgroup for the group is assumed: the rest of the group becomes
+            // known, from the live frontier so evicted positions stay unknown.
+            if matches!(key, SubgroupKey::Stream { .. }) && !live.has_open_stream() {
                 ledger
                     .known_ranges
-                    .insert(location(group_id, 0), location(group_id, 0));
+                    .insert(live.knowledge_frontier(group_id), location(group_id, 0));
+            }
+            if live.open_subgroups.is_empty() {
+                ledger.live_groups.remove(&group_id);
             }
         }
         self.notify.notify_waiters();
@@ -91,7 +105,7 @@ impl TrackCache {
         self.wait_until(
             |ledger| match ledger.next_subgroup_object(key, from_object_id) {
                 Some(object) => Some(Some(object)),
-                None if ledger.open_subgroups.contains_key(&key) => None,
+                None if ledger.is_open(key) => None,
                 None => Some(None),
             },
         )

--- a/relay/src/modules/sequences/fetch.rs
+++ b/relay/src/modules/sequences/fetch.rs
@@ -708,7 +708,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_source_is_cache_for_known_gapped_object_ids() {
+    async fn fetch_source_is_upstream_across_a_skipped_object_id() {
         let cache_store = Arc::new(TrackCacheStore::new());
         let track_key = TrackKey::new("ns", "track");
         let cache = cache_store.get_or_create(&track_key);
@@ -729,7 +729,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(matches!(source, FetchSource::Cache(_)));
+        assert!(matches!(source, FetchSource::Upstream(_)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 概要
live insert は `[{G,0}, {G,id+1})`、group の close は group 全体を知識として登録していたため、長寿命の group で object が evict された後の insert / close がその位置を再び「既知」にし、FETCH が上流転送ではなく「存在しない」（FIN のみ）を返していました。§9.2.1.3 では expire した object の状態は unknown に戻ります。
#334 に stacked しています（base: `refactor/canonical-cache-ledger`）。

## やったこと
- live insert は受信した object の位置だけを知識登録する（§10.4.2: 非ゼロ delta で飛ばされた id は推論できない）。飛ばされた id を跨ぐ FETCH は上流転送になる
- open 中の group ごとに live ingest が見た最大 object id を保持し、最後の subgroup の close はその後ろの tail だけを登録する

## 影響範囲
`relay` の cache のみ。

## テスト
- `cargo test -p relay`（新規 5 件）, `cargo clippy --all-targets`, `cargo fmt --check`: pass / 警告なし
- Docker E2E（fetch / cache-eviction / object-dedup / cascading-relay / multiple-publishers）: 全 PASS
