### PR TITLE
docs: coding-style から 1 ファイル 300 行制限を削除

### DIFF
--- a/.agents/rules/coding-style.md
+++ b/.agents/rules/coding-style.md
@@ -55,7 +55,6 @@ Shared by all agents (Claude Code, Codex).
 
 ## Module Structure
 - Split modules and structs based on SOLID principles with functional cohesion.
-- Keep each file under 300 lines.
 - When creating a directory module, use a same-name `.rs` file (e.g. `foo.rs` + `foo/`) instead of `foo/mod.rs`.
 
 ## Visibility


### PR DESCRIPTION
## 概要
`.agents/rules/coding-style.md` の「1 ファイル 300 行以下」ルールを削除します。ファイル分割は責務（SOLID / 機能的凝集）で判断し、行数を機械的な基準にはしません。

## やったこと
- Module Structure 節から `Keep each file under 300 lines.` の 1 行を削除

## 影響範囲
エージェント向けルールのみ。コードの変更はありません。
