### PR TITLE
fix(moqt): datagram Type 0x04 を Object ID 省略型として decode する

### DIFF
--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -1671,11 +1671,6 @@ fn emit_object_datagram(
             object_id,
             publisher_priority,
             payload,
-        }
-        | DatagramField::Payload0x04 {
-            object_id,
-            publisher_priority,
-            payload,
         } => {
             if let Some(callback) = callbacks.borrow().object_datagram_callback.clone() {
                 let wrapper = ObjectDatagramMessage::new(
@@ -1735,7 +1730,11 @@ fn emit_object_datagram(
                 let _ = callback.call1(&JsValue::NULL, &JsValue::from(wrapper));
             }
         }
-        DatagramField::Payload0x06WithEndOfGroup {
+        DatagramField::Payload0x04 {
+            publisher_priority,
+            payload,
+        }
+        | DatagramField::Payload0x06WithEndOfGroup {
             publisher_priority,
             payload,
         } => {

--- a/moqt/src/modules/moqt/data_plane/object/datagram_field.rs
+++ b/moqt/src/modules/moqt/data_plane/object/datagram_field.rs
@@ -93,7 +93,6 @@ pub enum DatagramField {
         payload: Bytes,
     },
     Payload0x04 {
-        object_id: u64,
         publisher_priority: u8,
         payload: Bytes,
     },
@@ -135,7 +134,6 @@ impl DatagramField {
             | Self::Payload0x01 { object_id, .. }
             | Self::Payload0x02WithEndOfGroup { object_id, .. }
             | Self::Payload0x03WithEndOfGroup { object_id, .. }
-            | Self::Payload0x04 { object_id, .. }
             | Self::Status0x20 { object_id, .. }
             | Self::Status0x21 { object_id, .. } => Some(*object_id),
             _ => None,
@@ -149,10 +147,10 @@ impl DatagramField {
             | Self::Payload0x01 { object_id, .. }
             | Self::Payload0x02WithEndOfGroup { object_id, .. }
             | Self::Payload0x03WithEndOfGroup { object_id, .. }
-            | Self::Payload0x04 { object_id, .. }
             | Self::Status0x20 { object_id, .. }
             | Self::Status0x21 { object_id, .. } => *object_id,
-            Self::Payload0x05 { .. }
+            Self::Payload0x04 { .. }
+            | Self::Payload0x05 { .. }
             | Self::Payload0x06WithEndOfGroup { .. }
             | Self::Payload0x07WithEndOfGroup { .. } => 0,
         }
@@ -289,13 +287,11 @@ impl DatagramField {
                 })
             }
             val if val == DatagramTypeValue::Payload0x04 as u64 => {
-                let object_id = data.try_get_varint().log_context("object id").ok()?;
                 let publisher_priority =
                     data.try_get_u8().log_context("publisher priority").ok()?;
                 let payload = data.clone().freeze();
                 data.advance(payload.len());
                 Some(Self::Payload0x04 {
-                    object_id,
                     publisher_priority,
                     payload,
                 })
@@ -416,11 +412,9 @@ impl DatagramField {
                 (DatagramTypeValue::Payload0x03WithEndOfGroup as u64, buf)
             }
             Self::Payload0x04 {
-                object_id,
                 publisher_priority,
                 payload,
             } => {
-                buf.put_varint(*object_id);
                 buf.put_u8(*publisher_priority);
                 buf.extend_from_slice(payload);
                 (DatagramTypeValue::Payload0x04 as u64, buf)
@@ -658,7 +652,6 @@ mod tests {
         fn payload0x04_encode_decode() {
             // setup
             let field = DatagramField::Payload0x04 {
-                object_id: 112,
                 publisher_priority: 50,
                 payload: Bytes::from(vec![21, 22, 23, 24, 25]),
             };
@@ -670,12 +663,11 @@ mod tests {
             // validation
             assert_eq!(message_type, 0x04);
             if let DatagramField::Payload0x04 {
-                object_id,
                 publisher_priority,
                 payload,
             } = decoded
             {
-                assert_eq!(object_id, 112);
+                assert_eq!(field.resolve_object_id(), 0);
                 assert_eq!(publisher_priority, 50);
                 assert_eq!(*payload, vec![21, 22, 23, 24, 25]);
             } else {


### PR DESCRIPTION
## 概要
draft-14 §10.3.1 の型テーブルでは datagram Type 0x04 は 0x05–0x07 と同じく Object ID フィールドを持たず、Object ID は 0 です。moqt の decoder は 0x04 でも先頭で varint の Object ID を読んでいたため、正しい 0x04 datagram を受けると Publisher Priority を Object ID として消費し、以降のフィールドがずれていました。encoder も同じ余分なフィールドを書いていました。
#339 に stacked しています（base: `fix/unknown-object-status-protocol-violation`）。

## やったこと
- `DatagramField::Payload0x04` から `object_id` を外し、decode / encode / `object_id()` / `resolve_object_id()` を 0x05–0x07 と同じ扱いに
- wasm bindings の `emit_object_datagram` で 0x04 を Object ID 省略型の腕へ移動

## 影響範囲
`moqt` の公開 enum `DatagramField` のフィールド変更（`Payload0x04` を構築・分解している外部コードは修正が必要）。workspace 内の利用箇所は wasm bindings のみで対応済み。relay は `resolve_object_id()` 経由なので変更なし。

## テスト
- `cargo test -p moqt`（`payload0x04_encode_decode` を新しい wire 形式で更新）, `cargo test -p relay`, `cargo check --workspace --all-targets`, `cargo clippy --all-targets`, `cargo fmt --check`: pass / 警告なし
