### PR TITLE
fix(relay): FIN 無しで終わった subgroup を完了扱いにせず、下流へ RESET を伝える

### DIFF
--- a/architecture_decision_record/relay/architecture.md
+++ b/architecture_decision_record/relay/architecture.md
@@ -159,8 +159,12 @@ from `TrackCache` over a new uni stream.
 - Readers convert every wire object into a canonical `CachedObject` and insert
   it into `TrackCache`. A SUBGROUP_HEADER is not cached: the reader keeps its
   group id, subgroup id and priority as the per-stream context, opens the
-  subgroup in the cache (`open_subgroup`, returning an `OpenSubgroupGuard` whose drop closes
-  it on FIN, stop, error or abort) and broadcasts `SubgroupOpened`. Header
+  subgroup in the cache (`open_subgroup`, returning an `OpenSubgroupGuard`) and
+  broadcasts `SubgroupOpened`. Only a FIN or an End of Group / End of Track
+  object `finish`es the guard; every other end (RESET_STREAM, stop, decode
+  error, task abort) drops it, which marks the subgroup aborted: its group is
+  never declared complete (draft-14 §10.4.2) and egress resets, rather than
+  FINs, the downstream stream (§10.4.3). Header
   types without an explicit subgroup id map to 0, or to the first object's id
   (Type 0x12/0x13/0x1A/0x1B, opened once that object arrives). For End-of-Group
   header types (0x18–0x1D) a clean FIN inserts an EndOfGroup status object at
@@ -205,8 +209,8 @@ from `TrackCache` over a new uni stream.
   their requested range only at `Fetch::End` (guarded by the eviction
   generation counter); datagram objects register nothing.
 - `next_subgroup_object_or_wait(key, from)` (live egress) returns the next object of that
-  subgroup or `None` once the subgroup is no longer open; a subgroup that was
-  never opened (fetch-fill only) therefore never blocks. `fetch_objects` walks
+  subgroup, `Finished` once it closed cleanly, or `Aborted` once it closed without
+  a FIN; a subgroup that was never opened (fetch-fill only) therefore never blocks. `fetch_objects` walks
   `[start, end)` in location order, reading positions inside knowledge without
   waiting and waiting past the frontier only while some subgroup of the group
   is open.
@@ -231,7 +235,8 @@ keeps one runner per `(subscriber_session_id, downstream_subscribe_id)`
   opens nothing), regenerates the SUBGROUP_HEADER from that object's canonical
   properties (explicit subgroup id, priority; extensions always declared
   present so no object can lose its extension headers), and streams objects
-  until `next_subgroup_object_or_wait` reports the subgroup closed. Datagram groups are
+  until `next_subgroup_object_or_wait` reports the subgroup finished (FIN
+  downstream) or aborted (RESET_STREAM downstream, INTERNAL_ERROR). Datagram groups are
   re-emitted with the downstream track alias.
 
 ## Cascading relays (`route_registry`, `inter_relay`)

--- a/moqt/src/modules/moqt/data_plane/stream/stream_data_sender.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/stream_data_sender.rs
@@ -91,6 +91,10 @@ impl<T: TransportProtocol> StreamDataSender<T, Uninitialized> {
     pub async fn close(&mut self) -> anyhow::Result<()> {
         self.stream_sender.close().await
     }
+
+    pub async fn reset(&mut self, error_code: u64) -> anyhow::Result<()> {
+        self.stream_sender.reset(error_code).await
+    }
 }
 
 // ─── HeaderSent State ──────────────────────────────────────────────────────────
@@ -122,5 +126,9 @@ impl<T: TransportProtocol> StreamDataSender<T, HeaderSent> {
 
     pub async fn close(&mut self) -> anyhow::Result<()> {
         self.stream_sender.close().await
+    }
+
+    pub async fn reset(&mut self, error_code: u64) -> anyhow::Result<()> {
+        self.stream_sender.reset(error_code).await
     }
 }

--- a/relay/src/modules/core/data_sender.rs
+++ b/relay/src/modules/core/data_sender.rs
@@ -12,4 +12,8 @@ pub(crate) trait DataSender: 'static + Send + Sync {
     async fn close(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
+
+    async fn reset(&mut self, _error_code: u64) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/relay/src/modules/core/data_sender/stream_sender.rs
+++ b/relay/src/modules/core/data_sender/stream_sender.rs
@@ -50,6 +50,14 @@ impl<T: moqt::TransportProtocol> StreamSender<T> {
             None => Ok(()),
         }
     }
+
+    pub(crate) async fn reset(&mut self, error_code: u64) -> anyhow::Result<()> {
+        match self.inner.as_mut() {
+            Some(SenderInner::Uninitialized(sender)) => sender.reset(error_code).await,
+            Some(SenderInner::HeaderSent(sender)) => sender.reset(error_code).await,
+            None => Ok(()),
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -60,5 +68,9 @@ impl<T: moqt::TransportProtocol> DataSender for StreamSender<T> {
 
     async fn close(&mut self) -> anyhow::Result<()> {
         StreamSender::close(self).await
+    }
+
+    async fn reset(&mut self, error_code: u64) -> anyhow::Result<()> {
+        StreamSender::reset(self, error_code).await
     }
 }

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -32,7 +32,7 @@ mod ledger;
 mod open_subgroup;
 
 use ledger::Ledger;
-pub(crate) use open_subgroup::OpenSubgroupGuard;
+pub(crate) use open_subgroup::{NextObject, OpenSubgroupGuard};
 
 pub(crate) struct TrackCache {
     ledger: RwLock<Ledger>,
@@ -180,6 +180,7 @@ impl TrackCache {
             for &at in &removed {
                 ledger.known_ranges.remove_range(at, after(at));
             }
+            ledger.forget_aborts_of_vanished_groups();
             removed.len()
         };
         if removed_count > 0 {
@@ -211,6 +212,20 @@ impl TrackCache {
             AtomicOrdering::Relaxed,
             |count| Some(count.saturating_sub(1)),
         );
+    }
+}
+
+/// Why a cache-served FETCH cannot be completed with a FIN.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FetchInterrupted {
+    Malformed,
+    /// An upstream subgroup in the range ended without a FIN, so objects may be missing.
+    Incomplete,
+}
+
+impl From<TrackMalformed> for FetchInterrupted {
+    fn from(_: TrackMalformed) -> Self {
+        Self::Malformed
     }
 }
 
@@ -313,7 +328,7 @@ impl TrackCache {
         start: moqt::Location,
         end: moqt::Location,
         group_order: moqt::GroupOrder,
-    ) -> Result<Vec<moqt::FetchObjectField>, TrackMalformed> {
+    ) -> Result<Vec<moqt::FetchObjectField>, FetchInterrupted> {
         let mut groups = self.read().groups_in_range(start.group_id, end.group_id);
         if matches!(group_order, moqt::GroupOrder::Descending) {
             groups.reverse();
@@ -349,13 +364,16 @@ impl TrackCache {
                 let in_known =
                     group_fully_known || frontier.is_some_and(|frontier| next_object_id < frontier);
                 let found = if in_known {
-                    self.read().next_group_object(group_id, next_object_id)
+                    match self.read().next_group_object(group_id, next_object_id) {
+                        Some(object) => NextObject::Object(object),
+                        None => NextObject::Finished,
+                    }
                 } else {
                     self.next_group_object_or_wait(group_id, next_object_id)
                         .await?
                 };
                 match found {
-                    Some(object) => {
+                    NextObject::Object(object) => {
                         let object_id = object.location.object_id;
                         next_object_id = object_id.saturating_add(1);
                         if end_exclusive.is_some_and(|end_object_id| object_id >= end_object_id) {
@@ -363,11 +381,12 @@ impl TrackCache {
                         }
                         fetch_objects.push(object.to_fetch_object_field());
                     }
-                    None if group_fully_known => break,
-                    None if in_known => {
+                    NextObject::Aborted => return Err(FetchInterrupted::Incomplete),
+                    NextObject::Finished if group_fully_known => break,
+                    NextObject::Finished if in_known => {
                         next_object_id = frontier.unwrap_or(next_object_id);
                     }
-                    None => break,
+                    NextObject::Finished => break,
                 }
             }
         }
@@ -683,7 +702,7 @@ mod tests {
         tokio::time::advance(Duration::from_secs(11)).await;
         cache.evict(ttl);
         // Act
-        drop(open);
+        open.finish();
         // Assert: "no more objects after 1" is known, positions 0 and 1 are not
         assert!(!cache.covers(location(0, 0), location(0, 2)));
         assert!(cache.covers(location(0, 2), location(0, 0)));
@@ -1022,8 +1041,8 @@ mod fetch_tests {
         for object_id in [1, 3, 5] {
             let _ = odd.insert(stream_object_in_subgroup(0, 1, object_id));
         }
-        drop(even);
-        drop(odd);
+        even.finish();
+        odd.finish();
         // Act / Assert
         let objects = fetch(&cache, location(0, 0), location(0, 6)).await;
         assert_eq!(
@@ -1080,7 +1099,7 @@ mod fetch_tests {
         for object_id in 0..3 {
             let _ = open_g0.insert(stream_object(0, object_id));
         }
-        drop(open_g0);
+        open_g0.finish();
         // Assert: the late group 0 objects are delivered, not silently dropped
         let objects = tokio::time::timeout(Duration::from_secs(5), fetch)
             .await
@@ -1115,6 +1134,30 @@ mod fetch_tests {
             .await
             .expect("fetch must abort once the track is malformed")
             .unwrap();
-        assert!(matches!(result, Err(TrackMalformed)));
+        assert!(matches!(result, Err(FetchInterrupted::Malformed)));
+    }
+
+    #[tokio::test]
+    async fn fetch_objects_is_incomplete_when_a_waited_subgroup_aborts() {
+        // Arrange: the fetch waits on an open group whose stream is then reset upstream
+        let cache = Arc::new(TrackCache::new());
+        let open = open_group(&cache, 0, &[0]);
+        let fetch = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                cache
+                    .fetch_objects(location(0, 0), location(0, 3), moqt::GroupOrder::Ascending)
+                    .await
+            }
+        });
+        tokio::task::yield_now().await;
+        // Act
+        drop(open);
+        // Assert: the relay must not FIN a range that may be missing objects
+        let result = tokio::time::timeout(Duration::from_secs(5), fetch)
+            .await
+            .expect("fetch must end once the subgroup aborts")
+            .unwrap();
+        assert_eq!(result, Err(FetchInterrupted::Incomplete));
     }
 }

--- a/relay/src/modules/relay/cache/track_cache/ledger.rs
+++ b/relay/src/modules/relay/cache/track_cache/ledger.rs
@@ -29,9 +29,6 @@ impl LiveGroup {
 pub(super) struct Ledger {
     pub(super) objects: BTreeMap<moqt::Location, Arc<CachedObject>>,
     pub(super) live_groups: HashMap<u64, LiveGroup>,
-    /// Subgroups whose upstream stream ended without a FIN (reset, stop,
-    /// decode error): their tail is unknown, so the group can never be
-    /// declared complete and their downstream streams are reset, not FIN'd.
     pub(super) aborted_subgroups: HashSet<SubgroupKey>,
     pub(super) known_ranges: KnownRanges,
 }

--- a/relay/src/modules/relay/cache/track_cache/ledger.rs
+++ b/relay/src/modules/relay/cache/track_cache/ledger.rs
@@ -45,18 +45,15 @@ impl Ledger {
 
     /// Drops abort markers of groups the ledger no longer knows anything about.
     pub(super) fn forget_aborts_of_vanished_groups(&mut self) {
-        let vanished: Vec<SubgroupKey> = self
-            .aborted_subgroups
-            .iter()
-            .copied()
-            .filter(|key| {
-                self.next_group_object(key.group_id(), 0).is_none()
-                    && !self.live_groups.contains_key(&key.group_id())
-            })
-            .collect();
-        for key in vanished {
-            self.aborted_subgroups.remove(&key);
-        }
+        let (objects, live_groups) = (&self.objects, &self.live_groups);
+        self.aborted_subgroups.retain(|key| {
+            let group_id = key.group_id();
+            objects
+                .range(location(group_id, 0)..=location(group_id, u64::MAX))
+                .next()
+                .is_some()
+                || live_groups.contains_key(&group_id)
+        });
     }
 
     pub(super) fn is_open(&self, key: SubgroupKey) -> bool {

--- a/relay/src/modules/relay/cache/track_cache/ledger.rs
+++ b/relay/src/modules/relay/cache/track_cache/ledger.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -29,10 +29,36 @@ impl LiveGroup {
 pub(super) struct Ledger {
     pub(super) objects: BTreeMap<moqt::Location, Arc<CachedObject>>,
     pub(super) live_groups: HashMap<u64, LiveGroup>,
+    /// Subgroups whose upstream stream ended without a FIN (reset, stop,
+    /// decode error): their tail is unknown, so the group can never be
+    /// declared complete and their downstream streams are reset, not FIN'd.
+    pub(super) aborted_subgroups: HashSet<SubgroupKey>,
     pub(super) known_ranges: KnownRanges,
 }
 
 impl Ledger {
+    pub(super) fn is_group_aborted(&self, group_id: u64) -> bool {
+        self.aborted_subgroups
+            .iter()
+            .any(|key| key.group_id() == group_id)
+    }
+
+    /// Drops abort markers of groups the ledger no longer knows anything about.
+    pub(super) fn forget_aborts_of_vanished_groups(&mut self) {
+        let vanished: Vec<SubgroupKey> = self
+            .aborted_subgroups
+            .iter()
+            .copied()
+            .filter(|key| {
+                self.next_group_object(key.group_id(), 0).is_none()
+                    && !self.live_groups.contains_key(&key.group_id())
+            })
+            .collect();
+        for key in vanished {
+            self.aborted_subgroups.remove(&key);
+        }
+    }
+
     pub(super) fn is_open(&self, key: SubgroupKey) -> bool {
         self.live_groups
             .get(&key.group_id())

--- a/relay/src/modules/relay/cache/track_cache/open_subgroup.rs
+++ b/relay/src/modules/relay/cache/track_cache/open_subgroup.rs
@@ -8,21 +8,56 @@ use crate::modules::relay::{
 use super::{TrackCache, TrackMalformed, location};
 
 /// Live-ingest ownership of one subgroup; dropping it closes the subgroup so
-/// every exit path of a reader (FIN, stop, error, abort) closes exactly once.
+/// every exit path of a reader closes exactly once. Only `finish` marks the
+/// subgroup complete (upstream FIN or End of Group); a plain drop — reset,
+/// stop, decode error, task abort — leaves its tail unknown (draft-14 §10.4.3).
 pub(crate) struct OpenSubgroupGuard<'a> {
     cache: &'a TrackCache,
     key: SubgroupKey,
+    finished: bool,
 }
 
 impl OpenSubgroupGuard<'_> {
     pub(crate) fn insert(&self, object: CachedObject) -> Result<(), TrackMalformed> {
         self.cache.insert_live(object)
     }
+
+    pub(crate) fn finish(mut self) {
+        self.finished = true;
+    }
 }
 
 impl Drop for OpenSubgroupGuard<'_> {
     fn drop(&mut self) {
-        self.cache.close_subgroup(self.key);
+        self.cache.close_subgroup(self.key, self.finished);
+    }
+}
+
+/// Outcome of waiting for the next object of a live subgroup.
+#[derive(Debug)]
+pub(crate) enum NextObject {
+    Object(Arc<CachedObject>),
+    /// Every object was received and the upstream stream ended cleanly.
+    Finished,
+    /// The upstream stream ended without a FIN; objects may be missing.
+    Aborted,
+}
+
+#[cfg(test)]
+impl NextObject {
+    pub(crate) fn unwrap(self) -> Arc<CachedObject> {
+        match self {
+            Self::Object(object) => object,
+            other => panic!("expected an object, got {other:?}"),
+        }
+    }
+
+    pub(crate) fn is_finished(&self) -> bool {
+        matches!(self, Self::Finished)
+    }
+
+    pub(crate) fn is_aborted(&self) -> bool {
+        matches!(self, Self::Aborted)
     }
 }
 
@@ -37,14 +72,22 @@ impl TrackCache {
             .entry(key)
             .or_default() += 1;
         self.notify.notify_waiters();
-        OpenSubgroupGuard { cache: self, key }
+        OpenSubgroupGuard {
+            cache: self,
+            key,
+            finished: false,
+        }
     }
 
-    fn close_subgroup(&self, key: SubgroupKey) {
+    fn close_subgroup(&self, key: SubgroupKey, finished: bool) {
         {
             let mut guard = self.write();
             let ledger: &mut Ledger = &mut guard;
             let group_id = key.group_id();
+            if !finished {
+                ledger.aborted_subgroups.insert(key);
+            }
+            let group_aborted = ledger.is_group_aborted(group_id);
             let Some(live) = ledger.live_groups.get_mut(&group_id) else {
                 return;
             };
@@ -56,10 +99,14 @@ impl TrackCache {
                 return;
             }
             live.open_subgroups.remove(&key);
-            // Once every live subgroup stream of the group has closed, no later
+            // Once every live subgroup stream of the group has finished, no later
             // subgroup for the group is assumed: the rest of the group becomes
             // known, from the live frontier so evicted positions stay unknown.
-            if matches!(key, SubgroupKey::Stream { .. }) && !live.has_open_stream() {
+            // A group with an aborted subgroup is never declared complete.
+            let group_complete = matches!(key, SubgroupKey::Stream { .. })
+                && !live.has_open_stream()
+                && !group_aborted;
+            if group_complete {
                 ledger.known_ranges.insert(
                     location(group_id, live.knowledge_frontier),
                     location(group_id, 0),
@@ -96,18 +143,19 @@ impl TrackCache {
     }
 
     /// Next object of `key` with id >= `from_object_id`, waiting while the
-    /// subgroup is still open under live ingest. `Ok(None)` once it is closed
-    /// and no such object exists; `Err` as soon as the track is malformed.
+    /// subgroup is still open under live ingest; `Err` as soon as the track
+    /// is malformed.
     pub(crate) async fn next_subgroup_object_or_wait(
         &self,
         key: SubgroupKey,
         from_object_id: u64,
-    ) -> Result<Option<Arc<CachedObject>>, TrackMalformed> {
+    ) -> Result<NextObject, TrackMalformed> {
         self.wait_until(
             |ledger| match ledger.next_subgroup_object(key, from_object_id) {
-                Some(object) => Some(Some(object)),
+                Some(object) => Some(NextObject::Object(object)),
                 None if ledger.is_open(key) => None,
-                None => Some(None),
+                None if ledger.aborted_subgroups.contains(&key) => Some(NextObject::Aborted),
+                None => Some(NextObject::Finished),
             },
         )
         .await
@@ -117,12 +165,13 @@ impl TrackCache {
         &self,
         group_id: u64,
         from_object_id: u64,
-    ) -> Result<Option<Arc<CachedObject>>, TrackMalformed> {
+    ) -> Result<NextObject, TrackMalformed> {
         self.wait_until(
             |ledger| match ledger.next_group_object(group_id, from_object_id) {
-                Some(object) => Some(Some(object)),
+                Some(object) => Some(NextObject::Object(object)),
                 None if ledger.has_open_subgroup_in_group(group_id) => None,
-                None => Some(None),
+                None if ledger.is_group_aborted(group_id) => Some(NextObject::Aborted),
+                None => Some(NextObject::Finished),
             },
         )
         .await
@@ -176,22 +225,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn next_subgroup_object_or_wait_returns_none_when_closed_and_exhausted() {
-        // Arrange: one object at id 0, then the subgroup closes
+    async fn next_subgroup_object_or_wait_is_finished_when_closed_and_exhausted() {
+        // Arrange: one object at id 0, then the subgroup finishes
         let cache = TrackCache::new();
-        drop(open_group(&cache, 0, &[0]));
+        open_group(&cache, 0, &[0]).finish();
         // Act / Assert
         assert!(
             cache
                 .next_subgroup_object_or_wait(stream_key(0), 1)
                 .await
                 .unwrap()
-                .is_none()
+                .is_finished()
         );
     }
 
     #[tokio::test]
-    async fn next_subgroup_object_or_wait_returns_none_for_never_opened_subgroup() {
+    async fn next_subgroup_object_or_wait_is_finished_for_never_opened_subgroup() {
         // Arrange: a fetch fill wrote the object without any live stream
         let cache = TrackCache::new();
         let _ = cache.insert(stream_object(0, 0));
@@ -201,7 +250,7 @@ mod tests {
                 .next_subgroup_object_or_wait(stream_key(0), 1)
                 .await
                 .unwrap()
-                .is_none()
+                .is_finished()
         );
     }
 
@@ -240,7 +289,7 @@ mod tests {
             .expect("waiter must wake on insert")
             .unwrap()
             .unwrap()
-            .expect("the inserted object is returned");
+            .unwrap();
         assert_eq!(object.location.object_id, 0);
     }
 
@@ -255,13 +304,33 @@ mod tests {
         });
         tokio::task::yield_now().await;
         // Act
+        open.finish();
+        // Assert
+        let result = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter must wake on close")
+            .unwrap();
+        assert!(matches!(result, Ok(NextObject::Finished)));
+    }
+
+    #[tokio::test]
+    async fn waiter_learns_that_a_dropped_subgroup_was_aborted() {
+        // Arrange: the reader ends without a FIN (reset, stop, decode error, task abort)
+        let cache = Arc::new(TrackCache::new());
+        let open = cache.open_subgroup(stream_key(0));
+        let waiter = tokio::spawn({
+            let cache = cache.clone();
+            async move { cache.next_subgroup_object_or_wait(stream_key(0), 0).await }
+        });
+        tokio::task::yield_now().await;
+        // Act
         drop(open);
         // Assert
         let result = tokio::time::timeout(Duration::from_secs(1), waiter)
             .await
             .expect("waiter must wake on close")
             .unwrap();
-        assert!(matches!(result, Ok(None)));
+        assert!(matches!(result, Ok(NextObject::Aborted)));
     }
 
     #[tokio::test]
@@ -271,7 +340,7 @@ mod tests {
         let first = cache.open_subgroup(stream_key(0));
         let second = cache.open_subgroup(stream_key(0));
         // Act
-        drop(first);
+        first.finish();
         // Assert: still open, so a waiter would keep waiting
         assert!(cache.has_group(0));
         assert!(
@@ -282,13 +351,13 @@ mod tests {
             .await
             .is_err()
         );
-        drop(second);
+        second.finish();
         assert!(
             cache
                 .next_subgroup_object_or_wait(stream_key(0), 0)
                 .await
                 .unwrap()
-                .is_none()
+                .is_finished()
         );
     }
 
@@ -301,12 +370,29 @@ mod tests {
             group_id: 0,
             subgroup_id: 1,
         });
-        // Act / Assert: one subgroup closing leaves the group open
-        drop(first);
+        // Act / Assert: one subgroup finishing leaves the group open
+        first.finish();
         assert!(!cache.covers(location(0, 0), location(0, 0)));
-        // Act / Assert: the last one closing completes the group
-        drop(second);
+        // Act / Assert: the last one finishing completes the group
+        second.finish();
         assert!(cache.covers(location(0, 0), location(0, 0)));
+    }
+
+    #[test]
+    fn an_aborted_subgroup_keeps_the_group_from_completing() {
+        // Arrange: subgroup 1 is reset upstream while subgroup 0 finishes cleanly
+        let cache = TrackCache::new();
+        let finished = open_group(&cache, 0, &[0]);
+        let aborted = cache.open_subgroup(SubgroupKey::Stream {
+            group_id: 0,
+            subgroup_id: 1,
+        });
+        // Act
+        drop(aborted);
+        finished.finish();
+        // Assert: the tail of the group stays unknown (§10.4.3)
+        assert!(!cache.covers(location(0, 1), location(0, 0)));
+        assert!(cache.covers(location(0, 0), location(0, 1)));
     }
 
     #[test]

--- a/relay/src/modules/relay/cache/track_cache/open_subgroup.rs
+++ b/relay/src/modules/relay/cache/track_cache/open_subgroup.rs
@@ -33,13 +33,10 @@ impl Drop for OpenSubgroupGuard<'_> {
     }
 }
 
-/// Outcome of waiting for the next object of a live subgroup.
 #[derive(Debug)]
 pub(crate) enum NextObject {
     Object(Arc<CachedObject>),
-    /// Every object was received and the upstream stream ended cleanly.
     Finished,
-    /// The upstream stream ended without a FIN; objects may be missing.
     Aborted,
 }
 
@@ -99,10 +96,6 @@ impl TrackCache {
                 return;
             }
             live.open_subgroups.remove(&key);
-            // Once every live subgroup stream of the group has finished, no later
-            // subgroup for the group is assumed: the rest of the group becomes
-            // known, from the live frontier so evicted positions stay unknown.
-            // A group with an aborted subgroup is never declared complete.
             let group_complete = matches!(key, SubgroupKey::Stream { .. })
                 && !live.has_open_stream()
                 && !group_aborted;
@@ -142,9 +135,6 @@ impl TrackCache {
         }
     }
 
-    /// Next object of `key` with id >= `from_object_id`, waiting while the
-    /// subgroup is still open under live ingest; `Err` as soon as the track
-    /// is malformed.
     pub(crate) async fn next_subgroup_object_or_wait(
         &self,
         key: SubgroupKey,

--- a/relay/src/modules/relay/egress/coordinator.rs
+++ b/relay/src/modules/relay/egress/coordinator.rs
@@ -10,7 +10,10 @@ use crate::modules::{
     core::subscription::DownstreamSubscription,
     enums::FetchErrorCode,
     relay::{
-        cache::{store::TrackCacheStore, track_cache::TrackCache},
+        cache::{
+            store::TrackCacheStore,
+            track_cache::{FetchInterrupted, TrackCache},
+        },
         egress::runner::EgressRunner,
         notifications::subgroup_opened_notifier_map::SubgroupOpenedNotifierMap,
     },
@@ -154,12 +157,17 @@ impl EgressCoordinator {
                 .await
             {
                 Ok(objects) => objects,
-                Err(_) => {
+                Err(interrupted) => {
+                    let error_code = match interrupted {
+                        FetchInterrupted::Malformed => FetchErrorCode::MalformedTrack as u64,
+                        FetchInterrupted::Incomplete => FetchErrorCode::InternalError as u64,
+                    };
                     tracing::warn!(
                         request_id = request.request_id,
-                        "malformed track detected; resetting fetch stream"
+                        ?interrupted,
+                        "fetch cannot be completed from cache; resetting fetch stream"
                     );
-                    if let Err(e) = sender.reset(FetchErrorCode::MalformedTrack as u64).await {
+                    if let Err(e) = sender.reset(error_code).await {
                         tracing::error!(?e, "failed to reset fetch stream");
                     }
                     return;

--- a/relay/src/modules/relay/egress/group_sender.rs
+++ b/relay/src/modules/relay/egress/group_sender.rs
@@ -17,7 +17,7 @@ use crate::modules::{
         subscription::DownstreamSubscription,
     },
     relay::{
-        cache::track_cache::{TrackCache, TrackMalformed},
+        cache::track_cache::{NextObject, TrackCache, TrackMalformed},
         types::SubgroupKey,
     },
     types::TrackKey,
@@ -26,6 +26,9 @@ use crate::modules::{
 use super::scheduler::GroupSendTask;
 
 type SharedStreamSenderFactory = Arc<Mutex<Box<dyn StreamSenderFactory>>>;
+
+/// draft-14 §10.4.3 RESET_STREAM error code INTERNAL_ERROR.
+const DATA_STREAM_INTERNAL_ERROR: u64 = 0x0;
 
 /// Receives `GroupSendTask` entries and spawns per-subgroup send tasks.
 pub(crate) struct GroupSender {
@@ -134,14 +137,14 @@ impl GroupSender {
         else {
             unreachable!("run() spawns send_stream_task only for SubgroupKey::Stream");
         };
-        let Ok(Some(first)) = task
+        let Ok(NextObject::Object(first)) = task
             .cache
             .next_subgroup_object_or_wait(task.key, task.object_id)
             .await
         else {
             span.record("object_count", 0u64);
             span.record("end_reason", "no_objects");
-            tracing::debug!("subgroup closed before any object to send");
+            tracing::debug!("subgroup ended before any object to send");
             return;
         };
 
@@ -186,8 +189,8 @@ impl GroupSender {
 
         let mut object_count = 0u64;
         let mut prev_sent_object_id = None;
-        let mut next = Some(first);
-        while let Some(object) = next {
+        let mut next = NextObject::Object(first);
+        while let NextObject::Object(object) = next {
             let object_id = object.location.object_id;
             tracing::debug!(object_id, "egress sending subgroup object");
             let field = object.to_subgroup_object_field(message_type, prev_sent_object_id);
@@ -219,9 +222,21 @@ impl GroupSender {
             };
         }
         span.record("object_count", object_count);
-        span.record("end_reason", "cache_closed");
-        if let Err(error) = sender.close().await {
-            tracing::warn!(?error, "failed to close egress stream sender");
+        match next {
+            NextObject::Aborted => {
+                // draft-14 §10.4.3: a subgroup that ended upstream without a FIN
+                // may be missing objects, so the downstream stream is reset.
+                span.record("end_reason", "upstream_aborted");
+                if let Err(error) = sender.reset(DATA_STREAM_INTERNAL_ERROR).await {
+                    tracing::warn!(?error, "failed to reset egress stream sender");
+                }
+            }
+            NextObject::Finished | NextObject::Object(_) => {
+                span.record("end_reason", "cache_closed");
+                if let Err(error) = sender.close().await {
+                    tracing::warn!(?error, "failed to close egress stream sender");
+                }
+            }
         }
     }
 
@@ -232,7 +247,9 @@ impl GroupSender {
         mut sender: Box<dyn DataSender>,
     ) {
         let mut cursor = task.object_id;
-        while let Ok(Some(object)) = cache.next_subgroup_object_or_wait(task.key, cursor).await {
+        while let Ok(NextObject::Object(object)) =
+            cache.next_subgroup_object_or_wait(task.key, cursor).await
+        {
             let object_id = object.location.object_id;
             tracing::debug!(
                 track_alias,

--- a/relay/src/modules/relay/egress/group_sender.rs
+++ b/relay/src/modules/relay/egress/group_sender.rs
@@ -222,20 +222,17 @@ impl GroupSender {
             };
         }
         span.record("object_count", object_count);
-        match next {
-            NextObject::Aborted => {
-                // draft-14 §10.4.3: a subgroup that ended upstream without a FIN
-                // may be missing objects, so the downstream stream is reset.
-                span.record("end_reason", "upstream_aborted");
-                if let Err(error) = sender.reset(DATA_STREAM_INTERNAL_ERROR).await {
-                    tracing::warn!(?error, "failed to reset egress stream sender");
-                }
+        if matches!(next, NextObject::Aborted) {
+            // draft-14 §10.4.3: a subgroup that ended upstream without a FIN
+            // may be missing objects, so the downstream stream is reset.
+            span.record("end_reason", "upstream_aborted");
+            if let Err(error) = sender.reset(DATA_STREAM_INTERNAL_ERROR).await {
+                tracing::warn!(?error, "failed to reset egress stream sender");
             }
-            NextObject::Finished | NextObject::Object(_) => {
-                span.record("end_reason", "cache_closed");
-                if let Err(error) = sender.close().await {
-                    tracing::warn!(?error, "failed to close egress stream sender");
-                }
+        } else {
+            span.record("end_reason", "cache_closed");
+            if let Err(error) = sender.close().await {
+                tracing::warn!(?error, "failed to close egress stream sender");
             }
         }
     }

--- a/relay/src/modules/relay/ingress/datagram_reader.rs
+++ b/relay/src/modules/relay/ingress/datagram_reader.rs
@@ -145,6 +145,9 @@ impl DatagramReader {
                     let open = match &mut current_group {
                         Some((current_group_id, open)) if *current_group_id == group_id => open,
                         slot => {
+                            if let Some((_, previous)) = slot.take() {
+                                previous.finish();
+                            }
                             let key = SubgroupKey::Datagram { group_id };
                             let (_, open) = slot.insert((group_id, cache.open_subgroup(key)));
                             let _ = notify.send(SubgroupOpened(key));

--- a/relay/src/modules/relay/ingress/stream_reader.rs
+++ b/relay/src/modules/relay/ingress/stream_reader.rs
@@ -149,7 +149,7 @@ impl StreamReader {
                     };
                     let object_id = field.resolve_object_id(header.prev_object_id);
                     header.prev_object_id = Some(object_id);
-                    let ingest = ingest.get_or_insert_with(|| {
+                    let current = ingest.get_or_insert_with(|| {
                         Self::open_subgroup(
                             &cache,
                             &notify,
@@ -171,7 +171,7 @@ impl StreamReader {
                         _ => None,
                     };
                     let object = match CachedObject::from_subgroup_object(
-                        &ingest.header,
+                        &current.header,
                         object_id,
                         field,
                     ) {
@@ -190,7 +190,7 @@ impl StreamReader {
                             return;
                         }
                     };
-                    if ingest.open.insert(object).is_err() {
+                    if current.open.insert(object).is_err() {
                         Self::report_malformed_track(
                             &span,
                             &session_event_sender,
@@ -201,6 +201,9 @@ impl StreamReader {
                     }
                     if let Some(end_reason) = end_reason {
                         span.record("end_reason", end_reason);
+                        if let Some(ingest) = ingest.take() {
+                            ingest.open.finish();
+                        }
                         return;
                     }
                 }
@@ -230,6 +233,9 @@ impl StreamReader {
                             );
                             return;
                         }
+                    }
+                    if let Some(ingest) = ingest.take() {
+                        ingest.open.finish();
                     }
                     tracing::debug!(%track_key, "stream finished");
                     return;
@@ -312,7 +318,7 @@ mod tests {
             make_status_object,
         },
     };
-    use crate::modules::relay::types::SubgroupKey;
+    use crate::modules::relay::{cache::track_cache::NextObject, types::SubgroupKey};
 
     // How the scripted stream ends once all objects were consumed.
     enum TerminalOutcome {
@@ -415,7 +421,7 @@ mod tests {
             let cache = self.cache();
             let mut objects = Vec::new();
             let mut cursor = 0;
-            while let Some(object) = cache
+            while let NextObject::Object(object) = cache
                 .next_subgroup_object_or_wait(key, cursor)
                 .await
                 .unwrap()
@@ -426,15 +432,15 @@ mod tests {
             objects
         }
 
-        async fn assert_subgroup_closed_after(&self, key: SubgroupKey, last_object_id: u64) {
+        async fn subgroup_end_after(&self, key: SubgroupKey, last_object_id: u64) -> NextObject {
             let cache = self.cache();
-            let closed = tokio::time::timeout(
+            tokio::time::timeout(
                 Duration::from_secs(1),
                 cache.next_subgroup_object_or_wait(key, last_object_id + 1),
             )
             .await
-            .expect("subgroup should be closed, not waiting for more objects");
-            assert!(matches!(closed, Ok(None)));
+            .expect("subgroup should be closed, not waiting for more objects")
+            .unwrap()
         }
     }
 
@@ -469,10 +475,10 @@ mod tests {
             env.cached_object_ids(stream_key(0)).await,
             vec![(0, ObjectStatus::Normal), (1, ObjectStatus::EndOfGroup)]
         );
-        env.assert_subgroup_closed_after(stream_key(0), 1).await;
+        assert!(env.subgroup_end_after(stream_key(0), 1).await.is_finished());
     }
 
-    async fn assert_open_subgroup_closed_on(terminal: TerminalOutcome) {
+    async fn assert_open_subgroup_ends_on(terminal: TerminalOutcome, finished: bool) {
         // Arrange
         let mut env = TestEnv::new();
         let receiver = scripted(vec![make_header(0), payload(0)], terminal);
@@ -483,22 +489,23 @@ mod tests {
             env.event_receiver.try_recv(),
             Ok(SubgroupOpened(key)) if key == stream_key(0)
         ));
-        env.assert_subgroup_closed_after(stream_key(0), 0).await;
+        let end = env.subgroup_end_after(stream_key(0), 0).await;
+        assert_eq!(end.is_finished(), finished, "unexpected end: {end:?}");
     }
 
     #[tokio::test]
-    async fn fin_closes_open_subgroup() {
-        assert_open_subgroup_closed_on(TerminalOutcome::Fin).await;
+    async fn fin_finishes_the_open_subgroup() {
+        assert_open_subgroup_ends_on(TerminalOutcome::Fin, true).await;
     }
 
     #[tokio::test]
-    async fn transport_close_closes_open_subgroup() {
-        assert_open_subgroup_closed_on(TerminalOutcome::TransportClosed).await;
+    async fn transport_close_aborts_the_open_subgroup() {
+        assert_open_subgroup_ends_on(TerminalOutcome::TransportClosed, false).await;
     }
 
     #[tokio::test]
-    async fn decode_failure_closes_open_subgroup() {
-        assert_open_subgroup_closed_on(TerminalOutcome::DecodeFailed).await;
+    async fn decode_failure_aborts_the_open_subgroup() {
+        assert_open_subgroup_ends_on(TerminalOutcome::DecodeFailed, false).await;
     }
 
     #[tokio::test]
@@ -521,8 +528,8 @@ mod tests {
             .await
             .expect("read loop should stop on signal")
             .expect("read loop should not panic");
-        // Assert
-        env.assert_subgroup_closed_after(stream_key(0), 0).await;
+        // Assert: a stopped reader cannot vouch for the subgroup's tail
+        assert!(env.subgroup_end_after(stream_key(0), 0).await.is_aborted());
     }
 
     #[tokio::test]

--- a/relay/src/modules/relay/tests/data_plane.rs
+++ b/relay/src/modules/relay/tests/data_plane.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use crate::modules::core::data_object::DataObject;
 
 use super::harness::{
-    OBJECT_COUNT, RelayHarness, assert_full_ordered_delivery,
+    OBJECT_COUNT, RelayHarness, Sent, assert_full_ordered_delivery,
     fixtures::cached_object::FIXTURE_PRIORITY, receive_objects_until_close,
-    resolve_downstream_object_ids,
+    receive_objects_until_end, resolve_downstream_object_ids,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -135,4 +135,28 @@ async fn downstream_header_is_regenerated_from_the_cached_objects() {
     assert_eq!(header.group_id, 0);
     assert_eq!(header.subgroup_id, moqt::SubgroupId::Value(0));
     assert_eq!(header.publisher_priority, FIXTURE_PRIORITY);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn upstream_reset_is_relayed_as_a_downstream_reset() {
+    let harness = RelayHarness::new();
+    let mut egress = harness.start_egress(None).await;
+
+    let upstream_stream = harness.open_upstream_stream().await;
+    upstream_stream.header(0);
+    for index in 0..3 {
+        upstream_stream.object(index);
+    }
+    upstream_stream.reset();
+
+    let (objects, end) = receive_objects_until_end(&mut egress).await;
+    assert_eq!(
+        resolve_downstream_object_ids(&objects),
+        vec![0, 1, 2],
+        "objects received before the reset are still forwarded"
+    );
+    assert!(
+        matches!(end, Sent::Reset(0)),
+        "a partial subgroup must be reset downstream with INTERNAL_ERROR, got {end:?}"
+    );
 }

--- a/relay/src/modules/relay/tests/harness.rs
+++ b/relay/src/modules/relay/tests/harness.rs
@@ -19,6 +19,8 @@ use crate::modules::{
 pub(crate) mod fixtures;
 mod mocks;
 
+pub(crate) use self::mocks::downstream_client::Sent;
+
 pub(crate) use self::fixtures::data_object::ordered_payload;
 
 use self::{
@@ -45,7 +47,7 @@ pub(crate) struct RelayHarness {
 }
 
 pub(crate) struct EgressRunnerHandle {
-    sent: mpsc::UnboundedReceiver<Option<DataObject>>,
+    sent: mpsc::UnboundedReceiver<Sent>,
     publish_done: mpsc::UnboundedReceiver<SentPublishDone>,
     join_handle: tokio::task::JoinHandle<()>,
 }
@@ -192,11 +194,22 @@ impl RelayHarness {
 pub(crate) async fn receive_objects_until_close(
     egress: &mut EgressRunnerHandle,
 ) -> Vec<DataObject> {
+    let (objects, end) = receive_objects_until_end(egress).await;
+    assert!(
+        matches!(end, Sent::Closed),
+        "downstream stream should end with a FIN, got {end:?}"
+    );
+    objects
+}
+
+pub(crate) async fn receive_objects_until_end(
+    egress: &mut EgressRunnerHandle,
+) -> (Vec<DataObject>, Sent) {
     let mut objects = Vec::new();
     loop {
         match tokio::time::timeout(RECV_TIMEOUT, egress.sent.recv()).await {
-            Ok(Some(Some(object))) => objects.push(object),
-            Ok(Some(None)) => return objects,
+            Ok(Some(Sent::Object(object))) => objects.push(object),
+            Ok(Some(end)) => return (objects, end),
             Ok(None) => panic!(
                 "egress dropped its sender after sending {} objects",
                 objects.len()

--- a/relay/src/modules/relay/tests/harness/fixtures/cached_object.rs
+++ b/relay/src/modules/relay/tests/harness/fixtures/cached_object.rs
@@ -88,5 +88,5 @@ pub(crate) fn open_group<'a>(
 }
 
 pub(crate) fn insert_closed_group(cache: &TrackCache, group_id: u64, object_ids: &[u64]) {
-    drop(open_group(cache, group_id, object_ids));
+    open_group(cache, group_id, object_ids).finish();
 }

--- a/relay/src/modules/relay/tests/harness/mocks/downstream_client.rs
+++ b/relay/src/modules/relay/tests/harness/mocks/downstream_client.rs
@@ -9,27 +9,41 @@ use crate::modules::core::{
     subscription::DownstreamSubscription,
 };
 
+/// What the downstream side observed on its data streams.
+#[derive(Debug)]
+pub(crate) enum Sent {
+    Object(DataObject),
+    Closed,
+    Reset(u64),
+}
+
 struct MockDataSender {
-    sent: mpsc::UnboundedSender<Option<DataObject>>,
+    sent: mpsc::UnboundedSender<Sent>,
 }
 
 #[async_trait::async_trait]
 impl DataSender for MockDataSender {
     async fn send_object(&mut self, object: DataObject) -> anyhow::Result<()> {
         self.sent
-            .send(Some(object))
+            .send(Sent::Object(object))
             .map_err(|_| anyhow::anyhow!("subscriber side dropped"))
     }
 
     async fn close(&mut self) -> anyhow::Result<()> {
         self.sent
-            .send(None)
+            .send(Sent::Closed)
+            .map_err(|_| anyhow::anyhow!("subscriber side dropped"))
+    }
+
+    async fn reset(&mut self, error_code: u64) -> anyhow::Result<()> {
+        self.sent
+            .send(Sent::Reset(error_code))
             .map_err(|_| anyhow::anyhow!("subscriber side dropped"))
     }
 }
 
 struct MockStreamSenderFactory {
-    sent: mpsc::UnboundedSender<Option<DataObject>>,
+    sent: mpsc::UnboundedSender<Sent>,
 }
 
 #[async_trait::async_trait]
@@ -50,12 +64,12 @@ pub(crate) struct SentPublishDone {
 }
 
 pub(crate) struct MockPublisher {
-    sent: mpsc::UnboundedSender<Option<DataObject>>,
+    sent: mpsc::UnboundedSender<Sent>,
     publish_done: mpsc::UnboundedSender<SentPublishDone>,
 }
 
 pub(crate) struct MockPublisherObservers {
-    pub(crate) sent: mpsc::UnboundedReceiver<Option<DataObject>>,
+    pub(crate) sent: mpsc::UnboundedReceiver<Sent>,
     pub(crate) publish_done: mpsc::UnboundedReceiver<SentPublishDone>,
 }
 

--- a/relay/src/modules/relay/tests/harness/mocks/upstream_client.rs
+++ b/relay/src/modules/relay/tests/harness/mocks/upstream_client.rs
@@ -47,6 +47,14 @@ impl UpstreamSubgroupStream {
             .expect("ingress should be reading this stream");
     }
 
+    pub(crate) fn reset(&self) {
+        self.sender
+            .send(Err(moqt::StreamReceiveError::Closed(
+                "stream reset by peer".to_string(),
+            )))
+            .expect("ingress should be reading this stream");
+    }
+
     pub(crate) fn fin(&self) {
         self.sender
             .send(Ok(None))


### PR DESCRIPTION
## 概要
reader の終了経路（FIN / RESET_STREAM / stop / decode error）がすべて同じ close になっていたため、RESET で途切れた subgroup でも group が「完了」として知識登録され、egress は下流 stream に FIN を送っていました。§10.4.2 は RESET 後は group の終端を判定できないとし、§10.4.3 は途中で止まる送信側は RESET_STREAM を使うことを要求しています。
FIN と End of Group / End of Track だけを完了とし、それ以外は「中断」として扱うようにします。
#340 に stacked しています（base: `fix/datagram-type-0x04-omits-object-id`）。

## やったこと
- `OpenSubgroupGuard::finish()` を呼んだときだけ完了扱い。それ以外の drop は台帳の `aborted_subgroups` に記録し、その group は完了とみなさない
- 待機結果を `NextObject::{Object, Finished, Aborted}` にし、egress は `Aborted` で下流 stream を RESET（INTERNAL_ERROR 0x0）、cache から返す FETCH は `FetchInterrupted::Incomplete` で fetch stream を RESET
- `moqt::StreamDataSender::reset` と relay `DataSender::reset` を追加

## やらないこと
- 中断した subgroup の欠落 object を上流から補完する（§10.4.3 の MAY）。下流へは即 RESET
- RESET_STREAM_AT による reliable_size 指定

## 影響範囲
`relay` の cache / ingress / egress と `moqt` の公開 API 追加（既存 API に変更なし）。上流が正常に FIN する限り下流の挙動は変わりません。上流 RESET 時は下流も RESET になり、その group への FETCH はキャッシュではなく上流転送になります。

## テスト
- `cargo test -p relay`（新規 5 件: drop で Aborted、中断 group は完了しない、FETCH が Incomplete、reader の終了経路ごとの Finished / Aborted、上流 RESET → 下流 RESET）, `cargo test -p moqt`, `cargo check --workspace --all-targets`, `cargo clippy --all-targets`, `cargo fmt --check`: pass / 警告なし
