### PR TITLE
feat(live-ingest): SRT で受けた MPEG-TS を MoQT に publish する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LOCAL_MOQT_URL ?= $(shell node scripts/resolve-local-relay-url.mjs "$(MOQT_URL)"
 LIVE_INGEST_MOQT_URL ?= $(LOCAL_MOQT_URL)
 ONVIF_MOQT_URL ?= $(LOCAL_MOQT_URL)
 
-.PHONY: relay browser chrome chrome\:linux live-ingest onvif onvif-controller ffmpeg-rtmp test lint format relay-certs browser-e2e-media browser-e2e-call browser-e2e-call-headed
+.PHONY: relay browser chrome chrome\:linux live-ingest onvif onvif-controller ffmpeg-rtmp ffmpeg-srt test lint format relay-certs browser-e2e-media browser-e2e-call browser-e2e-call-headed
 
 # Applications
 relay:
@@ -41,6 +41,15 @@ ffmpeg-rtmp:
 		-g 60 -sc_threshold 0 \
 		-c:a aac -ar 48000 -ac 2 \
 		-f flv "rtmp://localhost:1935/live/test"
+
+ffmpeg-srt:
+	ffmpeg -re \
+		-f lavfi -i "testsrc=size=1920x1080:rate=30" \
+		-f lavfi -i "sine=frequency=1000:sample_rate=48000" \
+		-c:v libx264 -preset veryfast -profile:v baseline -pix_fmt yuv420p \
+		-g 60 -sc_threshold 0 \
+		-c:a aac -ar 48000 -ac 2 \
+		-f mpegts "srt://localhost:9000?mode=caller&streamid=live/test"
 
 # ONVIF Bridges
 onvif:

--- a/bridges/live-ingest/README.md
+++ b/bridges/live-ingest/README.md
@@ -29,6 +29,18 @@ Publish a generated test video and sine audio stream:
 make ffmpeg-rtmp
 ```
 
+## Publish Test SRT
+
+Publish an MPEG-TS test stream with the namespace `live/test`:
+
+```shell
+make ffmpeg-srt
+```
+
+The bridge uses the SRT stream ID as the MoQT namespace: either the `r=` resource
+of an access-control stream ID (`#!::r=live/test,m=publish`) or a plain path
+(`live/test`). Connections without a stream ID publish under `srt/live`.
+
 ## Direct CLI Options
 
 Use `cargo run` directly when you need options that are not exposed by the Makefile helpers.

--- a/bridges/live-ingest/src/main.rs
+++ b/bridges/live-ingest/src/main.rs
@@ -33,14 +33,10 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     tracing_subscriber::fmt::init();
 
-    let rtmp = tokio::spawn(rtmp::run_rtmp_listener(
-        args.rtmp_addr,
-        args.moqt_url.clone(),
-    ));
-    let srt = tokio::spawn(srt::run_srt_listener(args.srt_addr));
-
-    rtmp.await??;
-    srt.await??;
+    tokio::try_join!(
+        rtmp::run_rtmp_listener(args.rtmp_addr, args.moqt_url.clone()),
+        srt::run_srt_listener(args.srt_addr, args.moqt_url),
+    )?;
 
     Ok(())
 }

--- a/bridges/live-ingest/src/srt.rs
+++ b/bridges/live-ingest/src/srt.rs
@@ -1,50 +1,118 @@
 use anyhow::{Context, Result};
 use futures::StreamExt;
+use mediapack::mpegts;
 use srt_tokio::{ConnectionRequest, SrtListener};
 use tokio::task;
 
-pub async fn run_srt_listener(addr: String) -> Result<()> {
+use crate::{moqt::MoqtManager, publisher::MediaPublisher};
+
+const DEFAULT_NAMESPACE: &str = "srt/live";
+const ACCESS_CONTROL_PREFIX: &str = "#!::";
+
+pub async fn run_srt_listener(addr: String, moqt_url: Option<String>) -> Result<()> {
     let (_listener, mut incoming) = SrtListener::builder()
         .bind(addr.as_str())
         .await
         .with_context(|| format!("bind SRT listener on {addr}"))?;
     tracing::info!(%addr, "SRT listener started");
-
     while let Some(request) = incoming.incoming().next().await {
-        task::spawn(handle_request(request));
+        task::spawn(handle_request(request, MoqtManager::new(moqt_url.clone())));
     }
-
     Ok(())
 }
 
-async fn handle_request(request: ConnectionRequest) {
-    let stream_id = request
-        .stream_id()
-        .map(|id| id.to_string())
-        .unwrap_or_else(|| "<no-streamid>".to_string());
+async fn handle_request(request: ConnectionRequest, moqt: MoqtManager) {
+    let stream_id = request.stream_id().map(ToString::to_string);
+    let namespace = namespace_from_stream_id(stream_id.as_deref());
     let remote = request.remote();
-    tracing::info!(%remote, %stream_id, "SRT caller connected");
-
-    let result: Result<()> = async {
-        let mut socket = request.accept(None).await?;
-        let mut count = 0_u64;
-
-        while let Some(packet) = socket.next().await {
-            let (_, data) = packet?;
-            count += 1;
-
-            if count == 1 || count.is_multiple_of(200) {
-                tracing::debug!(%remote, %stream_id, packets = count, last_size = data.len(), "SRT packets received");
-            }
-            // Not implemented: Forward data to MoQT server
-        }
-
-        tracing::info!(%remote, %stream_id, total_packets = count, "SRT stream ended");
-        Ok(())
+    tracing::info!(%remote, ?stream_id, namespace = %namespace.join("/"), "SRT publisher connected");
+    match publish(request, moqt, namespace).await {
+        Ok(packets) => tracing::info!(%remote, packets, "SRT stream ended"),
+        Err(err) => tracing::warn!(%remote, ?err, "SRT publisher failed"),
     }
-    .await;
+}
 
-    if let Err(err) = result {
-        tracing::warn!(%remote, %stream_id, ?err, "SRT connection failed");
+async fn publish(
+    request: ConnectionRequest,
+    moqt: MoqtManager,
+    namespace: Vec<String>,
+) -> Result<u64> {
+    let mut socket = request.accept(None).await?;
+    let mut demuxer = mpegts::Demuxer::new();
+    let mut publisher = MediaPublisher::new(moqt, namespace);
+    let mut packets = 0_u64;
+    while let Some(packet) = socket.next().await {
+        let (_, data) = packet?;
+        packets += 1;
+        for event in demuxer.push(&data)? {
+            publisher.push(&event).await?;
+        }
+    }
+    for event in demuxer.finish()? {
+        publisher.push(&event).await?;
+    }
+    Ok(packets)
+}
+
+fn namespace_from_stream_id(stream_id: Option<&str>) -> Vec<String> {
+    let resource = match stream_id {
+        Some(control) if control.starts_with(ACCESS_CONTROL_PREFIX) => control
+            .strip_prefix(ACCESS_CONTROL_PREFIX)
+            .and_then(|fields| fields.split(',').find_map(|field| field.strip_prefix("r=")))
+            .unwrap_or(DEFAULT_NAMESPACE),
+        Some(plain) => plain,
+        None => DEFAULT_NAMESPACE,
+    };
+    let parts: Vec<String> = resource
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .map(str::to_owned)
+        .collect();
+    if parts.is_empty() {
+        namespace_from_stream_id(Some(DEFAULT_NAMESPACE))
+    } else {
+        parts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_srt_access_control_resource() {
+        // Arrange
+        let stream_id = "#!::r=live/camera-1,m=publish";
+
+        // Act
+        let namespace = namespace_from_stream_id(Some(stream_id));
+
+        // Assert
+        assert_eq!(namespace, ["live", "camera-1"]);
+    }
+
+    #[test]
+    fn accepts_plain_stream_id() {
+        // Arrange
+        let stream_id = "live/camera-2";
+
+        // Act
+        let namespace = namespace_from_stream_id(Some(stream_id));
+
+        // Assert
+        assert_eq!(namespace, ["live", "camera-2"]);
+    }
+
+    #[test]
+    fn falls_back_when_stream_id_is_missing_or_empty() {
+        // Arrange / Act
+        let missing = namespace_from_stream_id(None);
+        let empty = namespace_from_stream_id(Some(""));
+        let without_resource = namespace_from_stream_id(Some("#!::m=publish"));
+
+        // Assert
+        assert_eq!(missing, ["srt", "live"]);
+        assert_eq!(empty, ["srt", "live"]);
+        assert_eq!(without_resource, ["srt", "live"]);
     }
 }


### PR DESCRIPTION
## 概要
SRT listener はパケット数を数えるだけで MoQT には流していませんでした。
#345 の構成に乗せ、受信した MPEG-TS を mediapack で demux し、RTMP と同じ `MediaPublisher` から publish します。stacked PR（base: `claude/live-ingest-rtmp-mediapack`）です。

## やったこと
- 接続ごとに `mpegts::Demuxer` と `MediaPublisher` を持ち、stream ID（`#!::r=live/x` の `r=` か素の `live/x`、無ければ `srt/live`）を namespace にする
- RTMP/SRT listener を `try_join!` で起動し、SRT の bind 失敗が握りつぶされないようにする
- `make ffmpeg-srt`（テスト送信）と README の SRT 手順

## やらないこと
- パスフレーズ付き SRT（`accept(None)` のまま平文のみ）
- MoQT 送信失敗時の継続（失敗した SRT 接続は切断してログに残す。RTMP 経路はログして継続する既存挙動のまま）

## 影響範囲
`bridges/live-ingest` と Makefile。RTMP 経路の publish 処理は変わらない。

## テスト
- `cargo test -p moqt-bridge-live-ingest`（5 件）、`cargo clippy -p moqt-bridge-live-ingest --all-targets -- -D warnings`、`cargo fmt --check`
- relay + live-ingest + `ffmpeg -f mpegts srt://…?streamid=live/mp2`（10 秒）を moq-cli で購読: video 280 object（key 4）/ audio 443 object、timestamp 単調増加、catalog `avc1.42C01E`
