### PR TITLE
fix(moqt): subgroup header の拡張ヘッダフラグが落ちる 2 つの不具合を修正する

### DIFF
--- a/moqt/src/modules.rs
+++ b/moqt/src/modules.rs
@@ -1,4 +1,6 @@
 pub(crate) mod extensions;
 pub(crate) mod moqt;
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) mod test_support;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod transport;

--- a/moqt/src/modules/moqt/data_plane/stream/stream_data_sender.rs
+++ b/moqt/src/modules/moqt/data_plane/stream/stream_data_sender.rs
@@ -59,8 +59,8 @@ impl<T: TransportProtocol> StreamDataSender<T, Uninitialized> {
             group_id,
             subgroup_id,
             publisher_priority,
-            end_of_group,
             has_extensions,
+            end_of_group,
         )
     }
 

--- a/moqt/src/modules/moqt/domains/track_writer.rs
+++ b/moqt/src/modules/moqt/domains/track_writer.rs
@@ -7,6 +7,11 @@ use crate::{
 };
 
 const PUBLISHER_PRIORITY: u8 = 128;
+/// draft-14 §10.4.2: extension headers are only encoded when the subgroup
+/// header type says they are present, and `write()` accepts extensions per
+/// object, so every subgroup declares them (objects without any carry a
+/// zero-length extension block).
+const EXTENSIONS_PRESENT: bool = true;
 
 pub struct TrackWriter<T: TransportProtocol> {
     factory: StreamDataSenderFactory<T>,
@@ -72,7 +77,7 @@ impl<T: TransportProtocol> TrackWriter<T> {
             SubgroupId::None,
             PUBLISHER_PRIORITY,
             false,
-            false,
+            EXTENSIONS_PRESENT,
         );
         let sender = uninitialized.send_header(header).await?;
         self.next_group_id += 1;
@@ -107,5 +112,90 @@ impl<T: TransportProtocol> GroupSender<T> {
         );
         self.sender.send(end_of_group).await?;
         self.sender.close().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use crate::{
+        DUAL, DataReceiver, FilterType, PublishOption, Session, SessionEvent, Subscription,
+        TrackReader, TrackWriter,
+        modules::test_support::{HANDSHAKE_TIMEOUT, connect_sessions, spawn_dual_server},
+    };
+
+    async fn accept_publish(server: &Session<DUAL>) -> Subscription {
+        let SessionEvent::Publish(handler) = server.receive_event().await.unwrap() else {
+            panic!("expected PUBLISH from the client");
+        };
+        let subscription = handler.ok(128, FilterType::LargestObject, 0).await.unwrap();
+        handler.accept_data_receiver().await;
+        subscription
+    }
+
+    /// The data receiver resolves only once the first object has arrived, so
+    /// this must run after the writer has sent something.
+    async fn track_reader(
+        server: &Session<DUAL>,
+        subscription: &Subscription,
+    ) -> TrackReader<DUAL> {
+        let DataReceiver::Stream(factory) = server
+            .subscriber()
+            .accept_data_receiver(subscription)
+            .await
+            .unwrap()
+        else {
+            panic!("expected a subgroup stream receiver");
+        };
+        TrackReader::new(factory)
+    }
+
+    #[tokio::test]
+    async fn objects_arrive_with_their_immutable_extensions_and_ids() {
+        // Arrange
+        let (port, accept) = spawn_dual_server("track-writer");
+        let (client, server) = connect_sessions(&format!("moqt://127.0.0.1:{port}"), accept)
+            .await
+            .unwrap();
+        let publisher = client.publisher();
+        let (published, accepted) = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
+            tokio::join!(
+                publisher.publish("ns".into(), "track".into(), PublishOption::default()),
+                accept_publish(&server)
+            )
+        })
+        .await
+        .unwrap();
+        let mut writer = TrackWriter::new(publisher.create_stream(&published.unwrap()), 7);
+
+        // Act
+        writer.start_group().await.unwrap();
+        writer
+            .write(
+                Bytes::from_static(b"with"),
+                vec![Bytes::from_static(b"ext")],
+            )
+            .await
+            .unwrap();
+        writer
+            .write(Bytes::from_static(b"without"), vec![])
+            .await
+            .unwrap();
+        writer.finish().await.unwrap();
+        let mut reader = track_reader(&server, &accepted).await;
+        let first = reader.next_object().await.unwrap().unwrap();
+        let second = reader.next_object().await.unwrap().unwrap();
+
+        // Assert
+        assert_eq!((first.group_id, first.object_id), (7, 0));
+        assert_eq!(first.payload, Bytes::from_static(b"with"));
+        assert_eq!(
+            first.extension_headers.immutable_extensions(),
+            vec![Bytes::from_static(b"ext")]
+        );
+        assert_eq!((second.group_id, second.object_id), (7, 1));
+        assert_eq!(second.payload, Bytes::from_static(b"without"));
+        assert!(second.extension_headers.immutable_extensions().is_empty());
     }
 }

--- a/moqt/src/modules/test_support.rs
+++ b/moqt/src/modules/test_support.rs
@@ -1,0 +1,63 @@
+use std::{net::UdpSocket, path::Path, time::Duration};
+
+use rcgen::{CertifiedKey, generate_simple_self_signed};
+
+use crate::{ClientConfig, DUAL, Endpoint, ServerConfig, Session};
+
+pub(crate) const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(crate) fn free_udp_port() -> u16 {
+    let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    socket.local_addr().unwrap().port()
+}
+
+fn write_self_signed_cert(dir: &Path) -> ServerConfig {
+    let CertifiedKey { cert, signing_key } =
+        generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .unwrap();
+    std::fs::create_dir_all(dir).unwrap();
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+    std::fs::write(&cert_path, cert.pem()).unwrap();
+    std::fs::write(&key_path, signing_key.serialize_pem()).unwrap();
+    ServerConfig {
+        port: 0,
+        cert_path: cert_path.to_string_lossy().into_owned(),
+        key_path: key_path.to_string_lossy().into_owned(),
+        keep_alive_interval_sec: 5,
+    }
+}
+
+/// Starts a DUAL server on a free port whose accept loop resolves the first
+/// incoming session; returns the port and the accept task.
+pub(crate) fn spawn_dual_server(name: &str) -> (u16, tokio::task::JoinHandle<Session<DUAL>>) {
+    let port = free_udp_port();
+    let cert_dir = std::env::temp_dir().join(format!("moqt-test-{name}-{port}"));
+    let mut server_config = write_self_signed_cert(&cert_dir);
+    server_config.port = port;
+    let mut server = Endpoint::<DUAL>::create_server(&server_config).unwrap();
+    let accept = tokio::spawn(async move { server.accept().await.unwrap().await.unwrap() });
+    (port, accept)
+}
+
+pub(crate) fn dual_client() -> Endpoint<DUAL> {
+    Endpoint::<DUAL>::create_client(&ClientConfig {
+        port: 0,
+        verify_certificate: false,
+    })
+    .unwrap()
+}
+
+/// Connects a DUAL client to the server started by `spawn_dual_server` and
+/// returns both established sessions as (client, server).
+pub(crate) async fn connect_sessions(
+    url: &str,
+    accept: tokio::task::JoinHandle<Session<DUAL>>,
+) -> anyhow::Result<(Session<DUAL>, Session<DUAL>)> {
+    let client = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
+        dual_client().connect(url).await?.await
+    })
+    .await??;
+    let server = tokio::time::timeout(HANDSHAKE_TIMEOUT, accept).await??;
+    Ok((client, server))
+}

--- a/moqt/src/modules/transport/dual/dual_connection_creator.rs
+++ b/moqt/src/modules/transport/dual/dual_connection_creator.rs
@@ -214,72 +214,15 @@ impl TransportConnectionCreator for DualProtocolCreator {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::UdpSocket, path::Path, time::Duration};
-
-    use rcgen::{CertifiedKey, generate_simple_self_signed};
-
-    use crate::{ClientConfig, DUAL, Endpoint, ServerConfig, Session};
-
-    fn free_udp_port() -> u16 {
-        let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
-        socket.local_addr().unwrap().port()
-    }
-
-    fn write_self_signed_cert(dir: &Path) -> ServerConfig {
-        let CertifiedKey { cert, signing_key } =
-            generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
-                .unwrap();
-        std::fs::create_dir_all(dir).unwrap();
-        let cert_path = dir.join("cert.pem");
-        let key_path = dir.join("key.pem");
-        std::fs::write(&cert_path, cert.pem()).unwrap();
-        std::fs::write(&key_path, signing_key.serialize_pem()).unwrap();
-        ServerConfig {
-            port: 0,
-            cert_path: cert_path.to_string_lossy().into_owned(),
-            key_path: key_path.to_string_lossy().into_owned(),
-            keep_alive_interval_sec: 5,
-        }
-    }
-
-    fn spawn_dual_server(name: &str) -> (u16, tokio::task::JoinHandle<Session<DUAL>>) {
-        let port = free_udp_port();
-        let cert_dir = std::env::temp_dir().join(format!("moqt-dual-client-{name}-{port}"));
-        let mut server_config = write_self_signed_cert(&cert_dir);
-        server_config.port = port;
-        let mut server = Endpoint::<DUAL>::create_server(&server_config).unwrap();
-        let accept = tokio::spawn(async move { server.accept().await.unwrap().await.unwrap() });
-        (port, accept)
-    }
-
-    fn dual_client() -> Endpoint<DUAL> {
-        Endpoint::<DUAL>::create_client(&ClientConfig {
-            port: 0,
-            verify_certificate: false,
-        })
-        .unwrap()
-    }
-
-    async fn connect_and_accept(
-        url: &str,
-        accept: tokio::task::JoinHandle<Session<DUAL>>,
-    ) -> anyhow::Result<()> {
-        let client = tokio::time::timeout(Duration::from_secs(5), async {
-            dual_client().connect(url).await?.await
-        })
-        .await??;
-        let server = tokio::time::timeout(Duration::from_secs(5), accept).await??;
-        drop((client, server));
-        Ok(())
-    }
+    use crate::modules::test_support::{connect_sessions, dual_client, spawn_dual_server};
 
     #[tokio::test]
     async fn dual_client_connects_over_raw_quic_with_moqt_scheme() {
         // Arrange
-        let (port, accept) = spawn_dual_server("quic");
+        let (port, accept) = spawn_dual_server("dual-quic");
 
         // Act
-        let result = connect_and_accept(&format!("moqt://127.0.0.1:{port}"), accept).await;
+        let result = connect_sessions(&format!("moqt://127.0.0.1:{port}"), accept).await;
 
         // Assert
         result.unwrap();
@@ -288,10 +231,10 @@ mod tests {
     #[tokio::test]
     async fn dual_client_connects_over_web_transport_with_https_scheme() {
         // Arrange
-        let (port, accept) = spawn_dual_server("wt");
+        let (port, accept) = spawn_dual_server("dual-wt");
 
         // Act
-        let result = connect_and_accept(&format!("https://127.0.0.1:{port}/moq"), accept).await;
+        let result = connect_sessions(&format!("https://127.0.0.1:{port}/moq"), accept).await;
 
         // Assert
         result.unwrap();


### PR DESCRIPTION
## 概要
`TrackWriter::write` に渡した immutable extension が受信側に届かない。
原因は `create_header` のフラグ引数の入れ替えと、`TrackWriter` が `has_extensions=false` で subgroup を開いていたことの 2 点。

## やったこと
- `StreamDataSender::create_header(.., end_of_group, has_extensions)` が `SubgroupHeader::new(.., has_extension_headers, has_end_of_group)` に位置で渡していて入れ替わっていたのを修正
- `TrackWriter` が subgroup を常に「拡張あり」で開くようにした。draft-14 §10.4.2 ではヘッダ型が拡張ありを宣言したときだけ拡張ヘッダがエンコードされるため
- DUAL クライアントテストの証明書生成・in-process サーバー起動を `modules/test_support.rs` に共通化し、`TrackWriter` → `TrackReader` の往復テストを追加。修正前は失敗することを確認済み

## やらないこと
- relay に対する E2E と onvif bridge の実機確認は未実施

## 影響範囲
- onvif の video track は `(false, true)` で拡張ありを意図していたが 0x18(拡張なし)になっていた。修正後は 0x11。他の呼び出し側は `(false, false)` で影響なし
- `TrackWriter` 経由の object は拡張なしでも長さ 0 の拡張ブロックが付き 1 byte 増える

## テスト
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `cargo fmt --all -- --check`: 警告なし
- `cargo test -p moqt -p relay`: 全通過
