### PR TITLE
refactor(live-ingest): MoQT 送信を TrackWriter に載せ替える

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LOCAL_MOQT_URL ?= $(shell node scripts/resolve-local-relay-url.mjs "$(MOQT_URL)"
 LIVE_INGEST_MOQT_URL ?= $(LOCAL_MOQT_URL)
 ONVIF_MOQT_URL ?= $(LOCAL_MOQT_URL)
 
-.PHONY: relay browser chrome chrome\:linux live-ingest onvif onvif-controller ffmpeg-rtmp test lint format relay-certs browser-e2e-media browser-e2e-call browser-e2e-call-headed
+.PHONY: relay browser chrome chrome\:linux live-ingest onvif onvif-controller ffmpeg-rtmp ffmpeg-srt test lint format relay-certs browser-e2e-media browser-e2e-call browser-e2e-call-headed
 
 # Applications
 relay:
@@ -41,6 +41,15 @@ ffmpeg-rtmp:
 		-g 60 -sc_threshold 0 \
 		-c:a aac -ar 48000 -ac 2 \
 		-f flv "rtmp://localhost:1935/live/test"
+
+ffmpeg-srt:
+	ffmpeg -re \
+		-f lavfi -i "testsrc=size=1920x1080:rate=30" \
+		-f lavfi -i "sine=frequency=1000:sample_rate=48000" \
+		-c:v libx264 -preset veryfast -profile:v baseline -pix_fmt yuv420p \
+		-g 60 -sc_threshold 0 \
+		-c:a aac -ar 48000 -ac 2 \
+		-f mpegts "srt://localhost:9000?mode=caller&streamid=live/test"
 
 # ONVIF Bridges
 onvif:

--- a/bridges/live-ingest/README.md
+++ b/bridges/live-ingest/README.md
@@ -29,6 +29,18 @@ Publish a generated test video and sine audio stream:
 make ffmpeg-rtmp
 ```
 
+## Publish Test SRT
+
+Publish an MPEG-TS test stream with the namespace `live/test`:
+
+```shell
+make ffmpeg-srt
+```
+
+The bridge uses the SRT stream ID as the MoQT namespace: either the `r=` resource
+of an access-control stream ID (`#!::r=live/test,m=publish`) or a plain path
+(`live/test`). Connections without a stream ID publish under `srt/live`.
+
 ## Direct CLI Options
 
 Use `cargo run` directly when you need options that are not exposed by the Makefile helpers.

--- a/bridges/live-ingest/src/main.rs
+++ b/bridges/live-ingest/src/main.rs
@@ -33,14 +33,10 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     tracing_subscriber::fmt::init();
 
-    let rtmp = tokio::spawn(rtmp::run_rtmp_listener(
-        args.rtmp_addr,
-        args.moqt_url.clone(),
-    ));
-    let srt = tokio::spawn(srt::run_srt_listener(args.srt_addr));
-
-    rtmp.await??;
-    srt.await??;
+    tokio::try_join!(
+        rtmp::run_rtmp_listener(args.rtmp_addr, args.moqt_url.clone()),
+        srt::run_srt_listener(args.srt_addr, args.moqt_url),
+    )?;
 
     Ok(())
 }

--- a/bridges/live-ingest/src/moqt.rs
+++ b/bridges/live-ingest/src/moqt.rs
@@ -5,14 +5,14 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow, bail};
+use bytes::Bytes;
 use media_streaming_format::{
     Catalog, Track,
     types::{KnownPackaging, KnownTrackRole, Packaging, TrackRole},
 };
 use moqt::{
-    ClientConfig, ContentExists, Endpoint, ExtensionHeaders, QUIC, Session, SessionEvent,
-    SubgroupId, SubgroupObject, SubgroupObjectSender, Subscription, TransportProtocol,
-    WEBTRANSPORT,
+    ClientConfig, ContentExists, Endpoint, QUIC, Session, SessionEvent, TrackWriter,
+    TransportProtocol, WEBTRANSPORT,
 };
 use tokio::sync::Mutex;
 
@@ -33,27 +33,9 @@ struct ManagerState {
     backend: Option<Arc<PublisherBackend>>,
 }
 
-struct TrackInfo<T: TransportProtocol> {
-    publication: Option<Subscription>,
-    stream: Option<SubgroupObjectSender<T>>,
-    object_id: u64,
-    group_id: u64,
-}
-
-impl<T: TransportProtocol> Default for TrackInfo<T> {
-    fn default() -> Self {
-        Self {
-            publication: None,
-            stream: None,
-            object_id: 0,
-            group_id: 0,
-        }
-    }
-}
-
 struct BackendState<T: TransportProtocol> {
     announced_namespaces: HashSet<String>,
-    tracks: HashMap<(String, String), TrackInfo<T>>,
+    tracks: HashMap<(String, String), Option<TrackWriter<T>>>,
     catalogs: HashMap<String, CatalogMetadata>,
     disconnected: bool,
 }
@@ -113,7 +95,7 @@ impl MoqtManager {
         namespace: &[String],
         track_name: &str,
         rotate_group: bool,
-        payload: &[u8],
+        payload: Vec<u8>,
     ) -> Result<()> {
         let url = match &self.url {
             Some(u) => u.clone(),
@@ -200,7 +182,7 @@ impl PublisherBackend {
         namespace: &[String],
         track_name: &str,
         rotate_group: bool,
-        payload: &[u8],
+        payload: Vec<u8>,
     ) -> Result<()> {
         match self {
             Self::Quic(publisher) => {
@@ -319,21 +301,19 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
 
                         let publication = handler.into_subscription(track_alias);
                         let should_send_catalog = track_name == CATALOG_TRACK_NAME;
+                        let writer = TrackWriter::new(
+                            session.publisher().create_stream(&publication),
+                            now_unix_micros(),
+                        );
                         let mut guard = state.lock().await;
                         guard.catalogs.entry(namespace.clone()).or_default();
-                        let entry = guard
+                        guard
                             .tracks
-                            .entry((namespace.clone(), track_name.clone()))
-                            .or_default();
-                        entry.publication = Some(publication);
-                        entry.stream = None;
-                        entry.object_id = 0;
-                        entry.group_id = 0;
+                            .insert((namespace.clone(), track_name.clone()), Some(writer));
                         drop(guard);
                         tracing::info!(%namespace, %track_name, track_alias, "SUBSCRIBE accepted");
                         if should_send_catalog
-                            && let Err(err) =
-                                Self::send_catalog_snapshot(&session, &state, &namespace).await
+                            && let Err(err) = Self::send_catalog_snapshot(&state, &namespace).await
                         {
                             tracing::warn!(%namespace, ?err, "failed to send initial catalog");
                         }
@@ -399,93 +379,24 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
         namespace: &[String],
         track_name: &str,
         rotate_group: bool,
-        payload: &[u8],
+        payload: Vec<u8>,
     ) -> Result<()> {
-        let namespace_path = namespace.join("/");
-        let key = (namespace_path.clone(), track_name.to_string());
-        let (publication, mut stream, mut object_id, mut group_id) = {
+        let key = (namespace.join("/"), track_name.to_string());
+        let mut writer = {
             let mut guard = self.state.lock().await;
             if guard.disconnected {
                 bail!("MoQ publisher disconnected");
             }
-            let entry = guard
-                .tracks
-                .get_mut(&key)
-                .ok_or_else(|| anyhow!("track not set up: {namespace_path}/{track_name}"))?;
-            (
-                entry.publication.clone().ok_or_else(|| {
-                    anyhow!("subscribe not completed: {namespace_path}/{track_name}")
-                })?,
-                entry.stream.take(),
-                entry.object_id,
-                entry.group_id,
-            )
+            match guard.tracks.get_mut(&key).and_then(Option::take) {
+                Some(writer) => writer,
+                None => return Ok(()),
+            }
         };
-
-        let send_result: Result<()> = async {
-            if rotate_group && let Some(mut current_stream) = stream.take() {
-                let eog = current_stream.create_object_field(
-                    0,
-                    empty_extension_headers(),
-                    SubgroupObject::new_status(moqt::wire::ObjectStatus::EndOfGroup as u64),
-                );
-                current_stream
-                    .send(eog)
-                    .await
-                    .context("send end-of-group object")?;
-                if let Err(err) = current_stream.close().await {
-                    tracing::warn!(?err, "failed to close previous subgroup stream");
-                }
-                group_id = group_id.saturating_add(1);
-                object_id = 0;
-            }
-
-            if stream.is_none() {
-                let uninit_stream = self
-                    .session
-                    .publisher()
-                    .create_stream(&publication)
-                    .next()
-                    .await
-                    .context("open subgroup stream")?;
-                let header =
-                    uninit_stream.create_header(group_id, SubgroupId::None, 0, false, false);
-                stream = Some(
-                    uninit_stream
-                        .send_header(header)
-                        .await
-                        .context("send subgroup header")?,
-                );
-                tracing::debug!(namespace = %namespace_path, track = %track_name, group_id, "subgroup header sent");
-            }
-
-            let stream_ref = stream
-                .as_mut()
-                .ok_or_else(|| anyhow!("subgroup stream not initialized"))?;
-            let object = stream_ref.create_object_field(
-                0,
-                empty_extension_headers(),
-                SubgroupObject::new_payload(payload.to_vec().into()),
-            );
-            stream_ref
-                .send(object)
-                .await
-                .context("send subgroup object")?;
-            tracing::trace!(namespace = %namespace_path, track = %track_name, group_id, object_id, "subgroup object sent");
-            object_id = object_id.saturating_add(1);
-            Ok(())
+        let result = write_object(&mut writer, rotate_group, payload).await;
+        if let Some(slot) = self.state.lock().await.tracks.get_mut(&key) {
+            *slot = Some(writer);
         }
-        .await;
-
-        let mut guard = self.state.lock().await;
-        if let Some(entry) = guard.tracks.get_mut(&key) {
-            if send_result.is_ok() {
-                entry.object_id = object_id;
-                entry.group_id = group_id;
-            }
-            entry.stream = stream;
-        }
-        send_result
+        result
     }
 
     async fn update_video_catalog(&self, namespace: &[String], codec: Option<&str>) -> Result<()> {
@@ -506,15 +417,16 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                 metadata.video_codec = normalized_codec;
             }
             changed
-                && guard
-                    .tracks
-                    .get(&(namespace_path.clone(), CATALOG_TRACK_NAME.to_string()))
-                    .and_then(|entry| entry.publication.as_ref())
-                    .is_some()
+                && matches!(
+                    guard
+                        .tracks
+                        .get(&(namespace_path.clone(), CATALOG_TRACK_NAME.to_string())),
+                    Some(Some(_))
+                )
         };
 
         if should_send {
-            Self::send_catalog_snapshot(&self.session, &self.state, &namespace_path).await?;
+            Self::send_catalog_snapshot(&self.state, &namespace_path).await?;
         }
 
         Ok(())
@@ -541,77 +453,44 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                 metadata.audio_channels = Some(channels);
             }
             changed
-                && guard
-                    .tracks
-                    .get(&(namespace_path.clone(), CATALOG_TRACK_NAME.to_string()))
-                    .and_then(|entry| entry.publication.as_ref())
-                    .is_some()
+                && matches!(
+                    guard
+                        .tracks
+                        .get(&(namespace_path.clone(), CATALOG_TRACK_NAME.to_string())),
+                    Some(Some(_))
+                )
         };
 
         if should_send {
-            Self::send_catalog_snapshot(&self.session, &self.state, &namespace_path).await?;
+            Self::send_catalog_snapshot(&self.state, &namespace_path).await?;
         }
 
         Ok(())
     }
 
     async fn send_catalog_snapshot(
-        session: &Arc<Session<T>>,
         state: &Arc<Mutex<BackendState<T>>>,
         namespace_path: &str,
     ) -> Result<()> {
         let key = (namespace_path.to_string(), CATALOG_TRACK_NAME.to_string());
-        let (publication, group_id, payload) = {
-            let mut guard = state.lock().await;
-            if guard.disconnected {
-                bail!("MoQ publisher disconnected");
-            }
-            let metadata = guard
-                .catalogs
-                .get(namespace_path)
-                .cloned()
-                .unwrap_or_default();
-            let entry = match guard.tracks.get_mut(&key) {
-                Some(entry) => entry,
-                None => return Ok(()),
-            };
-            let publication = match entry.publication.clone() {
-                Some(publication) => publication,
-                None => return Ok(()),
-            };
-            let payload = build_catalog_payload(namespace_path, &metadata)?;
-            let group_id = entry.group_id;
-            entry.group_id = entry.group_id.saturating_add(1);
-            entry.object_id = 0;
-            entry.stream = None;
-            (publication, group_id, payload)
+        let mut guard = state.lock().await;
+        if guard.disconnected {
+            bail!("MoQ publisher disconnected");
+        }
+        let metadata = guard
+            .catalogs
+            .get(namespace_path)
+            .cloned()
+            .unwrap_or_default();
+        let payload = build_catalog_payload(namespace_path, &metadata)?;
+        let Some(Some(writer)) = guard.tracks.get_mut(&key) else {
+            return Ok(());
         };
-
-        let uninit_stream = session
-            .publisher()
-            .create_stream(&publication)
-            .next()
+        writer
+            .write_group(Bytes::from(payload))
             .await
-            .context("open catalog stream")?;
-        let header = uninit_stream.create_header(group_id, SubgroupId::None, 0, false, false);
-        let mut stream = uninit_stream
-            .send_header(header)
-            .await
-            .context("send catalog subgroup header")?;
-        let object = stream.create_object_field(
-            0,
-            empty_extension_headers(),
-            SubgroupObject::new_payload(payload.into()),
-        );
-        stream
-            .send(object)
-            .await
-            .context("send catalog subgroup object")?;
-        stream
-            .close()
-            .await
-            .context("close catalog subgroup stream")?;
-        tracing::info!(namespace = %namespace_path, group_id, "catalog sent");
+            .context("send catalog group")?;
+        tracing::info!(namespace = %namespace_path, groups = writer.groups(), "catalog sent");
         Ok(())
     }
 }
@@ -622,8 +501,25 @@ impl<T: TransportProtocol> Drop for ConnectedPublisher<T> {
     }
 }
 
-fn empty_extension_headers() -> ExtensionHeaders {
-    ExtensionHeaders::default()
+async fn write_object<T: TransportProtocol>(
+    writer: &mut TrackWriter<T>,
+    rotate_group: bool,
+    payload: Vec<u8>,
+) -> Result<()> {
+    if rotate_group || writer.groups() == 0 {
+        writer.start_group().await.context("start group")?;
+    }
+    writer
+        .write(Bytes::from(payload), Vec::new())
+        .await
+        .context("send subgroup object")
+}
+
+fn now_unix_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_micros() as u64)
+        .unwrap_or(0)
 }
 
 fn is_supported_track(track_name: &str) -> bool {

--- a/bridges/live-ingest/src/moqt.rs
+++ b/bridges/live-ingest/src/moqt.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -303,7 +303,7 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                         let should_send_catalog = track_name == CATALOG_TRACK_NAME;
                         let writer = TrackWriter::new(
                             session.publisher().create_stream(&publication),
-                            now_unix_micros(),
+                            now_unix().as_micros() as u64,
                         );
                         let mut guard = state.lock().await;
                         guard.catalogs.entry(namespace.clone()).or_default();
@@ -515,13 +515,6 @@ async fn write_object<T: TransportProtocol>(
         .context("send subgroup object")
 }
 
-fn now_unix_micros() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_micros() as u64)
-        .unwrap_or(0)
-}
-
 fn is_supported_track(track_name: &str) -> bool {
     matches!(
         track_name,
@@ -635,7 +628,7 @@ fn build_catalog_payload(namespace_path: &str, metadata: &CatalogMetadata) -> Re
         add_tracks: None,
         remove_tracks: None,
         clone_tracks: None,
-        generated_at: Some(now_unix_ms()),
+        generated_at: Some(now_unix().as_millis() as u64),
         is_complete: Some(true),
         tracks: Some(tracks),
     };
@@ -651,9 +644,8 @@ fn channel_config_label(channels: u8) -> String {
     }
 }
 
-fn now_unix_ms() -> u64 {
+pub(crate) fn now_unix() -> Duration {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
-        .as_millis() as u64
 }

--- a/bridges/live-ingest/src/publisher.rs
+++ b/bridges/live-ingest/src/publisher.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context, Error, Result};
+use anyhow::{Context, Result};
 use mediapack::{
     AudioSample, MediaEvent, VideoSample, aac::AudioSpecificConfig,
     h264::AvcDecoderConfigurationRecord,
@@ -76,7 +76,9 @@ impl MediaPublisher {
             &sample.data,
             codec.as_deref(),
         );
-        self.send(VIDEO_TRACK, sample.is_keyframe, &payload).await
+        self.moqt
+            .send_object(&self.namespace, VIDEO_TRACK, sample.is_keyframe, payload)
+            .await
     }
 
     async fn publish_audio(&mut self, sample: &AudioSample) -> Result<()> {
@@ -94,7 +96,9 @@ impl MediaPublisher {
             duration_us,
             current_time_ms(),
         );
-        self.send(AUDIO_TRACK, rotate_group, &payload).await
+        self.moqt
+            .send_object(&self.namespace, AUDIO_TRACK, rotate_group, payload)
+            .await
     }
 
     async fn setup_namespace(&mut self) -> Result<()> {
@@ -103,17 +107,6 @@ impl MediaPublisher {
             self.namespace_ready = true;
         }
         Ok(())
-    }
-
-    async fn send(&self, track: &str, rotate_group: bool, payload: &[u8]) -> Result<()> {
-        match self
-            .moqt
-            .send_object(&self.namespace, track, rotate_group, payload)
-            .await
-        {
-            Err(error) if is_expected_pre_subscribe_send_error(&error) => Ok(()),
-            result => result,
-        }
     }
 
     fn rotate_audio_group(&mut self, duration_us: u64) -> bool {
@@ -134,9 +127,4 @@ fn current_time_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
-}
-
-fn is_expected_pre_subscribe_send_error(error: &Error) -> bool {
-    let message = error.to_string();
-    message.contains("track not set up:") || message.contains("subscribe not completed:")
 }

--- a/bridges/live-ingest/src/publisher.rs
+++ b/bridges/live-ingest/src/publisher.rs
@@ -1,5 +1,3 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use anyhow::{Context, Result};
 use mediapack::{
     AudioSample, MediaEvent, VideoSample, aac::AudioSpecificConfig,
@@ -8,7 +6,7 @@ use mediapack::{
 
 use crate::{
     chunk_payload::{pack_audio_chunk_payload, pack_video_chunk_payload},
-    moqt::MoqtManager,
+    moqt::{MoqtManager, now_unix},
 };
 
 const AUDIO_GROUP_ROTATION_INTERVAL_US: u64 = 2_000_000;
@@ -72,7 +70,7 @@ impl MediaPublisher {
         let payload = pack_video_chunk_payload(
             sample.is_keyframe,
             sample.pts.micros(),
-            current_time_ms(),
+            now_unix().as_millis() as u64,
             &sample.data,
             codec.as_deref(),
         );
@@ -94,7 +92,7 @@ impl MediaPublisher {
             &config,
             sample.pts.micros(),
             duration_us,
-            current_time_ms(),
+            now_unix().as_millis() as u64,
         );
         self.moqt
             .send_object(&self.namespace, AUDIO_TRACK, rotate_group, payload)
@@ -120,11 +118,4 @@ impl MediaPublisher {
         };
         rotate
     }
-}
-
-fn current_time_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
 }

--- a/bridges/live-ingest/src/srt.rs
+++ b/bridges/live-ingest/src/srt.rs
@@ -1,50 +1,118 @@
 use anyhow::{Context, Result};
 use futures::StreamExt;
+use mediapack::mpegts;
 use srt_tokio::{ConnectionRequest, SrtListener};
 use tokio::task;
 
-pub async fn run_srt_listener(addr: String) -> Result<()> {
+use crate::{moqt::MoqtManager, publisher::MediaPublisher};
+
+const DEFAULT_NAMESPACE: &str = "srt/live";
+const ACCESS_CONTROL_PREFIX: &str = "#!::";
+
+pub async fn run_srt_listener(addr: String, moqt_url: Option<String>) -> Result<()> {
     let (_listener, mut incoming) = SrtListener::builder()
         .bind(addr.as_str())
         .await
         .with_context(|| format!("bind SRT listener on {addr}"))?;
     tracing::info!(%addr, "SRT listener started");
-
     while let Some(request) = incoming.incoming().next().await {
-        task::spawn(handle_request(request));
+        task::spawn(handle_request(request, MoqtManager::new(moqt_url.clone())));
     }
-
     Ok(())
 }
 
-async fn handle_request(request: ConnectionRequest) {
-    let stream_id = request
-        .stream_id()
-        .map(|id| id.to_string())
-        .unwrap_or_else(|| "<no-streamid>".to_string());
+async fn handle_request(request: ConnectionRequest, moqt: MoqtManager) {
+    let stream_id = request.stream_id().map(ToString::to_string);
+    let namespace = namespace_from_stream_id(stream_id.as_deref());
     let remote = request.remote();
-    tracing::info!(%remote, %stream_id, "SRT caller connected");
-
-    let result: Result<()> = async {
-        let mut socket = request.accept(None).await?;
-        let mut count = 0_u64;
-
-        while let Some(packet) = socket.next().await {
-            let (_, data) = packet?;
-            count += 1;
-
-            if count == 1 || count.is_multiple_of(200) {
-                tracing::debug!(%remote, %stream_id, packets = count, last_size = data.len(), "SRT packets received");
-            }
-            // Not implemented: Forward data to MoQT server
-        }
-
-        tracing::info!(%remote, %stream_id, total_packets = count, "SRT stream ended");
-        Ok(())
+    tracing::info!(%remote, ?stream_id, namespace = %namespace.join("/"), "SRT publisher connected");
+    match publish(request, moqt, namespace).await {
+        Ok(packets) => tracing::info!(%remote, packets, "SRT stream ended"),
+        Err(err) => tracing::warn!(%remote, ?err, "SRT publisher failed"),
     }
-    .await;
+}
 
-    if let Err(err) = result {
-        tracing::warn!(%remote, %stream_id, ?err, "SRT connection failed");
+async fn publish(
+    request: ConnectionRequest,
+    moqt: MoqtManager,
+    namespace: Vec<String>,
+) -> Result<u64> {
+    let mut socket = request.accept(None).await?;
+    let mut demuxer = mpegts::Demuxer::new();
+    let mut publisher = MediaPublisher::new(moqt, namespace);
+    let mut packets = 0_u64;
+    while let Some(packet) = socket.next().await {
+        let (_, data) = packet?;
+        packets += 1;
+        for event in demuxer.push(&data)? {
+            publisher.push(&event).await?;
+        }
+    }
+    for event in demuxer.finish()? {
+        publisher.push(&event).await?;
+    }
+    Ok(packets)
+}
+
+fn namespace_from_stream_id(stream_id: Option<&str>) -> Vec<String> {
+    let resource = match stream_id {
+        Some(control) if control.starts_with(ACCESS_CONTROL_PREFIX) => control
+            .strip_prefix(ACCESS_CONTROL_PREFIX)
+            .and_then(|fields| fields.split(',').find_map(|field| field.strip_prefix("r=")))
+            .unwrap_or(DEFAULT_NAMESPACE),
+        Some(plain) => plain,
+        None => DEFAULT_NAMESPACE,
+    };
+    let parts: Vec<String> = resource
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .map(str::to_owned)
+        .collect();
+    if parts.is_empty() {
+        namespace_from_stream_id(Some(DEFAULT_NAMESPACE))
+    } else {
+        parts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_srt_access_control_resource() {
+        // Arrange
+        let stream_id = "#!::r=live/camera-1,m=publish";
+
+        // Act
+        let namespace = namespace_from_stream_id(Some(stream_id));
+
+        // Assert
+        assert_eq!(namespace, ["live", "camera-1"]);
+    }
+
+    #[test]
+    fn accepts_plain_stream_id() {
+        // Arrange
+        let stream_id = "live/camera-2";
+
+        // Act
+        let namespace = namespace_from_stream_id(Some(stream_id));
+
+        // Assert
+        assert_eq!(namespace, ["live", "camera-2"]);
+    }
+
+    #[test]
+    fn falls_back_when_stream_id_is_missing_or_empty() {
+        // Arrange / Act
+        let missing = namespace_from_stream_id(None);
+        let empty = namespace_from_stream_id(Some(""));
+        let without_resource = namespace_from_stream_id(Some("#!::m=publish"));
+
+        // Assert
+        assert_eq!(missing, ["srt", "live"]);
+        assert_eq!(empty, ["srt", "live"]);
+        assert_eq!(without_resource, ["srt", "live"]);
     }
 }


### PR DESCRIPTION
## 概要
live-ingest の MoQT 送信は track ごとに subgroup stream / object id / group id を自前で管理し、group 切り替えと EndOfGroup を再実装していました。
#342 で moqt crate に入った `TrackWriter` に置き換えます。stacked PR（base: `claude/live-ingest-srt-mediapack`）です。

## やったこと
- 購読された track ごとに `TrackWriter` を持ち、first group id は moq-cli と同じく壁時計（µs）で採番。catalog は `write_group` で 1 object の group として送る
- 購読前の `send_object` はエラーではなく何もしない扱いにし、`MediaPublisher` のエラー文字列照合を削除
- 時刻取得を `now_unix()` 1 つに集約

## やらないこと
- `SessionEvent::Subscribe` を待つ現行モデルから PUBLISH（publisher-initiated）への移行

## 影響範囲
`bridges/live-ingest` のみ。接続ごとに group id が 0 から始まっていた挙動は時刻シードに変わる。

## テスト
- `cargo test -p moqt-bridge-live-ingest`（5 件）、`cargo clippy -p moqt-bridge-live-ingest --all-targets -- -D warnings`、`cargo fmt --check`
- relay + live-ingest + ffmpeg（RTMP / SRT 各 8 秒）を moq-cli で購読: 映像 226 / 224 object、音声 354 / 355 object、timestamp 単調増加、catalog `avc1.42C01E`
