### PR TITLE
feat(transcode): GStreamer で映像を複数画質に再エンコードする transcode crate を追加

### DIFF
--- a/.github/actions/install-ffmpeg-deps/action.yml
+++ b/.github/actions/install-ffmpeg-deps/action.yml
@@ -1,5 +1,5 @@
-name: Install FFmpeg build dependencies
-description: Install FFmpeg and related build dependencies on Debian/Ubuntu
+name: Install media build dependencies
+description: Install FFmpeg and GStreamer build and runtime dependencies on Debian/Ubuntu
 
 runs:
   using: composite
@@ -18,6 +18,12 @@ runs:
           libavdevice-dev \
           libswscale-dev \
           libswresample-dev \
+          libgstreamer1.0-dev \
+          libgstreamer-plugins-base1.0-dev \
+          gstreamer1.0-plugins-good \
+          gstreamer1.0-plugins-bad \
+          gstreamer1.0-plugins-ugly \
+          gstreamer1.0-libav \
           clang \
           libclang-dev \
           llvm-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -257,7 +257,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -376,7 +376,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -472,7 +472,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -507,7 +507,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -515,6 +515,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
 
 [[package]]
 name = "atspi"
@@ -612,7 +618,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.3",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -726,7 +732,7 @@ checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -846,6 +852,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,7 +958,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1212,7 +1228,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1254,7 +1270,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1312,7 +1328,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1518,7 +1534,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1588,7 +1604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1764,7 +1780,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1866,7 +1882,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1958,6 +1974,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28739f914c15b87a9856000bed9cbd5b3a8afbca5e982d9a299e1601422cb5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps 9.0.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,6 +1995,49 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b9b8d350db41f690ec1b87109f202782748bbd8ab2f2ede17cb40d29e2838c"
+dependencies = [
+ "bitflags 2.13.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9597c68fa7bdf4154a3079642cd21c4dccac0b0bdd2897d82861523bf91e7b9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b38907e67e40dec9b60f858bcada952598719cb512a13eb13d6cdcd16f8295"
+dependencies = [
+ "libc",
+ "system-deps 9.0.0",
 ]
 
 [[package]]
@@ -2069,6 +2141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07595c9ba696bd9819cb6a8df39f08078f3dd679508fe052dd558492c2053834"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps 9.0.0",
+]
+
+[[package]]
 name = "gpu-allocator"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2183,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "gstreamer"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4527e1b9bae8d29ce137bde5b8eec8ae8f78f13ad00fc6e70cbe227d6ad027"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "glib",
+ "gstreamer-sys",
+ "itertools 0.15.0",
+ "kstring",
+ "libc",
+ "muldiv",
+ "num-integer",
+ "num-rational",
+ "option-operations",
+ "pastey",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gstreamer-app"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f8ae9238c2352398dcc084de28df3f7099af216ac6c160b52318d23f25c010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "glib",
+ "gstreamer",
+ "gstreamer-app-sys",
+ "gstreamer-base",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-app-sys"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a74a8211e5d7df2f45b612c284ddf56b92bdf4e879e8ed72e7c46dd0842e158"
+dependencies = [
+ "glib-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "gstreamer-base"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91c94a4d3047d05dd6e1f6d91c74f61f56384c7ea1c9d0c1051572eeeb0138d"
+dependencies = [
+ "atomic_refcell",
+ "cfg-if",
+ "glib",
+ "gstreamer",
+ "gstreamer-base-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-base-sys"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fbbc623dc066908ba10c43d629c21096508dea04796592a206c4edd864e37"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "gstreamer-sys"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533fa8d28fc830eafccbcfcfddb390563ea5d3a351af2c3aab99e197e5f5b1ba"
+dependencies = [
+ "cfg-if",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -2346,7 +2522,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2543,6 +2719,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,7 +2755,7 @@ checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2600,7 +2785,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2628,7 +2813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2677,6 +2862,15 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kstring"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b609e7ca5ea38f093c20a4a102335b247221c9643b7a6bc3510f196f99499a9e"
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "kurbo"
@@ -2893,7 +3087,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3015,6 +3209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "muldiv"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
+
+[[package]]
 name = "multiple-publishers-e2e"
 version = "0.1.0"
 dependencies = [
@@ -3104,7 +3304,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3129,6 +3329,16 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
  "num-traits",
 ]
 
@@ -3171,7 +3381,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3618,6 +3828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-operations"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aca39cf52b03268400c16eeb9b56382ea3c3353409309b63f5c8f0b1faf42754"
+dependencies = [
+ "pastey",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,6 +3915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,7 +3989,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3793,7 +4018,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3815,9 +4040,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -3982,7 +4207,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4055,7 +4280,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4096,9 +4321,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4327,7 +4552,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4525,7 +4750,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4584,7 +4809,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4733,7 +4958,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4757,7 +4982,16 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4991,7 +5225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5098,7 +5332,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5112,6 +5346,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5135,7 +5380,33 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0dae2cbca1f0ff93795713cfe0a4c02f760e3c0b8ae2ab4ec4045808ff429f"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
 ]
 
 [[package]]
@@ -5143,6 +5414,12 @@ name = "take-until"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdb6fa0dfa67b38c1e66b7041ba9dcf23b99d8121907cd31c807a332f7a0bbb"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -5154,7 +5431,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5198,7 +5475,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5209,7 +5486,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5341,7 +5618,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5380,6 +5657,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5402,12 +5694,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -5526,7 +5824,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5585,6 +5883,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "transcode"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "gstreamer",
+ "gstreamer-app",
+ "mediapack",
+ "tokio",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5619,7 +5929,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5728,6 +6038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5809,7 +6125,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -6235,7 +6551,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6291,7 +6607,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6302,7 +6618,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6702,7 +7018,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6759,7 +7075,7 @@ checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -6774,7 +7090,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6820,7 +7136,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6840,7 +7156,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6880,7 +7196,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6927,7 +7243,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "zvariant_utils",
 ]
 
@@ -6940,6 +7256,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.118",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     'shared/packages',
     'shared/mediapack',
+    'shared/transcode',
     'shared/media-streaming-format',
     'moqt',
     'relay',

--- a/architecture_decision_record/transcode/gstreamer.md
+++ b/architecture_decision_record/transcode/gstreamer.md
@@ -1,0 +1,43 @@
+# GStreamer for multi-rendition transcoding
+
+## Status
+
+Accepted
+
+## Date
+
+2026-09-08
+
+## What
+
+Add the `gstreamer` and `gstreamer-app` crates to the new `transcode` crate.
+They decode the incoming H.264 access units and re-encode them into several
+resolutions and bitrates in-process.
+
+## Context
+
+The live-ingest bridge publishes the source rendition as received. Viewers on
+constrained links need lower renditions, which requires decoding and
+re-encoding video. `mediapack` deliberately stays codec-free (containers and
+bitstream syntax only, pure Rust), so the encoder dependency needs its own
+crate with a `MediaEvent`-in / `MediaEvent`-out boundary.
+
+## Alternatives
+
+- Pure Rust codecs. `openh264` offers decoding and baseline-only encoding
+  through bindings, `rav1e` is far from real time; neither gives a hardware
+  path.
+- `ffmpeg-next` (already used by the ONVIF bridge). Decoding, scaling and
+  encoding N outputs must be driven by hand or through a libavfilter graph;
+  hardware encoders need per-platform code.
+- An external ffmpeg/gst-launch process feeding the bridge with several SRT
+  streams. Zero new Rust dependencies, but adds a process to manage and an
+  extra SRT hop per rendition.
+
+## Decision
+
+Use the GStreamer Rust bindings. `tee` fan-out to N `videoscale ! x264enc`
+branches is a pipeline primitive, back-pressure is built in, and the same
+description can swap `x264enc` for `vtenc_h264`/`nvh264enc` later. The
+dependency is confined to `shared/transcode`; `mediapack` and the bridges
+compile without GStreamer unless they opt in.

--- a/shared/README.md
+++ b/shared/README.md
@@ -5,3 +5,4 @@ Shared types used by multiple crates, bridges, and browser examples.
 - `media-streaming-format/`: MSF catalog structures
 - `packages/`: shared types such as LoC headers
 - `mediapack/`: container demuxers/muxers (MPEG-TS, FLV, fMP4) and H.264/AAC bitstream helpers
+- `transcode/`: GStreamer-backed re-encoding of `MediaEvent` video into multiple renditions

--- a/shared/mediapack/src/h264.rs
+++ b/shared/mediapack/src/h264.rs
@@ -1,7 +1,9 @@
 pub mod annexb;
 pub mod avcc;
 pub mod nal;
+pub mod parameter_sets;
 
 pub use annexb::annexb_to_avcc;
 pub use avcc::{AvcDecoderConfigurationRecord, avcc_to_annexb};
 pub use nal::{NalUnitType, SequenceParameterSet};
+pub use parameter_sets::{ParameterSetTracker, TrackedAccessUnit};

--- a/shared/mediapack/src/h264/parameter_sets.rs
+++ b/shared/mediapack/src/h264/parameter_sets.rs
@@ -1,0 +1,141 @@
+use anyhow::Result;
+use bytes::Bytes;
+
+use crate::h264::{
+    AvcDecoderConfigurationRecord, NalUnitType,
+    annexb::{nal_units, with_start_codes},
+    nal::nal_unit_type,
+};
+
+#[derive(Default)]
+pub struct ParameterSetTracker {
+    sps: Vec<Bytes>,
+    pps: Vec<Bytes>,
+    config: Option<AvcDecoderConfigurationRecord>,
+}
+
+pub struct TrackedAccessUnit {
+    pub data: Bytes,
+    pub is_keyframe: bool,
+    pub config_changed: Option<AvcDecoderConfigurationRecord>,
+}
+
+impl ParameterSetTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn track(&mut self, annexb: &[u8]) -> Result<Option<TrackedAccessUnit>> {
+        let nals: Vec<&[u8]> = nal_units(annexb).collect();
+        if nals.is_empty() {
+            return Ok(None);
+        }
+        let mut is_keyframe = false;
+        let mut inline_sps = Vec::new();
+        let mut inline_pps = Vec::new();
+        for nal in &nals {
+            match nal_unit_type(nal) {
+                Some(NalUnitType::IdrSlice) => is_keyframe = true,
+                Some(NalUnitType::Sps) => inline_sps.push(Bytes::copy_from_slice(nal)),
+                Some(NalUnitType::Pps) => inline_pps.push(Bytes::copy_from_slice(nal)),
+                _ => {}
+            }
+        }
+        let has_inline_sps = !inline_sps.is_empty();
+        if has_inline_sps {
+            self.sps = inline_sps;
+        }
+        if !inline_pps.is_empty() {
+            self.pps = inline_pps;
+        }
+        let mut config_changed = None;
+        if !self.sps.is_empty() && !self.pps.is_empty() {
+            let config = AvcDecoderConfigurationRecord::from_parameter_sets(
+                self.sps.clone(),
+                self.pps.clone(),
+            )?;
+            if self.config.as_ref() != Some(&config) {
+                self.config = Some(config.clone());
+                config_changed = Some(config);
+            }
+        }
+        let data = if is_keyframe && !has_inline_sps {
+            with_start_codes(
+                self.sps
+                    .iter()
+                    .chain(self.pps.iter())
+                    .map(|set| set.as_ref())
+                    .chain(nals),
+            )
+        } else {
+            with_start_codes(nals)
+        };
+        Ok(Some(TrackedAccessUnit {
+            data,
+            is_keyframe,
+            config_changed,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{IDR_SLICE, delta_frame_annexb, fixture_record, keyframe_annexb};
+
+    #[test]
+    fn reports_config_once_and_keeps_inline_parameter_sets() {
+        // Arrange
+        let mut tracker = ParameterSetTracker::new();
+
+        // Act
+        let first = tracker.track(&keyframe_annexb()).unwrap().unwrap();
+        let second = tracker.track(&keyframe_annexb()).unwrap().unwrap();
+
+        // Assert
+        assert_eq!(first.config_changed, Some(fixture_record()));
+        assert!(first.is_keyframe);
+        assert_eq!(first.data, keyframe_annexb());
+        assert!(second.config_changed.is_none());
+    }
+
+    #[test]
+    fn prepends_known_parameter_sets_to_bare_keyframes() {
+        // Arrange
+        let mut tracker = ParameterSetTracker::new();
+        tracker.track(&keyframe_annexb()).unwrap();
+
+        // Act
+        let unit = tracker
+            .track(&with_start_codes([&IDR_SLICE[..]]))
+            .unwrap()
+            .unwrap();
+
+        // Assert
+        assert_eq!(unit.data, keyframe_annexb());
+        assert!(unit.is_keyframe);
+    }
+
+    #[test]
+    fn leaves_delta_frames_untouched() {
+        // Arrange
+        let mut tracker = ParameterSetTracker::new();
+
+        // Act
+        let unit = tracker.track(&delta_frame_annexb()).unwrap().unwrap();
+
+        // Assert
+        assert!(!unit.is_keyframe);
+        assert!(unit.config_changed.is_none());
+        assert_eq!(unit.data, delta_frame_annexb());
+    }
+
+    #[test]
+    fn ignores_payload_without_nal_units() {
+        // Arrange
+        let mut tracker = ParameterSetTracker::new();
+
+        // Act / Assert
+        assert!(tracker.track(&[0, 0, 0]).unwrap().is_none());
+    }
+}

--- a/shared/mediapack/src/mpegts/demuxer.rs
+++ b/shared/mediapack/src/mpegts/demuxer.rs
@@ -1,15 +1,11 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use bytes::{Bytes, BytesMut};
+use bytes::BytesMut;
 
 use crate::{
     aac::{AdtsReader, AudioSpecificConfig},
-    h264::{
-        AvcDecoderConfigurationRecord, NalUnitType,
-        annexb::{nal_units, with_start_codes},
-        nal::nal_unit_type,
-    },
+    h264::ParameterSetTracker,
     mpegts::parser::{
         CLOCK_RATE, ElementaryStream, PAT_PID, PacketReader, STREAM_TYPE_AAC_ADTS,
         STREAM_TYPE_H264, TsPacket, parse_packet, parse_pat_pmt_pid, parse_pes_header, parse_pmt,
@@ -42,9 +38,7 @@ enum StreamKind {
 
 #[derive(Default)]
 struct VideoTrack {
-    sps: Vec<Bytes>,
-    pps: Vec<Bytes>,
-    config: Option<AvcDecoderConfigurationRecord>,
+    parameter_sets: ParameterSetTracker,
     last_pts: Timestamp,
 }
 
@@ -179,55 +173,17 @@ fn emit_video(
     dts: Option<Timestamp>,
     events: &mut Vec<MediaEvent>,
 ) -> Result<()> {
-    let nals: Vec<&[u8]> = nal_units(payload).collect();
-    if nals.is_empty() {
+    let Some(unit) = video.parameter_sets.track(payload)? else {
         return Ok(());
-    }
-    let mut is_keyframe = false;
-    let mut inline_sps = Vec::new();
-    let mut inline_pps = Vec::new();
-    for nal in &nals {
-        match nal_unit_type(nal) {
-            Some(NalUnitType::IdrSlice) => is_keyframe = true,
-            Some(NalUnitType::Sps) => inline_sps.push(Bytes::copy_from_slice(nal)),
-            Some(NalUnitType::Pps) => inline_pps.push(Bytes::copy_from_slice(nal)),
-            _ => {}
-        }
-    }
-    if !inline_sps.is_empty() {
-        video.sps = inline_sps.clone();
-    }
-    if !inline_pps.is_empty() {
-        video.pps = inline_pps.clone();
-    }
-    if !video.sps.is_empty() && !video.pps.is_empty() {
-        let config = AvcDecoderConfigurationRecord::from_parameter_sets(
-            video.sps.clone(),
-            video.pps.clone(),
-        )?;
-        if video.config.as_ref() != Some(&config) {
-            events.push(MediaEvent::VideoConfig(config.clone()));
-            video.config = Some(config);
-        }
-    }
-
-    let data = if is_keyframe && inline_sps.is_empty() {
-        with_start_codes(
-            video
-                .sps
-                .iter()
-                .chain(video.pps.iter())
-                .map(|set| set.as_ref())
-                .chain(nals.iter().copied()),
-        )
-    } else {
-        with_start_codes(nals)
     };
+    if let Some(config) = unit.config_changed {
+        events.push(MediaEvent::VideoConfig(config));
+    }
     let pts = pts.unwrap_or(video.last_pts);
     video.last_pts = pts;
     events.push(MediaEvent::Video(VideoSample {
-        data,
-        is_keyframe,
+        data: unit.data,
+        is_keyframe: unit.is_keyframe,
         pts,
         dts: dts.unwrap_or(pts),
     }));
@@ -260,6 +216,11 @@ fn emit_audio(
 mod tests {
     use super::*;
     use crate::{
+        h264::{
+            NalUnitType,
+            annexb::{nal_units, with_start_codes},
+            nal::nal_unit_type,
+        },
         mpegts::parser::PACKET_SIZE,
         test_support::{
             FIXTURE_TS, IDR_SLICE, NON_IDR_SLICE, adts_frame, audio_samples, count_events,

--- a/shared/transcode/Cargo.toml
+++ b/shared/transcode/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "transcode"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1"
+gstreamer = "0.25"
+gstreamer-app = "0.25"
+mediapack = { path = "../mediapack" }
+tokio = { version = "1", features = ["sync"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+bytes = "1"

--- a/shared/transcode/README.md
+++ b/shared/transcode/README.md
@@ -1,0 +1,41 @@
+# transcode
+
+Re-encodes H.264 video from mediapack `MediaEvent`s into several renditions with an
+in-process GStreamer pipeline. Audio is not touched; callers forward it as-is.
+
+```
+VideoSample (Annex-B) ─> appsrc ─> h264parse ─> decodebin ─> videoconvert ─> tee
+                                                   ├─> videoscale ─> x264enc ─> appsink ─> rendition 0 events
+                                                   └─> videoscale ─> x264enc ─> appsink ─> rendition 1 events
+```
+
+## Usage
+
+```rust
+use transcode::{Transcoder, ladder_for};
+
+let renditions = ladder_for(source_sps.width, source_sps.height); // e.g. 720p/480p/360p below a 1080p source
+let mut transcoder = Transcoder::new(&renditions)?;
+transcoder.push(&video_sample)?;              // any number of times
+while let Some(output) = transcoder.next().await {
+    let output = output?;                      // output.rendition indexes `renditions`
+    publish(output.rendition, output.event);   // VideoConfig once, then Video samples
+}
+```
+
+`ladder_for` never upscales: it returns the standard heights (1080/720/480/360) strictly
+below the source height with matching bitrates. Call `finish()` to flush the encoders;
+`next()` returns `None` once every rendition has ended.
+
+Each encoder uses `x264enc tune=zerolatency` with a fixed 60-frame keyframe interval
+and a baseline profile, so keyframes are not aligned with the source GOP yet.
+
+## Requirements
+
+GStreamer 1.20+ with `gst-plugins-base` (appsrc/appsink, decodebin, videoscale),
+`gst-plugins-bad` (h264parse), `gst-plugins-ugly` (x264enc) and `gst-libav` or a
+platform decoder. On macOS `brew install gstreamer` installs all of them.
+
+```shell
+cargo run -p transcode --example transcode -- ../mediapack/fixtures/testsrc.ts out 54:100
+```

--- a/shared/transcode/README.md
+++ b/shared/transcode/README.md
@@ -23,6 +23,9 @@ while let Some(output) = transcoder.next().await {
 }
 ```
 
+`input()` returns a cloneable `TranscodeInput` with the same `push` / `finish`, so a
+blocking feeder thread can own the input while an async task drains `next()`.
+
 `ladder_for` never upscales: it returns the standard heights (1080/720/480/360) strictly
 below the source height with matching bitrates. Call `finish()` to flush the encoders;
 `next()` returns `None` once every rendition has ended.

--- a/shared/transcode/examples/transcode.rs
+++ b/shared/transcode/examples/transcode.rs
@@ -1,0 +1,73 @@
+use std::{env, fs, path::Path};
+
+use anyhow::{Context, Result, bail};
+use bytes::BufMut;
+use mediapack::{MediaEvent, mp4::Fmp4Muxer, mpegts};
+use transcode::{Rendition, Transcoder, ladder_for};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let [input_path, output_prefix, rendition_args @ ..] = args.as_slice() else {
+        bail!("usage: transcode <input.ts> <output-prefix> [<height>:<kbps> ...]");
+    };
+    let mut demuxer = mpegts::Demuxer::new();
+    let mut events = demuxer.push(&fs::read(input_path).context("read input")?)?;
+    events.extend(demuxer.finish()?);
+    let source = events
+        .iter()
+        .find_map(|event| match event {
+            MediaEvent::VideoConfig(config) => Some(config.sequence_parameter_set()),
+            _ => None,
+        })
+        .context("input has no H.264 video")??;
+    let renditions = if rendition_args.is_empty() {
+        ladder_for(source.width, source.height)
+    } else {
+        rendition_args
+            .iter()
+            .map(|arg| parse_rendition(arg, source.width, source.height))
+            .collect::<Result<Vec<_>>>()?
+    };
+    if renditions.is_empty() {
+        bail!("no rendition below {}x{}", source.width, source.height);
+    }
+
+    let mut transcoder = Transcoder::new(&renditions)?;
+    for event in &events {
+        if let MediaEvent::Video(sample) = event {
+            transcoder.push(sample)?;
+        }
+    }
+    transcoder.finish()?;
+
+    let mut muxers: Vec<Fmp4Muxer> = renditions.iter().map(|_| Fmp4Muxer::new()).collect();
+    let mut outputs: Vec<bytes::BytesMut> = renditions.iter().map(|_| Default::default()).collect();
+    while let Some(output) = transcoder.next().await {
+        let output = output?;
+        outputs[output.rendition].put_slice(&muxers[output.rendition].push(&output.event)?);
+    }
+    for (index, rendition) in renditions.iter().enumerate() {
+        outputs[index].put_slice(&muxers[index].finish()?);
+        let path = format!("{output_prefix}_{}.mp4", rendition.name);
+        fs::write(Path::new(&path), &outputs[index]).with_context(|| format!("write {path}"))?;
+        println!(
+            "{path}: {}x{} {} kbps",
+            rendition.width, rendition.height, rendition.bitrate_kbps
+        );
+    }
+    Ok(())
+}
+
+fn parse_rendition(arg: &str, source_width: u32, source_height: u32) -> Result<Rendition> {
+    let (height, bitrate) = arg
+        .split_once(':')
+        .with_context(|| format!("rendition {arg} must be <height>:<kbps>"))?;
+    let height: u32 = height.parse().context("rendition height")?;
+    Ok(Rendition {
+        name: format!("{height}p"),
+        width: (source_width * height / source_height).next_multiple_of(2),
+        height,
+        bitrate_kbps: bitrate.parse().context("rendition bitrate")?,
+    })
+}

--- a/shared/transcode/src/ladder.rs
+++ b/shared/transcode/src/ladder.rs
@@ -1,0 +1,68 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rendition {
+    pub name: String,
+    pub width: u32,
+    pub height: u32,
+    pub bitrate_kbps: u32,
+}
+
+const LADDER: [(u32, u32); 4] = [(1080, 4_500), (720, 2_500), (480, 1_200), (360, 700)];
+
+pub fn ladder_for(source_width: u32, source_height: u32) -> Vec<Rendition> {
+    LADDER
+        .iter()
+        .filter(|(height, _)| *height < source_height)
+        .map(|(height, bitrate_kbps)| Rendition {
+            name: format!("{height}p"),
+            width: (source_width * height / source_height).next_multiple_of(2),
+            height: *height,
+            bitrate_kbps: *bitrate_kbps,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_renditions_below_a_1080p_source() {
+        // Arrange
+        let (width, height) = (1920, 1080);
+
+        // Act
+        let ladder = ladder_for(width, height);
+
+        // Assert
+        let summary: Vec<(&str, u32, u32, u32)> = ladder
+            .iter()
+            .map(|r| (r.name.as_str(), r.width, r.height, r.bitrate_kbps))
+            .collect();
+        assert_eq!(
+            summary,
+            [
+                ("720p", 1280, 720, 2_500),
+                ("480p", 854, 480, 1_200),
+                ("360p", 640, 360, 700)
+            ]
+        );
+    }
+
+    #[test]
+    fn never_upscales() {
+        // Arrange / Act
+        let ladder = ladder_for(640, 360);
+
+        // Assert
+        assert!(ladder.is_empty());
+    }
+
+    #[test]
+    fn keeps_portrait_aspect_ratio_with_even_width() {
+        // Arrange / Act
+        let ladder = ladder_for(1080, 1920);
+
+        // Assert
+        assert_eq!((ladder[0].width, ladder[0].height), (608, 1080));
+    }
+}

--- a/shared/transcode/src/lib.rs
+++ b/shared/transcode/src/lib.rs
@@ -2,4 +2,4 @@ pub mod ladder;
 pub mod transcoder;
 
 pub use ladder::{Rendition, ladder_for};
-pub use transcoder::{TranscodedEvent, Transcoder};
+pub use transcoder::{TranscodeInput, TranscodedEvent, Transcoder};

--- a/shared/transcode/src/lib.rs
+++ b/shared/transcode/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod ladder;
+pub mod transcoder;
+
+pub use ladder::{Rendition, ladder_for};
+pub use transcoder::{TranscodedEvent, Transcoder};

--- a/shared/transcode/src/transcoder.rs
+++ b/shared/transcode/src/transcoder.rs
@@ -22,9 +22,41 @@ enum Message {
 
 pub struct Transcoder {
     pipeline: gst::Pipeline,
-    source: AppSrc,
+    input: TranscodeInput,
     message_receiver: mpsc::UnboundedReceiver<Message>,
     open_renditions: usize,
+}
+
+#[derive(Clone)]
+pub struct TranscodeInput {
+    source: AppSrc,
+}
+
+impl TranscodeInput {
+    pub fn push(&self, sample: &VideoSample) -> Result<()> {
+        let mut buffer = gst::Buffer::from_slice(sample.data.clone());
+        {
+            let buffer = buffer
+                .get_mut()
+                .ok_or_else(|| anyhow!("fresh buffer is shared"))?;
+            buffer.set_pts(gst::ClockTime::from_useconds(sample.pts.micros()));
+            buffer.set_dts(gst::ClockTime::from_useconds(sample.dts.micros()));
+            if !sample.is_keyframe {
+                buffer.set_flags(gst::BufferFlags::DELTA_UNIT);
+            }
+        }
+        self.source
+            .push_buffer(buffer)
+            .map(|_| ())
+            .map_err(|error| anyhow!("push sample into transcoder: {error:?}"))
+    }
+
+    pub fn finish(&self) -> Result<()> {
+        self.source
+            .end_of_stream()
+            .map(|_| ())
+            .map_err(|error| anyhow!("signal end of stream: {error:?}"))
+    }
 }
 
 impl Transcoder {
@@ -55,35 +87,22 @@ impl Transcoder {
             .context("start transcode pipeline")?;
         Ok(Self {
             pipeline,
-            source,
+            input: TranscodeInput { source },
             message_receiver,
             open_renditions: renditions.len(),
         })
     }
 
+    pub fn input(&self) -> TranscodeInput {
+        self.input.clone()
+    }
+
     pub fn push(&self, sample: &VideoSample) -> Result<()> {
-        let mut buffer = gst::Buffer::from_slice(sample.data.clone());
-        {
-            let buffer = buffer
-                .get_mut()
-                .ok_or_else(|| anyhow!("fresh buffer is shared"))?;
-            buffer.set_pts(gst::ClockTime::from_useconds(sample.pts.micros()));
-            buffer.set_dts(gst::ClockTime::from_useconds(sample.dts.micros()));
-            if !sample.is_keyframe {
-                buffer.set_flags(gst::BufferFlags::DELTA_UNIT);
-            }
-        }
-        self.source
-            .push_buffer(buffer)
-            .map(|_| ())
-            .map_err(|error| anyhow!("push sample into transcoder: {error:?}"))
+        self.input.push(sample)
     }
 
     pub fn finish(&self) -> Result<()> {
-        self.source
-            .end_of_stream()
-            .map(|_| ())
-            .map_err(|error| anyhow!("signal end of stream: {error:?}"))
+        self.input.finish()
     }
 
     pub async fn next(&mut self) -> Option<Result<TranscodedEvent>> {

--- a/shared/transcode/src/transcoder.rs
+++ b/shared/transcode/src/transcoder.rs
@@ -155,8 +155,13 @@ fn install_sink_callbacks(
                 let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                 let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
                 let map = buffer.map_readable().map_err(|_| gst::FlowError::Error)?;
-                let pts = timestamp(buffer.pts());
-                let dts = buffer.dts().map_or(pts, |_| timestamp(buffer.dts()));
+                let segment = sample
+                    .segment()
+                    .and_then(|segment| segment.downcast_ref::<gst::ClockTime>());
+                let pts = running_timestamp(segment, buffer.pts());
+                let dts = buffer
+                    .dts()
+                    .map_or(pts, |_| running_timestamp(segment, buffer.dts()));
                 match parameter_sets.track(map.as_slice()) {
                     Ok(Some(unit)) => {
                         if let Some(config) = unit.config_changed {
@@ -207,8 +212,18 @@ fn forward_bus_errors(
     Ok(())
 }
 
-fn timestamp(clock_time: Option<gst::ClockTime>) -> Timestamp {
-    Timestamp::from_micros(clock_time.map_or(0, |time| time.useconds()))
+/// Encoders shift PTS (and the segment with it) to keep DTS non-negative;
+/// running time undoes that shift so outputs stay on the input timeline.
+fn running_timestamp(
+    segment: Option<&gst::FormattedSegment<gst::ClockTime>>,
+    clock_time: Option<gst::ClockTime>,
+) -> Timestamp {
+    let running = clock_time.map(|time| {
+        segment
+            .and_then(|segment| segment.to_running_time(time))
+            .unwrap_or(time)
+    });
+    Timestamp::from_micros(running.map_or(0, |time| time.useconds()))
 }
 
 #[cfg(test)]
@@ -279,6 +294,8 @@ mod tests {
         assert_eq!(video.len(), samples.len());
         assert!(video[0].is_keyframe);
         assert!(video.windows(2).all(|pair| pair[0].pts < pair[1].pts));
+        assert_eq!(video[0].pts, samples[0].pts);
+        assert_eq!(video[0].dts, samples[0].pts);
         assert!(outputs.iter().all(|output| output.rendition == 0));
     }
 

--- a/shared/transcode/src/transcoder.rs
+++ b/shared/transcode/src/transcoder.rs
@@ -1,0 +1,271 @@
+use anyhow::{Context, Result, anyhow, ensure};
+use gstreamer::{self as gst, prelude::*};
+use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
+use mediapack::{MediaEvent, Timestamp, VideoSample, h264::ParameterSetTracker};
+use tokio::sync::mpsc;
+
+use crate::ladder::Rendition;
+
+const KEYFRAME_INTERVAL_FRAMES: u32 = 60;
+const INPUT_QUEUE_BYTES: u32 = 4 * 1024 * 1024;
+
+pub struct TranscodedEvent {
+    pub rendition: usize,
+    pub event: MediaEvent,
+}
+
+enum Message {
+    Event(TranscodedEvent),
+    Error(anyhow::Error),
+    EndOfStream,
+}
+
+pub struct Transcoder {
+    pipeline: gst::Pipeline,
+    source: AppSrc,
+    message_receiver: mpsc::UnboundedReceiver<Message>,
+    open_renditions: usize,
+}
+
+impl Transcoder {
+    pub fn new(renditions: &[Rendition]) -> Result<Self> {
+        ensure!(!renditions.is_empty(), "at least one rendition is required");
+        gst::init()?;
+        let pipeline = gst::parse::launch(&pipeline_description(renditions))
+            .context("build transcode pipeline")?
+            .downcast::<gst::Pipeline>()
+            .map_err(|_| anyhow!("transcode description did not produce a pipeline"))?;
+        let source = pipeline
+            .by_name("source")
+            .context("missing appsrc")?
+            .downcast::<AppSrc>()
+            .map_err(|_| anyhow!("source is not an appsrc"))?;
+        let (message_sender, message_receiver) = mpsc::unbounded_channel();
+        for index in 0..renditions.len() {
+            let sink = pipeline
+                .by_name(&format!("sink{index}"))
+                .context("missing appsink")?
+                .downcast::<AppSink>()
+                .map_err(|_| anyhow!("sink{index} is not an appsink"))?;
+            install_sink_callbacks(&sink, index, message_sender.clone());
+        }
+        forward_bus_errors(&pipeline, message_sender)?;
+        pipeline
+            .set_state(gst::State::Playing)
+            .context("start transcode pipeline")?;
+        Ok(Self {
+            pipeline,
+            source,
+            message_receiver,
+            open_renditions: renditions.len(),
+        })
+    }
+
+    pub fn push(&self, sample: &VideoSample) -> Result<()> {
+        let mut buffer = gst::Buffer::from_slice(sample.data.clone());
+        {
+            let buffer = buffer
+                .get_mut()
+                .ok_or_else(|| anyhow!("fresh buffer is shared"))?;
+            buffer.set_pts(gst::ClockTime::from_useconds(sample.pts.micros()));
+            buffer.set_dts(gst::ClockTime::from_useconds(sample.dts.micros()));
+            if !sample.is_keyframe {
+                buffer.set_flags(gst::BufferFlags::DELTA_UNIT);
+            }
+        }
+        self.source
+            .push_buffer(buffer)
+            .map(|_| ())
+            .map_err(|error| anyhow!("push sample into transcoder: {error:?}"))
+    }
+
+    pub fn finish(&self) -> Result<()> {
+        self.source
+            .end_of_stream()
+            .map(|_| ())
+            .map_err(|error| anyhow!("signal end of stream: {error:?}"))
+    }
+
+    pub async fn next(&mut self) -> Option<Result<TranscodedEvent>> {
+        while self.open_renditions > 0 {
+            match self.message_receiver.recv().await? {
+                Message::Event(event) => return Some(Ok(event)),
+                Message::Error(error) => return Some(Err(error)),
+                Message::EndOfStream => self.open_renditions -= 1,
+            }
+        }
+        None
+    }
+}
+
+impl Drop for Transcoder {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+fn pipeline_description(renditions: &[Rendition]) -> String {
+    let mut description = format!(
+        "appsrc name=source is-live=true format=time block=true max-bytes={INPUT_QUEUE_BYTES} \
+         caps=\"video/x-h264,stream-format=(string)byte-stream,alignment=(string)au\" ! \
+         h264parse ! decodebin ! videoconvert ! tee name=split "
+    );
+    for (index, rendition) in renditions.iter().enumerate() {
+        description.push_str(&format!(
+            "split. ! queue ! videoscale ! video/x-raw,width={},height={} ! \
+             x264enc tune=zerolatency speed-preset=veryfast bitrate={} key-int-max={KEYFRAME_INTERVAL_FRAMES} ! \
+             video/x-h264,profile=baseline ! h264parse config-interval=-1 ! \
+             video/x-h264,stream-format=byte-stream,alignment=au ! \
+             appsink name=sink{index} sync=false ",
+            rendition.width, rendition.height, rendition.bitrate_kbps
+        ));
+    }
+    description
+}
+
+fn install_sink_callbacks(
+    sink: &AppSink,
+    rendition: usize,
+    message_sender: mpsc::UnboundedSender<Message>,
+) {
+    let eos_sender = message_sender.clone();
+    let mut parameter_sets = ParameterSetTracker::new();
+    sink.set_callbacks(
+        AppSinkCallbacks::builder()
+            .new_sample(move |sink| {
+                let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+                let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
+                let map = buffer.map_readable().map_err(|_| gst::FlowError::Error)?;
+                let pts = timestamp(buffer.pts());
+                let dts = buffer.dts().map_or(pts, |_| timestamp(buffer.dts()));
+                match parameter_sets.track(map.as_slice()) {
+                    Ok(Some(unit)) => {
+                        if let Some(config) = unit.config_changed {
+                            let _ = message_sender.send(Message::Event(TranscodedEvent {
+                                rendition,
+                                event: MediaEvent::VideoConfig(config),
+                            }));
+                        }
+                        let _ = message_sender.send(Message::Event(TranscodedEvent {
+                            rendition,
+                            event: MediaEvent::Video(VideoSample {
+                                data: unit.data,
+                                is_keyframe: unit.is_keyframe,
+                                pts,
+                                dts,
+                            }),
+                        }));
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        let _ = message_sender.send(Message::Error(error));
+                    }
+                }
+                Ok(gst::FlowSuccess::Ok)
+            })
+            .eos(move |_| {
+                let _ = eos_sender.send(Message::EndOfStream);
+            })
+            .build(),
+    );
+}
+
+fn forward_bus_errors(
+    pipeline: &gst::Pipeline,
+    message_sender: mpsc::UnboundedSender<Message>,
+) -> Result<()> {
+    let bus = pipeline.bus().context("transcode pipeline has no bus")?;
+    bus.set_sync_handler(move |_, message| {
+        if let gst::MessageView::Error(error) = message.view() {
+            let _ = message_sender.send(Message::Error(anyhow!(
+                "transcode pipeline error: {} ({:?})",
+                error.error(),
+                error.debug()
+            )));
+        }
+        gst::BusSyncReply::Drop
+    });
+    Ok(())
+}
+
+fn timestamp(clock_time: Option<gst::ClockTime>) -> Timestamp {
+    Timestamp::from_micros(clock_time.map_or(0, |time| time.useconds()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use mediapack::mpegts;
+
+    use super::*;
+
+    const FIXTURE_TS: &[u8] = include_bytes!("../../mediapack/fixtures/testsrc.ts");
+
+    fn fixture_video_samples() -> Vec<VideoSample> {
+        let mut demuxer = mpegts::Demuxer::new();
+        let mut events = demuxer.push(FIXTURE_TS).unwrap();
+        events.extend(demuxer.finish().unwrap());
+        events
+            .into_iter()
+            .filter_map(|event| match event {
+                MediaEvent::Video(sample) => Some(sample),
+                _ => None,
+            })
+            .collect()
+    }
+
+    async fn drain(transcoder: &mut Transcoder) -> Vec<TranscodedEvent> {
+        let mut outputs = Vec::new();
+        while let Some(event) = transcoder.next().await {
+            outputs.push(event.unwrap());
+        }
+        outputs
+    }
+
+    #[tokio::test]
+    async fn transcodes_fixture_into_a_smaller_rendition() {
+        // Arrange
+        let samples = fixture_video_samples();
+        let rendition = Rendition {
+            name: "54p".into(),
+            width: 96,
+            height: 54,
+            bitrate_kbps: 100,
+        };
+        let mut transcoder = Transcoder::new(&[rendition]).unwrap();
+
+        // Act
+        for sample in &samples {
+            transcoder.push(sample).unwrap();
+        }
+        transcoder.finish().unwrap();
+        let outputs = tokio::time::timeout(Duration::from_secs(30), drain(&mut transcoder))
+            .await
+            .expect("transcoder finished");
+
+        // Assert
+        let MediaEvent::VideoConfig(config) = &outputs[0].event else {
+            panic!("first event must be the rendition's VideoConfig");
+        };
+        let sps = config.sequence_parameter_set().unwrap();
+        assert_eq!((sps.width, sps.height), (96, 54));
+        let video: Vec<&VideoSample> = outputs
+            .iter()
+            .filter_map(|output| match &output.event {
+                MediaEvent::Video(sample) => Some(sample),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(video.len(), samples.len());
+        assert!(video[0].is_keyframe);
+        assert!(video.windows(2).all(|pair| pair[0].pts < pair[1].pts));
+        assert!(outputs.iter().all(|output| output.rendition == 0));
+    }
+
+    #[test]
+    fn rejects_empty_ladder() {
+        // Arrange / Act / Assert
+        assert!(Transcoder::new(&[]).is_err());
+    }
+}


### PR DESCRIPTION
## 概要
SRT/RTMP で受けた映像を複数画質で配信するには再エンコードが必要ですが、mediapack はコーデック非依存のまま保ちたいので、エンコーダ依存を別 crate に隔離します。
GStreamer をプロセス内で使う `shared/transcode` を追加します。入出力は mediapack の `MediaEvent` です。stacked PR（base: `claude/mediapack`）です。

## やったこと
- `ladder_for(width, height)`: 元解像度より下の標準段（1080/720/480/360p）と bitrate を返す
- `Transcoder`: `appsrc → h264parse → decodebin → videoconvert → tee → (videoscale → x264enc tune=zerolatency → h264parse) × N → appsink`。画質ごとに `VideoConfig` を 1 回、以後 Annex-B の `Video` を返す。出力 pts は segment の running time に変換して入力タイムラインに揃える。`input()` で入力側だけの handle を取り出せる
- mediapack: MPEG-TS demuxer 内の SPS/PPS 追跡を `h264::ParameterSetTracker` として公開し、エンコーダ出力にも同じ処理を適用

## やらないこと
- live-ingest への組み込み（画質ごとの track と catalog の `alt_group`）
- 元ストリームの keyframe 位置との GOP 整合（`key-int-max=60` 固定）、ハードウェアエンコーダの選択、音声の再エンコード

## 影響範囲
`transcode` に依存しない crate は GStreamer なしでビルドできるが、CI の lint/test ジョブは `--workspace` のため GStreamer パッケージを常にインストールする。

## テスト
- `cargo test -p transcode`（5 件。fixture の 160x90 を 96x54 に再エンコードし、`VideoConfig` の SPS 解像度、フレーム数 9、pts 単調増加を確認）、`cargo test -p mediapack`（60 件）、clippy `-D warnings`、fmt
- example で fixture を 96x54 / 78x44 の fMP4 に変換し、ffprobe で Constrained Baseline・9 frames、ffmpeg でデコード可を確認

## 備考
出力は unbounded channel に積むので、消費側が長時間止まるとメモリが増えます。live-ingest 組み込み時にバックプレッシャーの扱いを決めます。
