### PR TITLE
feat(live-ingest): --transcode で下位画質の rendition track を publish する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3148,6 +3148,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "transcode",
  "url",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ live-ingest:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo run -p moqt-bridge-live-ingest -- \
 		--rtmp-addr 0.0.0.0:1935 \
 		--srt-addr 0.0.0.0:9000 \
-		--moqt-url $(LIVE_INGEST_MOQT_URL)
+		--moqt-url $(LIVE_INGEST_MOQT_URL) $(if $(LIVE_INGEST_TRANSCODE),--transcode,)
 
 ## Media helpers
 relay-certs:

--- a/bridges/live-ingest/Cargo.toml
+++ b/bridges/live-ingest/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3.32"
 moqt = { path = "../../moqt" }
 media-streaming-format = { path = "../../shared/media-streaming-format" }
 mediapack = { path = "../../shared/mediapack" }
+transcode = { path = "../../shared/transcode" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 base64 = "0.22"

--- a/bridges/live-ingest/README.md
+++ b/bridges/live-ingest/README.md
@@ -2,6 +2,10 @@
 
 Live ingest bridge for publishing RTMP or SRT media into MoQT.
 
+## Prerequisites
+
+`--transcode` needs GStreamer; see `shared/transcode/README.md` for the packages.
+
 ## Run
 
 Run the bridge:
@@ -20,6 +24,10 @@ Override the relay URL when needed:
 ```shell
 LIVE_INGEST_MOQT_URL=https://relay.example.com:443 make live-ingest
 ```
+
+Add lower renditions with `LIVE_INGEST_TRANSCODE=1 make live-ingest`. Each rendition
+below the source resolution (720p / 480p / 360p) is published as `video_<height>p`
+next to `video`, and the catalog lists them in one `altGroup` with `width` / `height`.
 
 ## Publish Test RTMP
 
@@ -57,3 +65,4 @@ Options:
 - `--rtmp-addr`: RTMP listen address
 - `--srt-addr`: SRT listen address
 - `--moqt-url`: MoQT relay URL
+- `--transcode`: re-encode video into the standard renditions below the source resolution

--- a/bridges/live-ingest/src/main.rs
+++ b/bridges/live-ingest/src/main.rs
@@ -2,11 +2,14 @@ mod chunk_payload;
 mod ingest;
 mod moqt;
 mod publisher;
+mod renditions;
 mod rtmp;
 mod srt;
 
 use anyhow::Result;
 use clap::Parser;
+
+use crate::publisher::IngestOptions;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -26,6 +29,10 @@ struct Args {
     /// MoQ server URL (`moqt://` for QUIC, `https://` for WebTransport)
     #[arg(long)]
     moqt_url: Option<String>,
+
+    /// Re-encode video into the standard renditions below the source resolution
+    #[arg(long)]
+    transcode: bool,
 }
 
 #[tokio::main]
@@ -33,9 +40,13 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     tracing_subscriber::fmt::init();
 
+    let options = IngestOptions {
+        moqt_url: args.moqt_url,
+        transcode: args.transcode,
+    };
     tokio::try_join!(
-        rtmp::run_rtmp_listener(args.rtmp_addr, args.moqt_url.clone()),
-        srt::run_srt_listener(args.srt_addr, args.moqt_url),
+        rtmp::run_rtmp_listener(args.rtmp_addr, options.clone()),
+        srt::run_srt_listener(args.srt_addr, options),
     )?;
 
     Ok(())

--- a/bridges/live-ingest/src/moqt.rs
+++ b/bridges/live-ingest/src/moqt.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -10,13 +10,14 @@ use media_streaming_format::{
     Catalog, Track,
     types::{KnownPackaging, KnownTrackRole, Packaging, TrackRole},
 };
+use mediapack::h264::AvcDecoderConfigurationRecord;
 use moqt::{
     ClientConfig, ContentExists, Endpoint, QUIC, Session, SessionEvent, TrackWriter,
     TransportProtocol, WEBTRANSPORT,
 };
 use tokio::sync::Mutex;
 
-const VIDEO_TRACK_NAME: &str = "video";
+pub(crate) const VIDEO_TRACK_NAME: &str = "video";
 const AUDIO_TRACK_NAME: &str = "audio";
 const CATALOG_TRACK_NAME: &str = "catalog";
 const CHAT_TRACK_NAME: &str = "chat";
@@ -51,9 +52,29 @@ impl<T: TransportProtocol> Default for BackendState<T> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoTrackInfo {
+    pub label: String,
+    pub codec: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl VideoTrackInfo {
+    pub fn from_record(record: &AvcDecoderConfigurationRecord, label: String) -> Result<Self> {
+        let sps = record.sequence_parameter_set()?;
+        Ok(Self {
+            label,
+            codec: record.codec_string(),
+            width: sps.width,
+            height: sps.height,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct CatalogMetadata {
-    video_codec: Option<String>,
+    video_tracks: BTreeMap<String, VideoTrackInfo>,
     audio_sample_rate: Option<u32>,
     audio_channels: Option<u8>,
 }
@@ -111,7 +132,8 @@ impl MoqtManager {
     pub async fn update_video_catalog(
         &self,
         namespace: &[String],
-        codec: Option<&str>,
+        track_name: &str,
+        info: VideoTrackInfo,
     ) -> Result<()> {
         let url = match &self.url {
             Some(u) => u.clone(),
@@ -120,7 +142,7 @@ impl MoqtManager {
 
         self.ensure_backend(&url)
             .await?
-            .update_video_catalog(namespace, codec)
+            .update_video_catalog(namespace, track_name, info)
             .await
     }
 
@@ -198,10 +220,23 @@ impl PublisherBackend {
         }
     }
 
-    async fn update_video_catalog(&self, namespace: &[String], codec: Option<&str>) -> Result<()> {
+    async fn update_video_catalog(
+        &self,
+        namespace: &[String],
+        track_name: &str,
+        info: VideoTrackInfo,
+    ) -> Result<()> {
         match self {
-            Self::Quic(publisher) => publisher.update_video_catalog(namespace, codec).await,
-            Self::WebTransport(publisher) => publisher.update_video_catalog(namespace, codec).await,
+            Self::Quic(publisher) => {
+                publisher
+                    .update_video_catalog(namespace, track_name, info)
+                    .await
+            }
+            Self::WebTransport(publisher) => {
+                publisher
+                    .update_video_catalog(namespace, track_name, info)
+                    .await
+            }
         }
     }
 
@@ -281,7 +316,11 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                     SessionEvent::Subscribe(handler) => {
                         let namespace = handler.track_namespace.clone();
                         let track_name = handler.track_name.clone();
-                        if !is_supported_track(&track_name) {
+                        let supported = {
+                            let guard = state.lock().await;
+                            is_supported_track(&track_name, guard.catalogs.get(&namespace))
+                        };
+                        if !supported {
                             if let Err(err) = handler
                                 .error(0, format!("unsupported track: {track_name}"))
                                 .await
@@ -399,12 +438,13 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
         result
     }
 
-    async fn update_video_catalog(&self, namespace: &[String], codec: Option<&str>) -> Result<()> {
+    async fn update_video_catalog(
+        &self,
+        namespace: &[String],
+        track_name: &str,
+        info: VideoTrackInfo,
+    ) -> Result<()> {
         let namespace_path = namespace.join("/");
-        let normalized_codec = codec
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned);
 
         let should_send = {
             let mut guard = self.state.lock().await;
@@ -412,9 +452,9 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                 bail!("MoQ publisher disconnected");
             }
             let metadata = guard.catalogs.entry(namespace_path.clone()).or_default();
-            let changed = metadata.video_codec != normalized_codec;
+            let changed = metadata.video_tracks.get(track_name) != Some(&info);
             if changed {
-                metadata.video_codec = normalized_codec;
+                metadata.video_tracks.insert(track_name.to_string(), info);
             }
             changed
                 && matches!(
@@ -483,6 +523,7 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
             .cloned()
             .unwrap_or_default();
         let payload = build_catalog_payload(namespace_path, &metadata)?;
+        tracing::debug!(namespace = %namespace_path, catalog = %String::from_utf8_lossy(&payload), "catalog snapshot");
         let Some(Some(writer)) = guard.tracks.get_mut(&key) else {
             return Ok(());
         };
@@ -515,11 +556,11 @@ async fn write_object<T: TransportProtocol>(
         .context("send subgroup object")
 }
 
-fn is_supported_track(track_name: &str) -> bool {
+fn is_supported_track(track_name: &str, metadata: Option<&CatalogMetadata>) -> bool {
     matches!(
         track_name,
-        VIDEO_TRACK_NAME | AUDIO_TRACK_NAME | CATALOG_TRACK_NAME | CHAT_TRACK_NAME
-    )
+        AUDIO_TRACK_NAME | CATALOG_TRACK_NAME | CHAT_TRACK_NAME
+    ) || metadata.is_some_and(|metadata| metadata.video_tracks.contains_key(track_name))
 }
 
 fn build_catalog_payload(namespace_path: &str, metadata: &CatalogMetadata) -> Result<Vec<u8>> {
@@ -529,29 +570,32 @@ fn build_catalog_payload(namespace_path: &str, metadata: &CatalogMetadata) -> Re
         AUDIO_TRACK_NAME.to_string(),
     ]);
 
-    let tracks = vec![
-        Track {
+    let alt_group = (metadata.video_tracks.len() > 1).then_some(1);
+    let mut tracks: Vec<Track> = metadata
+        .video_tracks
+        .iter()
+        .map(|(name, info)| Track {
             namespace: namespace.clone(),
-            name: VIDEO_TRACK_NAME.to_string(),
+            name: name.clone(),
             packaging: Packaging::Known(KnownPackaging::Loc),
             event_type: None,
             role: Some(TrackRole::Known(KnownTrackRole::Video)),
             is_live: true,
             target_latency: None,
-            label: Some("Video".to_string()),
+            label: Some(info.label.clone()),
             render_group: None,
-            alt_group: None,
+            alt_group,
             init_data: None,
             depends: None,
             temporal_id: None,
             spatial_id: None,
-            codec: metadata.video_codec.clone(),
+            codec: Some(info.codec.clone()),
             mime_type: Some("video/h264".to_string()),
             framerate: Some(30.0),
             timescale: None,
             bitrate: None,
-            width: None,
-            height: None,
+            width: Some(info.width),
+            height: Some(info.height),
             sample_rate: None,
             channel_config: None,
             display_width: None,
@@ -559,7 +603,9 @@ fn build_catalog_payload(namespace_path: &str, metadata: &CatalogMetadata) -> Re
             lang: None,
             parent_name: None,
             track_duration: None,
-        },
+        })
+        .collect();
+    tracks.extend([
         Track {
             namespace: namespace.clone(),
             name: AUDIO_TRACK_NAME.to_string(),
@@ -620,7 +666,7 @@ fn build_catalog_payload(namespace_path: &str, metadata: &CatalogMetadata) -> Re
             parent_name: None,
             track_duration: None,
         },
-    ];
+    ]);
 
     let catalog = Catalog {
         version: Some(1),

--- a/bridges/live-ingest/src/publisher.rs
+++ b/bridges/live-ingest/src/publisher.rs
@@ -1,36 +1,43 @@
 use anyhow::{Context, Result};
-use mediapack::{
-    AudioSample, MediaEvent, VideoSample, aac::AudioSpecificConfig,
-    h264::AvcDecoderConfigurationRecord,
-};
+use mediapack::{AudioSample, MediaEvent, VideoSample, aac::AudioSpecificConfig};
 
 use crate::{
     chunk_payload::{pack_audio_chunk_payload, pack_video_chunk_payload},
-    moqt::{MoqtManager, now_unix},
+    moqt::{MoqtManager, VIDEO_TRACK_NAME, VideoTrackInfo, now_unix},
+    renditions::RenditionFanout,
 };
 
 const AUDIO_GROUP_ROTATION_INTERVAL_US: u64 = 2_000_000;
-const VIDEO_TRACK: &str = "video";
 const AUDIO_TRACK: &str = "audio";
+
+#[derive(Clone)]
+pub struct IngestOptions {
+    pub moqt_url: Option<String>,
+    pub transcode: bool,
+}
 
 pub struct MediaPublisher {
     moqt: MoqtManager,
     namespace: Vec<String>,
+    transcode: bool,
     namespace_ready: bool,
     audio_group_duration_us: u64,
-    video_config: Option<AvcDecoderConfigurationRecord>,
+    video_codec: Option<String>,
     audio_config: Option<AudioSpecificConfig>,
+    renditions: Option<RenditionFanout>,
 }
 
 impl MediaPublisher {
-    pub fn new(moqt: MoqtManager, namespace: Vec<String>) -> Self {
+    pub fn new(moqt: MoqtManager, namespace: Vec<String>, transcode: bool) -> Self {
         Self {
             moqt,
             namespace,
+            transcode,
             namespace_ready: false,
             audio_group_duration_us: 0,
-            video_config: None,
+            video_codec: None,
             audio_config: None,
+            renditions: None,
         }
     }
 
@@ -38,11 +45,15 @@ impl MediaPublisher {
         match event {
             MediaEvent::Streams(_) => Ok(()),
             MediaEvent::VideoConfig(config) => {
+                let info = VideoTrackInfo::from_record(config, "Video".to_string())?;
+                self.video_codec = Some(info.codec.clone());
+                if self.transcode && self.renditions.is_none() {
+                    self.renditions =
+                        RenditionFanout::run(self.moqt.clone(), self.namespace.clone(), &info)?;
+                }
                 self.moqt
-                    .update_video_catalog(&self.namespace, Some(&config.codec_string()))
-                    .await?;
-                self.video_config = Some(config.clone());
-                Ok(())
+                    .update_video_catalog(&self.namespace, VIDEO_TRACK_NAME, info)
+                    .await
             }
             MediaEvent::AudioConfig(config) => {
                 self.moqt
@@ -62,21 +73,19 @@ impl MediaPublisher {
 
     async fn publish_video(&mut self, sample: &VideoSample) -> Result<()> {
         self.setup_namespace().await?;
-        let codec = self
-            .video_config
-            .as_ref()
-            .filter(|_| sample.is_keyframe)
-            .map(|config| config.codec_string());
-        let payload = pack_video_chunk_payload(
-            sample.is_keyframe,
-            sample.pts.micros(),
-            now_unix().as_millis() as u64,
-            &sample.data,
-            codec.as_deref(),
-        );
+        let payload = video_payload(sample, self.video_codec.as_deref());
         self.moqt
-            .send_object(&self.namespace, VIDEO_TRACK, sample.is_keyframe, payload)
-            .await
+            .send_object(
+                &self.namespace,
+                VIDEO_TRACK_NAME,
+                sample.is_keyframe,
+                payload,
+            )
+            .await?;
+        if let Some(renditions) = &self.renditions {
+            renditions.push(sample);
+        }
+        Ok(())
     }
 
     async fn publish_audio(&mut self, sample: &AudioSample) -> Result<()> {
@@ -118,4 +127,14 @@ impl MediaPublisher {
         };
         rotate
     }
+}
+
+pub fn video_payload(sample: &VideoSample, codec: Option<&str>) -> Vec<u8> {
+    pack_video_chunk_payload(
+        sample.is_keyframe,
+        sample.pts.micros(),
+        now_unix().as_millis() as u64,
+        &sample.data,
+        codec.filter(|_| sample.is_keyframe),
+    )
 }

--- a/bridges/live-ingest/src/renditions.rs
+++ b/bridges/live-ingest/src/renditions.rs
@@ -1,0 +1,116 @@
+use anyhow::Result;
+use mediapack::{MediaEvent, VideoSample};
+use tokio::{
+    sync::mpsc,
+    task::{self, JoinHandle},
+};
+use transcode::{Rendition, TranscodedEvent, Transcoder, ladder_for};
+
+use crate::{
+    moqt::{MoqtManager, VIDEO_TRACK_NAME, VideoTrackInfo},
+    publisher::video_payload,
+};
+
+const SAMPLE_QUEUE_CAPACITY: usize = 64;
+
+pub struct RenditionFanout {
+    sample_sender: mpsc::Sender<VideoSample>,
+    _feeder: JoinHandle<()>,
+    _publisher: JoinHandle<()>,
+}
+
+impl RenditionFanout {
+    pub fn run(
+        moqt: MoqtManager,
+        namespace: Vec<String>,
+        source: &VideoTrackInfo,
+    ) -> Result<Option<Self>> {
+        let namespace_path = namespace.join("/");
+        let renditions = ladder_for(source.width, source.height);
+        if renditions.is_empty() {
+            tracing::info!(namespace = %namespace_path, width = source.width, height = source.height, "source too small for lower renditions");
+            return Ok(None);
+        }
+        let transcoder = Transcoder::new(&renditions)?;
+        tracing::info!(
+            namespace = %namespace_path,
+            renditions = ?renditions.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
+            "transcoding renditions started"
+        );
+        let input = transcoder.input();
+        let (sample_sender, mut sample_receiver) =
+            mpsc::channel::<VideoSample>(SAMPLE_QUEUE_CAPACITY);
+        let feeder = task::spawn_blocking(move || {
+            while let Some(sample) = sample_receiver.blocking_recv() {
+                tracing::trace!(pts = sample.pts.micros(), "feeding transcoder");
+                if let Err(err) = input.push(&sample) {
+                    tracing::warn!(?err, "failed to feed the transcoder");
+                    break;
+                }
+            }
+            if let Err(err) = input.finish() {
+                tracing::warn!(?err, "failed to finish the transcoder");
+            }
+        });
+        let publisher = tokio::spawn(publish_renditions(transcoder, renditions, moqt, namespace));
+        Ok(Some(Self {
+            sample_sender,
+            _feeder: feeder,
+            _publisher: publisher,
+        }))
+    }
+
+    pub fn push(&self, sample: &VideoSample) {
+        if self.sample_sender.try_send(sample.clone()).is_err() {
+            tracing::warn!("transcoder input queue full, dropping video sample");
+        }
+    }
+}
+
+async fn publish_renditions(
+    mut transcoder: Transcoder,
+    renditions: Vec<Rendition>,
+    moqt: MoqtManager,
+    namespace: Vec<String>,
+) {
+    let namespace_path = namespace.join("/");
+    let mut codecs: Vec<Option<String>> = vec![None; renditions.len()];
+    while let Some(output) = transcoder.next().await {
+        let output = match output {
+            Ok(output) => output,
+            Err(err) => {
+                tracing::error!(namespace = %namespace_path, ?err, "transcoder failed");
+                break;
+            }
+        };
+        let rendition = &renditions[output.rendition];
+        let codec = &mut codecs[output.rendition];
+        if let Err(err) = publish_output(&moqt, &namespace, rendition, codec, output).await {
+            tracing::warn!(namespace = %namespace_path, rendition = %rendition.name, ?err, "failed to publish rendition");
+        }
+    }
+}
+
+async fn publish_output(
+    moqt: &MoqtManager,
+    namespace: &[String],
+    rendition: &Rendition,
+    codec: &mut Option<String>,
+    output: TranscodedEvent,
+) -> Result<()> {
+    let track = format!("{VIDEO_TRACK_NAME}_{}", rendition.name);
+    match output.event {
+        MediaEvent::VideoConfig(config) => {
+            let info = VideoTrackInfo::from_record(&config, format!("Video {}", rendition.name))?;
+            *codec = Some(info.codec.clone());
+            moqt.update_video_catalog(namespace, &track, info).await
+        }
+        MediaEvent::Video(sample) => {
+            tracing::trace!(%track, pts = sample.pts.micros(), is_keyframe = sample.is_keyframe, "rendition sample received");
+            let payload = video_payload(&sample, codec.as_deref());
+            moqt.send_object(namespace, &track, sample.is_keyframe, payload)
+                .await
+        }
+        _ => Ok(()),
+    }
+}

--- a/bridges/live-ingest/src/rtmp/connection.rs
+++ b/bridges/live-ingest/src/rtmp/connection.rs
@@ -14,9 +14,9 @@ use super::{
     handshake::perform_handshake,
     session::{RtmpState, handle_event},
 };
-use crate::moqt::MoqtManager;
+use crate::publisher::IngestOptions;
 
-pub async fn run_rtmp_listener(addr: String, moqt_url: Option<String>) -> Result<()> {
+pub async fn run_rtmp_listener(addr: String, options: IngestOptions) -> Result<()> {
     let listener = TcpListener::bind(&addr)
         .await
         .with_context(|| format!("bind RTMP listener on {addr}"))?;
@@ -25,23 +25,27 @@ pub async fn run_rtmp_listener(addr: String, moqt_url: Option<String>) -> Result
     loop {
         let (socket, peer) = listener.accept().await?;
         let label = peer.to_string();
-        let moqt = MoqtManager::new(moqt_url.clone());
+        let options = options.clone();
         tokio::spawn(async move {
-            if let Err(err) = handle_connection(socket, &label, moqt).await {
+            if let Err(err) = handle_connection(socket, &label, &options).await {
                 tracing::warn!(peer = %label, ?err, "RTMP connection failed");
             }
         });
     }
 }
 
-async fn handle_connection(mut socket: TcpStream, label: &str, moqt: MoqtManager) -> Result<()> {
+async fn handle_connection(
+    mut socket: TcpStream,
+    label: &str,
+    options: &IngestOptions,
+) -> Result<()> {
     tracing::debug!(peer = %label, "RTMP handshake started");
     let mut buf = [0u8; 4096];
     let leftover = perform_handshake(&mut socket, label).await?;
 
     let (mut session, initial_results) =
         ServerSession::new(ServerSessionConfig::new()).context("create RTMP session")?;
-    let mut state = RtmpState::new(moqt, label.to_string());
+    let mut state = RtmpState::new(options, label.to_string());
 
     handle_results(
         &mut session,

--- a/bridges/live-ingest/src/rtmp/session.rs
+++ b/bridges/live-ingest/src/rtmp/session.rs
@@ -8,7 +8,11 @@ use mediapack::{
 };
 use rml_rtmp::sessions::{ServerSession, ServerSessionEvent, ServerSessionResult};
 
-use crate::{ingest::flv::FlvRecorder, moqt::MoqtManager, publisher::MediaPublisher};
+use crate::{
+    ingest::flv::FlvRecorder,
+    moqt::MoqtManager,
+    publisher::{IngestOptions, MediaPublisher},
+};
 
 #[derive(Default)]
 pub struct RtmpCounters {
@@ -21,6 +25,7 @@ pub struct RtmpState {
     pub counters: RtmpCounters,
     pub recorder: Option<FlvRecorder>,
     pub moqt: MoqtManager,
+    transcode: bool,
     pub streams: HashMap<String, RtmpStream>,
 }
 
@@ -30,12 +35,13 @@ pub struct RtmpStream {
 }
 
 impl RtmpState {
-    pub fn new(moqt: MoqtManager, label: String) -> Self {
+    pub fn new(options: &IngestOptions, label: String) -> Self {
         Self {
             label,
             counters: RtmpCounters::default(),
             recorder: None,
-            moqt,
+            moqt: MoqtManager::new(options.moqt_url.clone()),
+            transcode: options.transcode,
             streams: HashMap::new(),
         }
     }
@@ -64,6 +70,7 @@ impl RtmpState {
                 publisher: MediaPublisher::new(
                     self.moqt.clone(),
                     namespace_path.split('/').map(str::to_owned).collect(),
+                    self.transcode,
                 ),
             });
         let events = match stream.demuxer.push_tag(&tag) {

--- a/bridges/live-ingest/src/srt.rs
+++ b/bridges/live-ingest/src/srt.rs
@@ -4,29 +4,32 @@ use mediapack::mpegts;
 use srt_tokio::{ConnectionRequest, SrtListener};
 use tokio::task;
 
-use crate::{moqt::MoqtManager, publisher::MediaPublisher};
+use crate::{
+    moqt::MoqtManager,
+    publisher::{IngestOptions, MediaPublisher},
+};
 
 const DEFAULT_NAMESPACE: &str = "srt/live";
 const ACCESS_CONTROL_PREFIX: &str = "#!::";
 
-pub async fn run_srt_listener(addr: String, moqt_url: Option<String>) -> Result<()> {
+pub async fn run_srt_listener(addr: String, options: IngestOptions) -> Result<()> {
     let (_listener, mut incoming) = SrtListener::builder()
         .bind(addr.as_str())
         .await
         .with_context(|| format!("bind SRT listener on {addr}"))?;
     tracing::info!(%addr, "SRT listener started");
     while let Some(request) = incoming.incoming().next().await {
-        task::spawn(handle_request(request, MoqtManager::new(moqt_url.clone())));
+        task::spawn(handle_request(request, options.clone()));
     }
     Ok(())
 }
 
-async fn handle_request(request: ConnectionRequest, moqt: MoqtManager) {
+async fn handle_request(request: ConnectionRequest, options: IngestOptions) {
     let stream_id = request.stream_id().map(ToString::to_string);
     let namespace = namespace_from_stream_id(stream_id.as_deref());
     let remote = request.remote();
     tracing::info!(%remote, ?stream_id, namespace = %namespace.join("/"), "SRT publisher connected");
-    match publish(request, moqt, namespace).await {
+    match publish(request, &options, namespace).await {
         Ok(packets) => tracing::info!(%remote, packets, "SRT stream ended"),
         Err(err) => tracing::warn!(%remote, ?err, "SRT publisher failed"),
     }
@@ -34,12 +37,16 @@ async fn handle_request(request: ConnectionRequest, moqt: MoqtManager) {
 
 async fn publish(
     request: ConnectionRequest,
-    moqt: MoqtManager,
+    options: &IngestOptions,
     namespace: Vec<String>,
 ) -> Result<u64> {
     let mut socket = request.accept(None).await?;
     let mut demuxer = mpegts::Demuxer::new();
-    let mut publisher = MediaPublisher::new(moqt, namespace);
+    let mut publisher = MediaPublisher::new(
+        MoqtManager::new(options.moqt_url.clone()),
+        namespace,
+        options.transcode,
+    );
     let mut packets = 0_u64;
     while let Some(packet) = socket.next().await {
         let (_, data) = packet?;


### PR DESCRIPTION
## 概要
#354 の transcode crate を live-ingest に組み込み、`--transcode` を付けると元映像より下の画質（720p/480p/360p）を `video_<height>p` track として同じ namespace に publish します。
catalog は登録された映像 track から組み立てるようにし、全映像 track に `codec` / `width` / `height` を入れて 1 つの `altGroup` にまとめます。stacked PR（base: `claude/transcode`）です。

## やったこと
- `MediaPublisher` が元映像の `VideoConfig` を受けた時点で SPS からラダーを決め、`RenditionFanout` を起動。blocking スレッドが `TranscodeInput` にサンプルを流し、async task が画質ごとの `MediaEvent` を publish する
- `moqt.rs` の catalog を `video_tracks`（track 名 → codec/width/height/label）駆動にし、登録済みの映像 track なら SUBSCRIBE を受理する
- `IngestOptions` で MoQT URL と `--transcode` を RTMP/SRT listener へ配線。Makefile は `LIVE_INGEST_TRANSCODE=1` で有効化

```mermaid
flowchart LR
    SRC["source VideoSample"] --> PUB["MediaPublisher"] --> V["track video"]
    PUB --> Q["mpsc queue"] --> FEED["blocking feeder"] --> TC["Transcoder"]
    TC --> R1["track video_480p"]
    TC --> R2["track video_360p"]
```

## やらないこと
- 元 keyframe と rendition の GOP 整合、ハードウェアエンコーダ、音声の再エンコード（#354 と同じ）
- `--transcode` 無効時のビルドから GStreamer を外すこと

## 影響範囲
`bridges/live-ingest` と Makefile。`--transcode` を付けない場合の publish 内容は変わらないが、catalog の `video` track に `width` / `height` が入り、`altGroup` は映像 track が 2 本以上のときだけ付く。live-ingest のビルドに GStreamer が必要になる。

## テスト
- `cargo test -p moqt-bridge-live-ingest`（5 件）、`cargo clippy -p moqt-bridge-live-ingest --all-targets -- -D warnings`、`cargo fmt --check`
- relay + live-ingest `--transcode` + ffmpeg 1280x720（RTMP / SRT 各 10 秒）を moq-cli で購読: `video_480p` 854x480・`video_360p` 640x360 とも 180 フレームをデコード、pts は元映像と同じタイムライン、catalog は `video` / `video_360p` / `video_480p` が `altGroup=1` で codec・解像度付き

## 備考
E2E 中に relay 側の timing 依存の取りこぼしに当たりました（上流 SUBSCRIBE_OK の直後に届く最初の group が購読者に届かず、`accept_data_receiver` が待ち続ける）。この PR とは独立の relay の問題なので別途報告します。
