### PR TITLE
fix(relay): Start Location より大きい id の最初の group が egress に配信されない不具合を修正する

### DIFF
--- a/architecture_decision_record/relay/architecture.md
+++ b/architecture_decision_record/relay/architecture.md
@@ -229,7 +229,12 @@ keeps one runner per `(subscriber_session_id, downstream_subscribe_id)`
   computes the delivery start per draft-14 filter type (`NextGroupStart`,
   `LargestObject`, `AbsoluteStart`, `AbsoluteRange`; an absolute start at or
   below Largest is clamped to Largest+1), and emits one `GroupSendTask` per
-  `SubgroupKey`.
+  `SubgroupKey`. It subscribes to open events first and then schedules every
+  cached group at or after the start, so a group that ingress opened and
+  closed before the scheduler existed is still delivered. The start is a
+  lower bound in both paths: group ids may begin anywhere and skip values
+  (§2.3.1), so the first delivered group is the first one at or above the
+  start, not the start group itself.
 - `GroupSender` — one task per subgroup: waits for the first object to send,
   only then opens the downstream uni stream (a subgroup that closes empty
   opens nothing), regenerates the SUBGROUP_HEADER from that object's canonical
@@ -263,6 +268,9 @@ keeps one runner per `(subscriber_session_id, downstream_subscribe_id)`
   `UpstreamCreationSerializer` per-track lock with a double-check.
 - **SUBSCRIBE_OK matches egress**: the largest location advertised downstream
   is the same value the egress scheduler starts from.
+- **Start Location is a lower bound**: egress delivers the first group at or
+  above the start whether it arrives as an open event or is already cached;
+  neither path requires the start group id itself to exist.
 - **First-publisher-wins ingress**: one active reader per track; stop is
   owner-checked.
 - **Cache identity is the key**: a cached object is self-contained (§8.1 "MUST

--- a/relay/src/modules/relay/cache/track_cache.rs
+++ b/relay/src/modules/relay/cache/track_cache.rs
@@ -150,8 +150,13 @@ impl TrackCache {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn has_group(&self, group_id: u64) -> bool {
         self.read().has_group(group_id)
+    }
+
+    pub(crate) fn groups_at_or_after(&self, group_id: u64) -> Vec<u64> {
+        self.read().groups_in_range(group_id, u64::MAX)
     }
 
     pub(crate) fn subgroups_in_group(&self, group_id: u64) -> BTreeSet<SubgroupKey> {
@@ -479,17 +484,6 @@ mod tests {
         assert!(!cache.is_malformed());
         let key = SubgroupKey::Datagram { group_id: 0 };
         assert!(cache.read().next_subgroup_object(key, 0).is_some());
-    }
-
-    #[test]
-    fn has_group_is_true_for_a_known_group_without_objects() {
-        // Arrange: a subgroup opened and closed without objects, so the group is
-        // known complete but holds nothing
-        let cache = TrackCache::new();
-        insert_closed_group(&cache, 0, &[]);
-        // Act / Assert: the scheduler's consecutive-group walk must not stop here
-        assert!(cache.has_group(0));
-        assert!(!cache.has_group(1));
     }
 
     #[test]

--- a/relay/src/modules/relay/cache/track_cache/ledger.rs
+++ b/relay/src/modules/relay/cache/track_cache/ledger.rs
@@ -110,6 +110,7 @@ impl Ledger {
         self.live_groups.contains_key(&group_id)
     }
 
+    #[cfg(test)]
     pub(super) fn has_group(&self, group_id: u64) -> bool {
         self.next_group_object(group_id, 0).is_some()
             || self.has_open_subgroup_in_group(group_id)

--- a/relay/src/modules/relay/egress/scheduler.rs
+++ b/relay/src/modules/relay/egress/scheduler.rs
@@ -150,9 +150,9 @@ impl EgressScheduler {
         }
     }
 
-    /// Re-schedules consecutive cached groups after `group_id`, recovering
-    /// groups whose open events were lost to receiver lag. Duplicates are
-    /// filtered by the `scheduled` set.
+    /// Re-schedules cached groups after `group_id`, recovering groups whose
+    /// open events were lost to receiver lag. Duplicates are filtered by the
+    /// `scheduled` set.
     async fn recover_lagged_groups(&self, group_id: u64, scheduled: &mut HashSet<SubgroupKey>) {
         if matches!(self.group_order, GroupOrder::Descending) {
             return;
@@ -167,8 +167,11 @@ impl EgressScheduler {
         .await;
     }
 
-    /// Schedules consecutive cached groups starting at the filter Start
-    /// Location.
+    /// Schedules every cached group at or after the filter Start Location.
+    ///
+    /// The Start Location is a lower bound (§9.7), not a group that has to
+    /// exist: group ids may start anywhere and skip values (§2.3.1), so the
+    /// first cached group can lie above the start group.
     ///
     /// With starts clamped to the subscribe-time Largest Object this never
     /// replays the past; what it covers is delivery that events cannot:
@@ -180,20 +183,18 @@ impl EgressScheduler {
         start: &moqt::Location,
         scheduled: &mut HashSet<SubgroupKey>,
     ) {
-        let mut next = start.group_id;
-        while self.cache.has_group(next) {
-            let object_id = if next == start.group_id {
+        for group_id in self.cache.groups_at_or_after(start.group_id) {
+            let object_id = if group_id == start.group_id {
                 start.object_id
             } else {
                 0
             };
-            for key in self.cache.subgroups_in_group(next) {
+            for key in self.cache.subgroups_in_group(group_id) {
                 let _ = self.schedule(key, object_id, scheduled).await;
             }
             if matches!(self.group_order, GroupOrder::Descending) {
                 return;
             }
-            next += 1;
         }
     }
 
@@ -360,6 +361,55 @@ mod tests {
             .await
             .expect("a task should be scheduled");
         assert_eq!(task.key, stream_key(5));
+    }
+
+    // The cached counterpart of the event case above: a first group that was
+    // ingested before the scheduler subscribed to open events is only
+    // reachable through the cache, and its id need not be the start group.
+    #[tokio::test]
+    async fn start_location_is_lower_bound_for_first_cached_group() {
+        // Arrange: no content at subscribe time, group 5 already cached and closed
+        let cache = Arc::new(TrackCache::new());
+        insert_closed_group(&cache, 5, &[0]);
+        // Act
+        let mut scheduler = start_scheduler(cache, FilterType::NextGroupStart, None).await;
+        // Assert
+        let task = scheduler
+            .task_receiver
+            .recv()
+            .await
+            .expect("a task should be scheduled");
+        assert_eq!(
+            task,
+            GroupSendTask {
+                key: stream_key(5),
+                object_id: 0
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn next_group_start_schedules_cached_groups_across_a_group_id_gap() {
+        // Arrange: group 3 holds the Largest Object; the publisher skipped to group 7
+        let cache = Arc::new(TrackCache::new());
+        insert_closed_group(&cache, 3, &[0]);
+        insert_closed_group(&cache, 7, &[0]);
+        // Act
+        let mut scheduler =
+            start_scheduler(cache, FilterType::NextGroupStart, Some(location(3, 0))).await;
+        // Assert
+        let task = scheduler
+            .task_receiver
+            .recv()
+            .await
+            .expect("a task should be scheduled");
+        assert_eq!(
+            task,
+            GroupSendTask {
+                key: stream_key(7),
+                object_id: 0
+            }
+        );
     }
 
     #[tokio::test]

--- a/relay/src/modules/relay/tests/data_plane.rs
+++ b/relay/src/modules/relay/tests/data_plane.rs
@@ -46,6 +46,42 @@ async fn egress_start_racing_ingest_burst_delivers_all_objects() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn next_group_start_delivers_a_first_group_with_nonzero_id_cached_before_egress_started() {
+    const FIRST_GROUP_ID: u64 = 1_757_300_000_000_000;
+
+    let harness = RelayHarness::new();
+    let no_content_before_subscribe = None;
+
+    let upstream_stream = harness.open_upstream_stream().await;
+    upstream_stream.header(FIRST_GROUP_ID);
+    upstream_stream.object(0);
+    upstream_stream.fin();
+    harness
+        .wait_largest_location(moqt::Location {
+            group_id: FIRST_GROUP_ID,
+            object_id: 0,
+        })
+        .await;
+
+    let mut egress = harness
+        .start_egress_with_filter(
+            moqt::FilterType::NextGroupStart,
+            no_content_before_subscribe,
+        )
+        .await;
+
+    let objects = receive_objects_until_close(&mut egress).await;
+    assert!(
+        matches!(
+            objects.first(),
+            Some(DataObject::SubgroupHeader(header)) if header.group_id == FIRST_GROUP_ID
+        ),
+        "downstream stream should start with the first group's subgroup header"
+    );
+    assert_eq!(resolve_downstream_object_ids(&objects), vec![0]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn egress_started_with_pre_subscribe_snapshot_delivers_head_objects_cached_mid_burst() {
     const IN_FLIGHT_BEFORE_EGRESS_START: usize = 10;
 

--- a/relay/src/modules/relay/tests/harness.rs
+++ b/relay/src/modules/relay/tests/harness.rs
@@ -24,7 +24,7 @@ pub(crate) use self::mocks::downstream_client::Sent;
 pub(crate) use self::fixtures::data_object::ordered_payload;
 
 use self::{
-    fixtures::subscription::make_largest_object_subscription,
+    fixtures::subscription::make_subscription,
     mocks::{
         downstream_client::{MockPublisher, SentPublishDone},
         upstream_client::UpstreamSubgroupStream,
@@ -138,6 +138,15 @@ impl RelayHarness {
         &self,
         largest_location: Option<moqt::Location>,
     ) -> EgressRunnerHandle {
+        self.start_egress_with_filter(moqt::FilterType::LargestObject, largest_location)
+            .await
+    }
+
+    pub(crate) async fn start_egress_with_filter(
+        &self,
+        filter_type: moqt::FilterType,
+        largest_location: Option<moqt::Location>,
+    ) -> EgressRunnerHandle {
         let (publisher, observers) = MockPublisher::channel();
         let (ready_sender, ready_receiver) = oneshot::channel();
         let runner = EgressRunner::new(
@@ -145,7 +154,7 @@ impl RelayHarness {
             self.cache_store.get_or_create(&self.track_key),
             self.notify_map.get_or_create(&self.track_key),
             Box::new(publisher),
-            make_largest_object_subscription(),
+            make_subscription(filter_type),
             ready_sender,
             largest_location,
         );

--- a/relay/src/modules/relay/tests/harness/fixtures/subscription.rs
+++ b/relay/src/modules/relay/tests/harness/fixtures/subscription.rs
@@ -1,6 +1,6 @@
 use crate::modules::core::subscription::DownstreamSubscription;
 
-pub(crate) fn make_largest_object_subscription() -> DownstreamSubscription {
+pub(crate) fn make_subscription(filter_type: moqt::FilterType) -> DownstreamSubscription {
     DownstreamSubscription::from(moqt::Subscription::SubscriberInitiated(
         moqt::SubscriberInitiatedSubscription {
             request_id: 0,
@@ -10,7 +10,7 @@ pub(crate) fn make_largest_object_subscription() -> DownstreamSubscription {
             expires: 0,
             group_order: moqt::GroupOrder::Ascending,
             content_exists: moqt::ContentExists::False,
-            filter_type: moqt::FilterType::LargestObject,
+            filter_type,
             delivery_timeout: None,
         },
     ))


### PR DESCRIPTION
## 概要

live-ingest → relay → moq-cli の構成で、subscriber が `catalog` を SUBSCRIBE すると SUBSCRIBE_OK は返るのに最初の group（catalog snapshot）が届かず、`accept_data_receiver()` で永久に待つことがありました。
原因は `EgressScheduler` の cache 走査が「Start Location の group id がそのまま cache に存在する」ことを前提にしていたことで、Start Location を draft-14 §9.7 どおり下限として扱うよう修正します。

## 関連タスク

- 過去の類似修正: #321（SUBSCRIBE 前 snapshot）

## やったこと

- 原因: `EgressScheduler::schedule_cached_objects` は `start.group_id` から `has_group` が真の間だけ連続して歩いていた。content なしの SUBSCRIBE では start が `{0, 0}` になるため、scheduler が open イベントを購読する前に ingest が読み終えた最初の group は、その id が 0 でない（`TrackWriter` の時刻シード採番や Largest Object 以降の id の飛び）と一度も schedule されない。open イベントは既に broadcast 済みなので、下流は次の group を待ち続ける。
- 修正: `TrackCache::groups_at_or_after` を追加し、Start Location 以上の cache 済み group をすべて schedule する。イベント経路の `StartLocationProgress` と同じ下限セマンティクスになる。
- テスト: in-process data-plane ハーネスに「id が 0 でない group を egress 起動前に ingest 済み・NextGroupStart・content なし」で配信されることを assert する回帰テストを追加。scheduler の単体テストに「最初の cache 済み group が start より上」「Largest Object 以降の group id の飛び」の 2 ケースを追加。

## やらないこと

- 既存 upstream に相乗りする 2 番目以降の subscriber が、catalog が cache に入った後に NextGroupStart で SUBSCRIBE した場合は、仕様どおり Largest の次の group から配信されるため catalog は届かない（FETCH または別 filter の領域）。
- `recover_lagged_groups` も同じ走査を使うため group id の飛びを越えて回復するようになるが、Descending order の扱いは従来どおり最初の group のみ。

## 影響範囲

- `relay` のみ。

## テスト

- `cargo test -p relay` → 174 passed / 0 failed（修正前は追加した回帰テストが `egress stalled without closing after sending 0 objects` で失敗）
- `cargo clippy -p relay --all-targets` warning なし、`cargo fmt --check -p relay` 差分なし
- data_plane テストモジュールを 5 回連続実行し全て pass
