### PR TITLE
fix(live-ingest): UNSUBSCRIBE 後に送信を続けて SRT 接続が切れる問題を修正する

### DIFF
--- a/bridges/live-ingest/src/moqt.rs
+++ b/bridges/live-ingest/src/moqt.rs
@@ -13,7 +13,7 @@ use media_streaming_format::{
 use mediapack::h264::AvcDecoderConfigurationRecord;
 use moqt::{
     ClientConfig, ContentExists, Endpoint, QUIC, Session, SessionEvent, TrackWriter,
-    TransportProtocol, WEBTRANSPORT,
+    TransportProtocol, TransportSendError, WEBTRANSPORT,
 };
 use tokio::sync::Mutex;
 
@@ -37,6 +37,7 @@ struct ManagerState {
 struct BackendState<T: TransportProtocol> {
     announced_namespaces: HashSet<String>,
     tracks: HashMap<(String, String), Option<TrackWriter<T>>>,
+    subscribed_tracks: HashMap<u64, (String, String)>,
     catalogs: HashMap<String, CatalogMetadata>,
     disconnected: bool,
 }
@@ -46,6 +47,7 @@ impl<T: TransportProtocol> Default for BackendState<T> {
         Self {
             announced_namespaces: HashSet::new(),
             tracks: HashMap::new(),
+            subscribed_tracks: HashMap::new(),
             catalogs: HashMap::new(),
             disconnected: false,
         }
@@ -338,6 +340,7 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                             }
                         };
 
+                        let request_id = handler.request_id();
                         let publication = handler.into_subscription(track_alias);
                         let should_send_catalog = track_name == CATALOG_TRACK_NAME;
                         let writer = TrackWriter::new(
@@ -346,9 +349,9 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                         );
                         let mut guard = state.lock().await;
                         guard.catalogs.entry(namespace.clone()).or_default();
-                        guard
-                            .tracks
-                            .insert((namespace.clone(), track_name.clone()), Some(writer));
+                        let key = (namespace.clone(), track_name.clone());
+                        guard.tracks.insert(key.clone(), Some(writer));
+                        guard.subscribed_tracks.insert(request_id, key);
                         drop(guard);
                         tracing::info!(%namespace, %track_name, track_alias, "SUBSCRIBE accepted");
                         if should_send_catalog
@@ -358,7 +361,17 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                         }
                     }
                     SessionEvent::Unsubscribe(handler) => {
-                        tracing::info!(request_id = %handler.subscribe_id(), "UNSUBSCRIBE received");
+                        let request_id = handler.subscribe_id();
+                        let mut guard = state.lock().await;
+                        match guard.subscribed_tracks.remove(&request_id) {
+                            Some(key) => {
+                                guard.tracks.remove(&key);
+                                tracing::info!(request_id, namespace = %key.0, track_name = %key.1, "UNSUBSCRIBE received; track released");
+                            }
+                            None => {
+                                tracing::warn!(request_id, "UNSUBSCRIBE for unknown request");
+                            }
+                        }
                     }
                     SessionEvent::UnsubscribeNamespace(handler) => {
                         tracing::info!(prefix = %handler.track_namespace_prefix(), "UNSUBSCRIBE_NAMESPACE received");
@@ -432,6 +445,13 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
             }
         };
         let result = write_object(&mut writer, rotate_group, payload).await;
+        if let Err(error) = &result
+            && is_stopped_by_peer(error)
+        {
+            tracing::info!(namespace = %key.0, track_name = %key.1, "subscriber stopped the track");
+            self.state.lock().await.tracks.remove(&key);
+            return Ok(());
+        }
         if let Some(slot) = self.state.lock().await.tracks.get_mut(&key) {
             *slot = Some(writer);
         }
@@ -690,8 +710,37 @@ fn channel_config_label(channels: u8) -> String {
     }
 }
 
+fn is_stopped_by_peer(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<TransportSendError>(),
+            Some(TransportSendError::Stopped { .. } | TransportSendError::InvalidStopped { .. })
+        )
+    })
+}
+
 pub(crate) fn now_unix() -> Duration {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_stop_sending_through_context_layers() {
+        // Arrange
+        let stopped = anyhow::Error::new(TransportSendError::InvalidStopped { code: 0 })
+            .context("send subgroup object");
+        let lost = anyhow::Error::new(TransportSendError::ConnectionLost {
+            reason: "timeout".into(),
+        })
+        .context("send subgroup object");
+
+        // Act / Assert
+        assert!(is_stopped_by_peer(&stopped));
+        assert!(!is_stopped_by_peer(&lost));
+    }
 }


### PR DESCRIPTION
## 概要
購読者が UNSUBSCRIBE を送ると、publisher は次の object をすでに読むのをやめた stream に書き込み、`invalid stop sending code: 0` で SRT の ingest 接続ごと切断されていました。
UNSUBSCRIBE を受けた track の `TrackWriter` を破棄し、送信時の peer stop も同じ扱いにします。

## やったこと
- `Subscribe` 受理時に request id と track の対応を記録し、`Unsubscribe` でその track の writer を破棄する（以後その track への送信は購読前と同じ no-op になる）
- 送信が `TransportSendError::Stopped` / `InvalidStopped` で失敗した場合も writer を破棄してエラーにしない（UNSUBSCRIBE 処理と送信の競合時の受け皿）

## 影響範囲
`bridges/live-ingest` のみ。`invalid stop sending code: 0` は quinn が受信 stream の drop 時に STOP_SENDING(0) を自動送出するためで、moqt / relay 側の変更は不要。

## テスト
- `cargo test -p moqt-bridge-live-ingest`（6 件。`is_stopped_by_peer` が context 付きの `Stopped` / `InvalidStopped` を判定し、`ConnectionLost` は判定しないことを確認）、clippy `-D warnings`、fmt
- relay + live-ingest + SRT 配信で購読者を配信中に落とし、ingest が生存し続けることを確認

## 備考
UNSUBSCRIBE 自体の E2E 再現はできていません。moq-cli は UNSUBSCRIBE を送らず、購読者を強制終了しても relay は上流 subscription を維持するためです。判定はユニットテストとコード読みに依ります。
