### PR TITLE
feat(wasm): Live Viewer example を追加し、トップページを Low Level demo と Usecases に分ける

### DIFF
--- a/examples/browser/examples/live-viewer/README.md
+++ b/examples/browser/examples/live-viewer/README.md
@@ -1,0 +1,35 @@
+# live-viewer
+
+`bridges/live-ingest` が RTMP / SRT から MoQT へ流した配信を視聴します。catalog に載っている映像
+track を切り替えられるので、`--transcode` で生成した下位画質（`video_480p` / `video_360p`）の確認にも
+使えます。
+
+## 使い方
+
+```shell
+make relay
+make live-ingest            # LIVE_INGEST_TRANSCODE=1 で下位画質も配信する
+make ffmpeg-rtmp            # または make ffmpeg-srt
+make browser
+make chrome                 # 自己署名証明書の relay に接続するため
+```
+
+Chrome で `examples/live-viewer/index.html` を開き、relay URL と namespace（RTMP は `app/stream`、
+SRT は stream ID）を入れて Watch を押します。`?moqtUrl=...&trackNamespace=...` でも指定できます。
+
+## ペイロード形式
+
+live-ingest は各 object を `[meta_len (u32 BE)][meta JSON][coded data]` で送り、ブラウザ publisher は
+coded data のみを送って metadata を MoQT の LOC 拡張ヘッダに載せます。`utils/media/ingestChunk.ts` が
+両方を受け付け、前者は JSON を外して capture timestamp を LOC ヘッダ相当に変換します。
+
+## E2E
+
+relay・live-ingest・配信元・dev server が動いている状態で実行します。
+
+```shell
+MEDIA_E2E_BASE_URL=http://127.0.0.1:5173 \
+MEDIA_E2E_MOQT_URL=https://127.0.0.1:4433 \
+LIVE_VIEWER_E2E_NAMESPACE=live \
+npm --prefix examples/browser run e2e:live-viewer
+```

--- a/examples/browser/examples/live-viewer/index.html
+++ b/examples/browser/examples/live-viewer/index.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MoQT Live Viewer</title>
+    <link rel="stylesheet" href="../media/media.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="hero">
+        <div>
+          <span class="pill">Live Viewer</span>
+          <h1>MoQT Live Viewer</h1>
+          <p>RTMP / SRT から live-ingest bridge が配信した映像を、画質を切り替えながら視聴します。</p>
+        </div>
+      </header>
+      <div id="app">
+        <div class="control-grid subscriber-grid">
+          <section class="card stack">
+            <h2>Stream</h2>
+            <label for="url">Relay URL:</label>
+            <input type="url" id="url" value="https://127.0.0.1:4433" data-testid="live-viewer-url-input" />
+            <div id="urlPresets" class="preset-bar">Preset:</div>
+            <label for="namespace"
+              >Track Namespace:
+              <input type="text" id="namespace" value="live/test" data-testid="live-viewer-namespace-input" />
+            </label>
+            <p class="hint">RTMP は <code>app/stream</code>、SRT は stream ID がそのまま namespace になります。</p>
+            <div class="button-row">
+              <button type="button" id="watchBtn" data-testid="live-viewer-watch-button">Watch</button>
+              <button type="button" id="stopBtn" data-testid="live-viewer-stop-button">Stop</button>
+            </div>
+          </section>
+
+          <section class="card stack">
+            <h2>Status</h2>
+            <div class="status-list">
+              <div class="status-item">
+                <span class="status-label">Connection</span>
+                <span id="connection-status" class="status-value" data-testid="live-viewer-connection-status">
+                  Not connected
+                </span>
+              </div>
+              <div class="status-item">
+                <span class="status-label">Catalog</span>
+                <span id="catalog-status" class="status-value" data-testid="live-viewer-catalog-status">
+                  Catalog not loaded yet
+                </span>
+              </div>
+              <div class="status-item">
+                <span class="status-label">Playback</span>
+                <span id="playback-status" class="status-value" data-testid="live-viewer-playback-status">
+                  Playback idle
+                </span>
+              </div>
+            </div>
+          </section>
+
+          <section class="card stack">
+            <h2>Quality</h2>
+            <label for="video-track"
+              >Video track:
+              <select id="video-track" data-testid="live-viewer-video-track-select"></select>
+            </label>
+            <p class="hint">live-ingest を <code>--transcode</code> で起動すると下位画質が選べます。</p>
+            <label for="audio-track"
+              >Audio track:
+              <select id="audio-track" data-testid="live-viewer-audio-track-select"></select>
+            </label>
+            <label class="field-row">
+              <input type="checkbox" id="bypass-jitter-buffer" checked />
+              Bypass jitter buffer (lowest latency)
+            </label>
+          </section>
+
+          <section class="card stack full">
+            <div class="card-title-row">
+              <h2>Playback</h2>
+              <div class="playback-meta">
+                <span id="video-stats" data-testid="live-viewer-video-stats">-</span>
+              </div>
+            </div>
+            <div class="media-grid">
+              <div class="playback-panel">
+                <video id="video" playsinline muted autoplay data-testid="live-viewer-video"></video>
+                <audio id="audio" autoplay data-testid="live-viewer-audio"></audio>
+              </div>
+            </div>
+          </section>
+
+          <section class="card stack full">
+            <h2>Console</h2>
+            <div id="logPanel" data-testid="live-viewer-log-panel"></div>
+          </section>
+        </div>
+      </div>
+    </div>
+    <script type="module" src="../../utils/preserveQueryLinks.js"></script>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/examples/browser/examples/live-viewer/main.ts
+++ b/examples/browser/examples/live-viewer/main.ts
@@ -1,0 +1,310 @@
+import { MoqtClientWrapper } from '@moqt/moqtClient'
+import { parse_msf_catalog_json } from '../../pkg/moqt_client_wasm'
+import { parseIngestChunk } from '../../utils/media/ingestChunk'
+import {
+  MEDIA_CATALOG_TRACK_NAME,
+  extractCatalogAudioTracks,
+  extractCatalogVideoTracks,
+  type MediaCatalogTrack
+} from '../media/catalog'
+import { getErrorMessage, initializeMediaExamplePage, parseTrackNamespace, setStatusText } from '../media/common'
+
+const AUTH_INFO = 'secret'
+const ANNEX_B_FORMAT = 'annexb'
+
+type MediaKind = 'video' | 'audio'
+
+type TrackSubscription = {
+  requestId: bigint
+  trackAlias: bigint
+  name: string
+}
+
+const moqtClient = new MoqtClientWrapper()
+const videoDecoderWorker = new Worker(new URL('../../utils/media/decoders/videoDecoder.ts', import.meta.url), {
+  type: 'module'
+})
+const audioDecoderWorker = new Worker(new URL('../../utils/media/decoders/audioDecoder.ts', import.meta.url), {
+  type: 'module'
+})
+
+let videoTracks: MediaCatalogTrack[] = []
+let audioTracks: MediaCatalogTrack[] = []
+const subscriptions = new Map<MediaKind, TrackSubscription>()
+let videoWriter: WritableStreamDefaultWriter<VideoFrame> | undefined
+let audioWriter: WritableStreamDefaultWriter<AudioData> | undefined
+let videoObjectCount = 0
+let receivedKbps = 0
+
+initializeMediaExamplePage('namespace')
+element<HTMLButtonElement>('watchBtn').addEventListener('click', () => void watchStream())
+element<HTMLButtonElement>('stopBtn').addEventListener('click', () => void stopStream())
+element<HTMLSelectElement>('video-track').addEventListener('change', () => void resubscribe('video'))
+element<HTMLSelectElement>('audio-track').addEventListener('change', () => void resubscribe('audio'))
+element<HTMLInputElement>('bypass-jitter-buffer').addEventListener('change', applyDecoderConfig)
+startRendering()
+
+async function watchStream(): Promise<void> {
+  try {
+    await stopStream()
+    const url = element<HTMLInputElement>('url').value.trim()
+    await moqtClient.connect(url)
+    setStatusText('connection-status', `Connected: ${url}`)
+    appendLog('info', `connected to ${url}`)
+    await subscribeCatalog()
+  } catch (error) {
+    setStatusText('connection-status', `Failed: ${getErrorMessage(error)}`)
+    appendLog('error', getErrorMessage(error))
+  }
+}
+
+async function stopStream(): Promise<void> {
+  for (const kind of subscriptions.keys()) {
+    await unsubscribeTrack(kind)
+  }
+  videoTracks = []
+  audioTracks = []
+  renderTrackOptions()
+  videoObjectCount = 0
+  if (moqtClient.getConnectionStatus()) {
+    await moqtClient.disconnect()
+  }
+  setStatusText('connection-status', 'Not connected')
+  setStatusText('catalog-status', 'Catalog not loaded yet')
+  setStatusText('playback-status', 'Playback idle')
+}
+
+async function subscribeCatalog(): Promise<void> {
+  const namespace = trackNamespace()
+  const { subscribeOk } = await moqtClient.subscribe(namespace, MEDIA_CATALOG_TRACK_NAME, AUTH_INFO, {
+    forward: true
+  })
+  moqtClient.setOnSubgroupObjectHandler(subscribeOk.trackAlias, (_groupId, object) => {
+    const { data } = parseIngestChunk(new Uint8Array(object.objectPayload))
+    if (data.byteLength === 0) {
+      return
+    }
+    void applyCatalog(new TextDecoder().decode(data))
+  })
+  appendLog('info', `subscribed ${namespace.join('/')}/${MEDIA_CATALOG_TRACK_NAME}`)
+}
+
+async function applyCatalog(payload: string): Promise<void> {
+  try {
+    const catalog = parse_msf_catalog_json(payload)
+    videoTracks = extractCatalogVideoTracks(catalog)
+    audioTracks = extractCatalogAudioTracks(catalog)
+    setStatusText('catalog-status', `Catalog loaded: ${videoTracks.length} video / ${audioTracks.length} audio`)
+    const changed = renderTrackOptions()
+    if (changed) {
+      await resubscribe('video')
+      await resubscribe('audio')
+    }
+  } catch (error) {
+    setStatusText('catalog-status', `Catalog error: ${getErrorMessage(error)}`)
+    appendLog('error', `catalog: ${getErrorMessage(error)}`)
+  }
+}
+
+function renderTrackOptions(): boolean {
+  const videoChanged = fillSelect(element<HTMLSelectElement>('video-track'), videoTracks, describeVideoTrack)
+  const audioChanged = fillSelect(element<HTMLSelectElement>('audio-track'), audioTracks, (track) => track.label)
+  return videoChanged || audioChanged
+}
+
+function fillSelect(
+  select: HTMLSelectElement,
+  tracks: MediaCatalogTrack[],
+  describe: (track: MediaCatalogTrack) => string
+): boolean {
+  const names = tracks.map((track) => track.name)
+  const current = Array.from(select.options).map((option) => option.value)
+  if (names.length === current.length && names.every((name, index) => name === current[index])) {
+    return false
+  }
+
+  const selected = select.value
+  select.replaceChildren(
+    ...tracks.map((track) => {
+      const option = document.createElement('option')
+      option.value = track.name
+      option.textContent = describe(track)
+      return option
+    })
+  )
+  select.value = names.includes(selected) ? selected : (names[0] ?? '')
+  return true
+}
+
+function describeVideoTrack(track: MediaCatalogTrack): string {
+  const resolution = track.width && track.height ? ` (${track.width}x${track.height})` : ''
+  return `${track.label}${resolution}`
+}
+
+async function resubscribe(kind: MediaKind): Promise<void> {
+  const select = element<HTMLSelectElement>(kind === 'video' ? 'video-track' : 'audio-track')
+  const trackName = select.value
+  if (subscriptions.get(kind)?.name === trackName) {
+    return
+  }
+
+  await unsubscribeTrack(kind)
+  const track = (kind === 'video' ? videoTracks : audioTracks).find((candidate) => candidate.name === trackName)
+  if (!track) {
+    return
+  }
+
+  postCatalogToDecoder(kind, track)
+  const { requestId, subscribeOk } = await moqtClient.subscribe(trackNamespace(), trackName, AUTH_INFO, {
+    forward: true
+  })
+  subscriptions.set(kind, { requestId, trackAlias: subscribeOk.trackAlias, name: trackName })
+  const worker = kind === 'video' ? videoDecoderWorker : audioDecoderWorker
+  moqtClient.setOnSubgroupObjectHandler(subscribeOk.trackAlias, (groupId, object) => {
+    const chunk = parseIngestChunk(new Uint8Array(object.objectPayload), object.locHeader)
+    if (kind === 'video') {
+      videoObjectCount += 1
+      setStatusText('playback-status', `Playing ${trackName}`)
+    }
+    worker.postMessage(
+      {
+        groupId,
+        subgroupStreamObject: {
+          subgroupId: object.subgroupId,
+          objectIdDelta: object.objectIdDelta,
+          objectPayloadLength: chunk.data.byteLength,
+          objectPayload: chunk.data,
+          objectStatus: object.objectStatus,
+          locHeader: chunk.locHeader
+        }
+      },
+      [chunk.data.buffer]
+    )
+  })
+  appendLog('info', `subscribed ${trackNamespace().join('/')}/${trackName}`)
+}
+
+async function unsubscribeTrack(kind: MediaKind): Promise<void> {
+  const subscription = subscriptions.get(kind)
+  if (!subscription) {
+    return
+  }
+
+  subscriptions.delete(kind)
+  moqtClient.clearSubgroupObjectHandler(subscription.trackAlias)
+  if (moqtClient.getConnectionStatus()) {
+    await moqtClient.unsubscribe(subscription.requestId)
+  }
+  appendLog('info', `unsubscribed ${subscription.name}`)
+}
+
+function postCatalogToDecoder(kind: MediaKind, track: MediaCatalogTrack): void {
+  if (kind === 'video') {
+    videoDecoderWorker.postMessage({
+      type: 'catalog',
+      codec: track.codec,
+      descriptionBase64: track.initData,
+      avcFormat: track.initData ? undefined : ANNEX_B_FORMAT
+    })
+    return
+  }
+  audioDecoderWorker.postMessage({
+    type: 'catalog',
+    codec: track.codec,
+    sampleRate: track.samplerate,
+    channels: channelCount(track.channelConfig),
+    descriptionBase64: track.initData
+  })
+}
+
+function channelCount(channelConfig?: string): number | undefined {
+  if (channelConfig === 'mono') {
+    return 1
+  }
+  if (channelConfig === 'stereo') {
+    return 2
+  }
+  const parsed = Number.parseInt(channelConfig ?? '', 10)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+function applyDecoderConfig(): void {
+  const config = {
+    telemetryEnabled: true,
+    bypassJitterBuffer: element<HTMLInputElement>('bypass-jitter-buffer').checked
+  }
+  videoDecoderWorker.postMessage({ type: 'config', config })
+  audioDecoderWorker.postMessage({ type: 'config', config })
+}
+
+function startRendering(): void {
+  applyDecoderConfig()
+  const videoGenerator = new MediaStreamTrackGenerator({ kind: 'video' })
+  const audioGenerator = new MediaStreamTrackGenerator({ kind: 'audio' })
+  videoWriter = videoGenerator.writable.getWriter()
+  audioWriter = audioGenerator.writable.getWriter()
+  element<HTMLVideoElement>('video').srcObject = new MediaStream([videoGenerator])
+  element<HTMLAudioElement>('audio').srcObject = new MediaStream([audioGenerator])
+
+  videoDecoderWorker.onmessage = async (event) => {
+    if (event.data.type === 'bitrate') {
+      receivedKbps = event.data.kbps ?? receivedKbps
+      return
+    }
+    if (event.data.type !== 'frame') {
+      return
+    }
+    const frame = event.data.frame as VideoFrame
+    updateVideoStats(frame)
+    if (!videoWriter || videoWriter.desiredSize === null || videoWriter.desiredSize <= 0) {
+      frame.close()
+      return
+    }
+    await videoWriter.ready
+    await videoWriter.write(frame)
+    frame.close()
+  }
+
+  audioDecoderWorker.onmessage = async (event) => {
+    if (event.data.type !== 'audioData') {
+      return
+    }
+    const audioData = event.data.audioData as AudioData
+    if (!audioWriter) {
+      audioData.close()
+      return
+    }
+    await audioWriter.ready
+    await audioWriter.write(audioData)
+    audioData.close()
+  }
+}
+
+function updateVideoStats(frame: VideoFrame): void {
+  const stats = element<HTMLSpanElement>('video-stats')
+  stats.textContent = `${frame.displayWidth}x${frame.displayHeight} · ${Math.round(receivedKbps)} kbps · ${videoObjectCount} objects`
+}
+
+function trackNamespace(): string[] {
+  return parseTrackNamespace(element<HTMLInputElement>('namespace').value)
+}
+
+function appendLog(level: 'info' | 'warn' | 'error', message: string): void {
+  const panel = document.getElementById('logPanel')
+  if (!panel) {
+    return
+  }
+
+  const entry = document.createElement('div')
+  entry.className = `log-entry log-${level}`
+  entry.textContent = `${new Date().toLocaleTimeString()} ${message}`
+  panel.prepend(entry)
+}
+
+function element<T extends HTMLElement>(id: string): T {
+  const found = document.getElementById(id)
+  if (!found) {
+    throw new Error(`missing element: ${id}`)
+  }
+  return found as T
+}

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -110,14 +110,30 @@
       .grid .card:nth-child(4) {
         animation-delay: 150ms;
       }
-      .grid .card:nth-child(5) {
-        animation-delay: 200ms;
+
+      .section {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
       }
-      .grid .card:nth-child(6) {
-        animation-delay: 250ms;
+
+      .section-heading {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        flex-wrap: wrap;
       }
-      .grid .card:nth-child(7) {
-        animation-delay: 300ms;
+
+      .section-heading h2 {
+        margin: 0;
+        font-size: 1.35rem;
+        letter-spacing: 0.01em;
+      }
+
+      .section-heading p {
+        margin: 0;
+        color: var(--text-sub);
+        font-size: 0.92rem;
       }
 
       .card:hover {
@@ -131,7 +147,7 @@
         outline-offset: 2px;
       }
 
-      .card h2 {
+      .card h3 {
         margin: 0;
         font-size: 1.08rem;
         line-height: 1.3;
@@ -203,54 +219,74 @@
         <h1>Examples Hub</h1>
         <p>
           MoQ / WebTransport / WebCodecs を使ったサンプル群への入口です。<br />
-          目的別に「シグナリング検証」「送受信デバッグ」「CMAF 配信検証」「ONVIF連携」「通話アプリ」「遠隔監視」「単体
-          WebCodecs テスト」を選べます。
+          プロトコルやコーデックを単体で確かめる Low Level demo と、用途ごとに組み上げた Usecases に分かれています。
         </p>
       </section>
 
-      <section class="grid" aria-label="Examples navigation">
-        <a class="card" href="examples/message/index.html">
-          <span class="tag">Protocol</span>
-          <h2>Message</h2>
-          <p>Setup / Announce / Subscribe など、MoQT 制御メッセージを手動で試す低レイヤ検証ページ。</p>
-          <span class="arrow">Open Example</span>
-        </a>
-        <a class="card" href="examples/media/index.html">
-          <span class="tag">Transport</span>
-          <h2>Media</h2>
-          <p>Publisher / Subscriber を分けて、Media over MoQ の送受信と挙動を個別に確認。</p>
-          <span class="arrow">Open Example</span>
-        </a>
-        <a class="card" href="examples/media-cmaf/index.html">
-          <span class="tag">CMAF</span>
-          <h2>Media CMAF</h2>
-          <p>moof+mdat のフル CMAF パッケージで Publish / Subscribe を試す配信検証ページ。</p>
-          <span class="arrow">Open Example</span>
-        </a>
-        <a class="card" href="examples/onvif/index.html">
-          <span class="tag">ONVIF</span>
-          <h2>ONVIF Viewer</h2>
-          <p>ONVIF 制御と映像視聴を統合。カメラ制御系と RTSP 由来映像の遅延観測に向いています。</p>
-          <span class="arrow">Open Example</span>
-        </a>
-        <a class="card" href="examples/call/index.html">
-          <span class="tag">Application</span>
-          <h2>Call</h2>
-          <p>Catalog / Subscribe 運用や jitter/pacing のチューニングを含む、実運用寄りの通話 UI。</p>
-          <span class="arrow">Open Example</span>
-        </a>
-        <a class="card" href="examples/remote-monitoring/index.html">
-          <span class="tag">Application</span>
-          <h2>Remote Monitoring</h2>
-          <p>複数カメラを監視ルームで一覧表示。publisher / monitor モードを切り替えて多拠点の遠隔監視を検証。</p>
-          <span class="arrow">Open Example</span>
-        </a>
-        <a class="card" href="examples/webcodecs/index.html">
-          <span class="tag">Codec Lab</span>
-          <h2>WebCodecs Loopback</h2>
-          <p>1タブで Encoder/Decoder の設定相性を比較し、MoQ を介さず純粋なコーデック特性を確認。</p>
-          <span class="arrow">Open Example</span>
-        </a>
+      <section class="section" aria-labelledby="low-level-heading">
+        <div class="section-heading">
+          <h2 id="low-level-heading">Low Level demo</h2>
+          <p>プロトコル・パッケージング・コーデックを個別に検証する</p>
+        </div>
+        <div class="grid">
+          <a class="card" href="examples/message/index.html">
+            <span class="tag">Protocol</span>
+            <h3>Message</h3>
+            <p>Setup / Announce / Subscribe など、MoQT 制御メッセージを手動で試す低レイヤ検証ページ。</p>
+            <span class="arrow">Open Example</span>
+          </a>
+          <a class="card" href="examples/media/index.html">
+            <span class="tag">Transport</span>
+            <h3>Media</h3>
+            <p>Publisher / Subscriber を分けて、Media over MoQ の送受信と挙動を個別に確認。</p>
+            <span class="arrow">Open Example</span>
+          </a>
+          <a class="card" href="examples/media-cmaf/index.html">
+            <span class="tag">CMAF</span>
+            <h3>Media CMAF</h3>
+            <p>moof+mdat のフル CMAF パッケージで Publish / Subscribe を試す配信検証ページ。</p>
+            <span class="arrow">Open Example</span>
+          </a>
+          <a class="card" href="examples/webcodecs/index.html">
+            <span class="tag">Codec Lab</span>
+            <h3>WebCodecs Loopback</h3>
+            <p>1タブで Encoder/Decoder の設定相性を比較し、MoQ を介さず純粋なコーデック特性を確認。</p>
+            <span class="arrow">Open Example</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="usecases-heading">
+        <div class="section-heading">
+          <h2 id="usecases-heading">Usecases</h2>
+          <p>用途ごとに組み上げたアプリケーション</p>
+        </div>
+        <div class="grid">
+          <a class="card" href="examples/call/index.html">
+            <span class="tag">Call</span>
+            <h3>Call</h3>
+            <p>Catalog / Subscribe 運用や jitter/pacing のチューニングを含む、実運用寄りの通話 UI。</p>
+            <span class="arrow">Open Example</span>
+          </a>
+          <a class="card" href="examples/onvif/index.html">
+            <span class="tag">ONVIF</span>
+            <h3>Onvif</h3>
+            <p>ONVIF 制御と映像視聴を統合。カメラ制御系と RTSP 由来映像の遅延観測に向いています。</p>
+            <span class="arrow">Open Example</span>
+          </a>
+          <a class="card" href="examples/remote-monitoring/index.html">
+            <span class="tag">Monitoring</span>
+            <h3>Remote Monitoring</h3>
+            <p>複数カメラを監視ルームで一覧表示。publisher / monitor モードを切り替えて多拠点の遠隔監視を検証。</p>
+            <span class="arrow">Open Example</span>
+          </a>
+          <a class="card" href="examples/live-viewer/index.html">
+            <span class="tag">Live</span>
+            <h3>Live Viewer</h3>
+            <p>RTMP / SRT から live-ingest bridge が流した配信を視聴し、画質（rendition）を切り替える。</p>
+            <span class="arrow">Open Example</span>
+          </a>
+        </div>
       </section>
 
       <p class="note">Tip: 低遅延検証では、まず WebCodecs → Media → Call の順で切り分けると原因特定が速くなります。</p>

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -14,7 +14,8 @@
     "e2e:install": "playwright install chromium",
     "e2e:media": "playwright test tests/media-e2e.spec.ts",
     "e2e:call": "playwright test tests/call-e2e.spec.ts",
-    "e2e:message": "playwright test tests/message-e2e.spec.ts"
+    "e2e:message": "playwright test tests/message-e2e.spec.ts",
+    "e2e:live-viewer": "playwright test tests/live-viewer-e2e.spec.ts"
   },
   "keywords": [],
   "author": "",

--- a/examples/browser/playwright.config.ts
+++ b/examples/browser/playwright.config.ts
@@ -16,7 +16,7 @@ const forceQuicOrigins = [
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /(media-e2e|call-e2e|message-e2e)\.spec\.ts/,
+  testMatch: /(media-e2e|call-e2e|message-e2e|live-viewer-e2e)\.spec\.ts/,
   fullyParallel: false,
   workers: 1,
   timeout: 120_000,

--- a/examples/browser/tests/live-viewer-e2e.spec.ts
+++ b/examples/browser/tests/live-viewer-e2e.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const PAGE_PATH = '/moq-wasm/examples/live-viewer/index.html'
+const MOQT_URL = process.env.MEDIA_E2E_MOQT_URL ?? 'https://127.0.0.1:4433'
+const NAMESPACE = process.env.LIVE_VIEWER_E2E_NAMESPACE ?? 'live'
+
+test('live viewer plays the ingested stream and switches renditions', async ({ page }) => {
+  // Arrange
+  await page.goto(`${PAGE_PATH}?moqtUrl=${encodeURIComponent(MOQT_URL)}&trackNamespace=${NAMESPACE}`, {
+    waitUntil: 'domcontentloaded'
+  })
+
+  // Act
+  await page.getByTestId('live-viewer-watch-button').click()
+
+  // Assert
+  await expect(page.getByTestId('live-viewer-connection-status')).toContainText('Connected:')
+  await expect(page.getByTestId('live-viewer-catalog-status')).toContainText(/Catalog loaded: [1-9]/)
+  await expect(page.getByTestId('live-viewer-playback-status')).toContainText('Playing')
+  await expectVideoPlaying(page)
+
+  // Act: 下位画質へ切り替える
+  const select = page.getByTestId('live-viewer-video-track-select')
+  const renditions = await select.locator('option').allInnerTexts()
+  expect(renditions.length).toBeGreaterThan(1)
+  await select.selectOption({ index: 1 })
+
+  // Assert
+  await expect(page.getByTestId('live-viewer-playback-status')).toContainText('video_')
+  await expectVideoPlaying(page)
+})
+
+async function expectVideoPlaying(page: Page): Promise<void> {
+  const video = page.getByTestId('live-viewer-video')
+  await expect
+    .poll(async () => video.evaluate((element) => (element as HTMLVideoElement).readyState), { timeout: 30_000 })
+    .toBeGreaterThanOrEqual(2)
+  await expect
+    .poll(async () => video.evaluate((element) => (element as HTMLVideoElement).videoWidth))
+    .toBeGreaterThan(0)
+}

--- a/examples/browser/utils/media/ingestChunk.ts
+++ b/examples/browser/utils/media/ingestChunk.ts
@@ -1,0 +1,74 @@
+import { type LocHeader } from './loc'
+
+/// The live-ingest bridge prefixes each object with its own metadata:
+/// `[meta_len (u32 BE)][meta JSON][coded data]`. Browser publishers instead send
+/// the coded data alone and carry metadata in MoQT LOC extension headers.
+type IngestChunkMetadata = {
+  type?: string
+  timestamp?: number
+  duration?: number
+  sentAt?: number
+  codec?: string | null
+  descriptionBase64?: string | null
+  sampleRate?: number
+  channels?: number
+}
+
+export type IngestChunk = {
+  data: Uint8Array
+  locHeader?: LocHeader
+  codec?: string
+  descriptionBase64?: string
+  sampleRate?: number
+  channels?: number
+}
+
+const META_LENGTH_BYTES = 4
+const JSON_OBJECT_START = 0x7b
+
+export function parseIngestChunk(payload: Uint8Array, locHeader?: LocHeader): IngestChunk {
+  const metadata = readMetadata(payload)
+  if (!metadata) {
+    return { data: payload, locHeader }
+  }
+
+  const [meta, dataOffset] = metadata
+  return {
+    data: payload.subarray(dataOffset),
+    locHeader: locHeader ?? buildLocHeaderFromMetadata(meta),
+    codec: meta.codec ?? undefined,
+    descriptionBase64: meta.descriptionBase64 ?? undefined,
+    sampleRate: meta.sampleRate,
+    channels: meta.channels
+  }
+}
+
+function readMetadata(payload: Uint8Array): [IngestChunkMetadata, number] | undefined {
+  if (payload.byteLength <= META_LENGTH_BYTES || payload[META_LENGTH_BYTES] !== JSON_OBJECT_START) {
+    return undefined
+  }
+
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength)
+  const metaLength = view.getUint32(0)
+  const dataOffset = META_LENGTH_BYTES + metaLength
+  if (metaLength === 0 || dataOffset > payload.byteLength) {
+    return undefined
+  }
+
+  try {
+    const meta = JSON.parse(new TextDecoder().decode(payload.subarray(META_LENGTH_BYTES, dataOffset)))
+    return [meta as IngestChunkMetadata, dataOffset]
+  } catch (_error) {
+    return undefined
+  }
+}
+
+function buildLocHeaderFromMetadata(meta: IngestChunkMetadata): LocHeader | undefined {
+  if (typeof meta.sentAt !== 'number') {
+    return undefined
+  }
+
+  return {
+    extensions: [{ type: 'captureTimestamp', value: { microsSinceUnixEpoch: Math.round(meta.sentAt * 1000) } }]
+  } as LocHeader
+}

--- a/examples/browser/vite.config.mjs
+++ b/examples/browser/vite.config.mjs
@@ -35,7 +35,8 @@ export default defineConfig({
         onvif: resolve(__dirname, 'examples/onvif/index.html'),
         call: resolve(__dirname, 'examples/call/index.html'),
         webcodecs: resolve(__dirname, 'examples/webcodecs/index.html'),
-        'remote-monitoring': resolve(__dirname, 'examples/remote-monitoring/index.html')
+        'remote-monitoring': resolve(__dirname, 'examples/remote-monitoring/index.html'),
+        'live-viewer': resolve(__dirname, 'examples/live-viewer/index.html')
       }
     }
   }


### PR DESCRIPTION
## 概要
live-ingest が RTMP / SRT から流した配信をブラウザで視聴するページがありませんでした（bridge は object 先頭に JSON で metadata を載せ、既存 demo は LOC 拡張ヘッダ前提のため再生できない）。
Live Viewer example を追加し、あわせてトップページを Low Level demo と Usecases に分けます。

## やったこと
- `examples/live-viewer`: namespace を購読して catalog を読み、共通 decoder worker 経由で映像・音声を再生する 1 ページ構成。`--transcode` で配信された rendition を選択できる
- `utils/media/ingestChunk.ts`: bridge の `[meta_len (u32 BE)][meta JSON][coded data]` と、ブラウザ publisher の生ペイロード + LOC 拡張ヘッダの両方を受け付ける
- トップページを Low Level demo（Message / Media / Media CMAF / WebCodecs Loopback）と Usecases（Call / Onvif / Remote Monitoring / Live Viewer）の 2 セクションに再構成
- Playwright spec `tests/live-viewer-e2e.spec.ts` と `npm run e2e:live-viewer`（relay・live-ingest・配信元が動いている前提。CI は named script のみ実行するので自動では走らない）

## やらないこと
- bridge のペイロード形式を LOC 拡張ヘッダへ統一すること（viewer 側で両対応にした）
- Live Viewer 用の repo レベル E2E ランナー（`scripts/run-*-e2e.mjs` 相当）

## 影響範囲
`examples/browser` のみ。既存 demo の URL は変わらない。

## テスト
- `npm --prefix examples/browser run lint`（tsc）、`npx prettier --check`
- relay + live-ingest `--transcode` + ffmpeg 1280x720 の RTMP 配信に対し `npm run e2e:live-viewer`: 接続・`Catalog loaded: 3 video / 1 audio`・再生（`readyState >= 2`、`videoWidth > 0`）・rendition 切り替え後の再生継続を確認

## 備考
catalog track では end-of-group のステータス object が空ペイロードで届くため、視聴側で読み飛ばしています。
