### PR TITLE
fix(live-ingest): FETCH で event loop が panic するのを修正する

### DIFF
--- a/bridges/live-ingest/src/moqt.rs
+++ b/bridges/live-ingest/src/moqt.rs
@@ -22,6 +22,8 @@ const AUDIO_TRACK_NAME: &str = "audio";
 const CATALOG_TRACK_NAME: &str = "catalog";
 const CHAT_TRACK_NAME: &str = "chat";
 const CHAT_EVENT_TYPE: &str = "com.skyway.chat.v1";
+/// FETCH_ERROR code NOT_SUPPORTED, draft-ietf-moq-transport-14 §13.1.5.
+const FETCH_NOT_SUPPORTED: u64 = 0x3;
 
 #[derive(Clone)]
 pub struct MoqtManager {
@@ -384,8 +386,17 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
                     SessionEvent::Publish(handler) => {
                         tracing::warn!(namespace = %handler.track_namespace, track = %handler.track_name, "unexpected PUBLISH received");
                     }
-                    SessionEvent::Fetch(_) => {
-                        todo!()
+                    SessionEvent::Fetch(handler) => {
+                        let request_id = handler.request_id;
+                        if let Err(err) = handler
+                            .error(
+                                FETCH_NOT_SUPPORTED,
+                                "live ingest does not serve FETCH".to_string(),
+                            )
+                            .await
+                        {
+                            tracing::warn!(request_id, ?err, "failed to reject FETCH");
+                        }
                     }
                     event @ (SessionEvent::GoAway(_)
                     | SessionEvent::MaxRequestId(_)

--- a/bridges/live-ingest/src/publisher.rs
+++ b/bridges/live-ingest/src/publisher.rs
@@ -73,6 +73,9 @@ impl MediaPublisher {
 
     async fn publish_video(&mut self, sample: &VideoSample) -> Result<()> {
         self.setup_namespace().await?;
+        if let Some(renditions) = &self.renditions {
+            renditions.push(sample);
+        }
         let payload = video_payload(sample, self.video_codec.as_deref());
         self.moqt
             .send_object(
@@ -81,11 +84,7 @@ impl MediaPublisher {
                 sample.is_keyframe,
                 payload,
             )
-            .await?;
-        if let Some(renditions) = &self.renditions {
-            renditions.push(sample);
-        }
-        Ok(())
+            .await
     }
 
     async fn publish_audio(&mut self, sample: &AudioSample) -> Result<()> {


### PR DESCRIPTION
## 概要
`SessionEvent::Fetch` が `todo!()` のままで、FETCH を受けると MoQT event loop の task が panic していました。
task は join されないため障害が表に出ず、以後 bridge は制御メッセージに一切応答しません。relay はキャッシュ外の範囲を上流へ転送するので、購読者が巻き戻しを試すだけで bridge が停止します。stacked PR（base: #359）です。

## やったこと
- FETCH に対して `FETCH_ERROR` の `NOT_SUPPORTED`（draft-14 §13.1.5、0x3）を返す

## 影響範囲
`bridges/live-ingest` のみ。巻き戻しは relay のキャッシュから配信される想定で、bridge は FETCH を提供しない。

## テスト
- `cargo test -p moqt-bridge-live-ingest`（6 件）、`cargo clippy -p moqt-bridge-live-ingest --all-targets -- -D warnings`、`cargo fmt --check`
