### PR TITLE
feat(wasm): Live Viewer に FETCH による巻き戻しと E2E テストを追加する

### DIFF
--- a/.github/actions/install-ffmpeg-deps/action.yml
+++ b/.github/actions/install-ffmpeg-deps/action.yml
@@ -7,8 +7,13 @@ runs:
     - shell: bash
       run: |
         set -euo pipefail
-        apt-get update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        # Container jobs run as root; jobs on the runner host need sudo.
+        privileged=""
+        if [ "$(id -u)" -ne 0 ]; then
+          privileged="sudo"
+        fi
+        $privileged apt-get update
+        $privileged env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
           ffmpeg \
           pkg-config \
           libavutil-dev \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,7 @@ on:
       - "scripts/run-media-e2e.mjs"
       - "scripts/run-call-e2e.mjs"
       - "scripts/run-message-e2e.mjs"
+      - "scripts/run-live-viewer-e2e.mjs"
       - "scripts/browser-e2e-process.mjs"
       - "scripts/media-e2e-helpers.mjs"
       - "scripts/ensure-relay-certs.mjs"
@@ -24,6 +25,7 @@ on:
       - "docker-compose.yml"
       - "examples/browser/**"
       - "bindings/wasm/**"
+      - "bridges/live-ingest/**"
       - "relay/**"
       - "moqt/**"
       - "shared/**"
@@ -49,6 +51,7 @@ on:
       - "scripts/run-media-e2e.mjs"
       - "scripts/run-call-e2e.mjs"
       - "scripts/run-message-e2e.mjs"
+      - "scripts/run-live-viewer-e2e.mjs"
       - "scripts/browser-e2e-process.mjs"
       - "scripts/media-e2e-helpers.mjs"
       - "scripts/ensure-relay-certs.mjs"
@@ -62,6 +65,7 @@ on:
       - "docker-compose.yml"
       - "examples/browser/**"
       - "bindings/wasm/**"
+      - "bridges/live-ingest/**"
       - "relay/**"
       - "moqt/**"
       - "shared/**"
@@ -88,6 +92,7 @@ jobs:
     outputs:
       media: ${{ steps.filter.outputs.media }}
       message: ${{ steps.filter.outputs.message }}
+      live_viewer: ${{ steps.filter.outputs.live_viewer }}
       call: ${{ steps.filter.outputs.call }}
       cascading: ${{ steps.filter.outputs.cascading }}
       cache_eviction: ${{ steps.filter.outputs.cache_eviction }}
@@ -113,6 +118,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             media=true
             message=true
+            live_viewer=true
             call=true
             cascading=true
             cache_eviction=true
@@ -130,6 +136,7 @@ jobs:
 
             media=false
             message=false
+            live_viewer=false
             call=false
             cascading=false
             cache_eviction=false
@@ -147,6 +154,12 @@ jobs:
               case "$path" in
                 .github/workflows/e2e.yml|.github/actions/setup-wasm-pack/*|scripts/setup-media-e2e.mjs|scripts/run-message-e2e.mjs|scripts/browser-e2e-process.mjs|scripts/media-e2e-helpers.mjs|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|scripts/chrome_linux.sh|examples/browser/*|bindings/wasm/*|relay/*|moqt/*|shared/*|Cargo.toml|Cargo.lock|rust-toolchain)
                   message=true
+                  ;;
+              esac
+
+              case "$path" in
+                .github/workflows/e2e.yml|.github/actions/setup-wasm-pack/*|.github/actions/install-ffmpeg-deps/*|scripts/setup-media-e2e.mjs|scripts/run-live-viewer-e2e.mjs|scripts/browser-e2e-process.mjs|scripts/media-e2e-helpers.mjs|scripts/ensure-relay-certs.mjs|scripts/resolve-local-relay-url.mjs|examples/browser/*|bindings/wasm/*|bridges/live-ingest/*|relay/*|moqt/*|shared/*|Cargo.toml|Cargo.lock|rust-toolchain)
+                  live_viewer=true
                   ;;
               esac
 
@@ -207,6 +220,7 @@ jobs:
           {
             echo "media=$media"
             echo "message=$message"
+            echo "live_viewer=$live_viewer"
             echo "call=$call"
             echo "cascading=$cascading"
             echo "cache_eviction=$cache_eviction"
@@ -305,6 +319,69 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: media-e2e-artifacts
+          path: |
+            examples/browser/test-results
+            examples/browser/playwright-report
+          if-no-files-found: ignore
+
+  live_viewer_e2e:
+    needs: changes
+    if: ${{ needs.changes.outputs.live_viewer == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout repository
+        # actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 = v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        # actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 = v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: examples/browser/package-lock.json
+
+      - name: Setup Rust toolchain
+        # dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 = v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: 1.96.0
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust build artifacts
+        # Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 = v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+
+      - name: Install wasm-pack
+        uses: ./.github/actions/setup-wasm-pack
+
+      - name: Install media build dependencies
+        uses: ./.github/actions/install-ffmpeg-deps
+
+      - name: Prepare media E2E environment
+        run: node scripts/setup-media-e2e.mjs
+
+      - name: Build relay and live ingest
+        run: cargo build -p relay -p moqt-bridge-live-ingest
+
+      - name: Install Playwright Linux dependencies
+        working-directory: examples/browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run live viewer E2E
+        env:
+          CI: "true"
+        run: node scripts/run-live-viewer-e2e.mjs
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        # actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a = v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: live-viewer-e2e-artifacts
           path: |
             examples/browser/test-results
             examples/browser/playwright-report

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LOCAL_MOQT_URL ?= $(shell node scripts/resolve-local-relay-url.mjs "$(MOQT_URL)"
 LIVE_INGEST_MOQT_URL ?= $(LOCAL_MOQT_URL)
 ONVIF_MOQT_URL ?= $(LOCAL_MOQT_URL)
 
-.PHONY: relay browser chrome chrome\:linux live-ingest onvif onvif-controller ffmpeg-rtmp ffmpeg-srt test lint format relay-certs browser-e2e-media browser-e2e-call browser-e2e-call-headed
+.PHONY: relay browser chrome chrome\:linux live-ingest onvif onvif-controller ffmpeg-rtmp ffmpeg-srt test lint format relay-certs browser-e2e-media browser-e2e-call browser-e2e-call-headed browser-e2e-live-viewer
 
 # Applications
 relay:
@@ -101,6 +101,9 @@ browser-e2e-media:
 	node scripts/run-media-e2e.mjs
 
 # Two-relay call E2E: brings up relay-a/relay-b via docker compose, then Playwright.
+browser-e2e-live-viewer:
+	node scripts/run-live-viewer-e2e.mjs
+
 browser-e2e-call:
 	node scripts/setup-media-e2e.mjs
 	node scripts/run-call-e2e.mjs

--- a/examples/browser/examples/live-viewer/README.md
+++ b/examples/browser/examples/live-viewer/README.md
@@ -17,6 +17,17 @@ make chrome                 # 自己署名証明書の relay に接続するた�
 Chrome で `examples/live-viewer/index.html` を開き、relay URL と namespace（RTMP は `app/stream`、
 SRT は stream ID）を入れて Watch を押します。`?moqtUrl=...&trackNamespace=...` でも指定できます。
 
+## 巻き戻し
+
+`-10s` / `-30s` は relay のキャッシュに残っている group を FETCH で取り出し、review canvas に
+capture timestamp のとおりのペースで再生します。`Back to live` でライブ表示へ戻ります。
+
+- 何秒戻るかは、ライブ再生中に観測した capture timestamp から求めます。bridge は group id を
+  壁時計で採番し、group はエンコーダの keyframe ごとに切り替わるため、group id の差は秒数になりません。
+- 取得範囲は publisher が書き込みを終えた group までに制限します。開いている group に伸ばすと
+  relay のキャッシュを外れて上流へ転送され、FETCH を提供しない bridge が `NOT_SUPPORTED` を返します。
+- relay のキャッシュ保持は既定 30 秒（`RELAY_CACHE_TTL_SECS`）です。それより前へは戻れません。
+
 ## ペイロード形式
 
 live-ingest は各 object を `[meta_len (u32 BE)][meta JSON][coded data]` で送り、ブラウザ publisher は

--- a/examples/browser/examples/live-viewer/index.html
+++ b/examples/browser/examples/live-viewer/index.html
@@ -74,6 +74,26 @@
             </label>
           </section>
 
+          <section class="card stack">
+            <h2>Rewind</h2>
+            <p class="hint">relay のキャッシュに残っている範囲を FETCH で取り出して再生します。</p>
+            <div class="button-row">
+              <button type="button" id="rewind10Btn" data-testid="live-viewer-rewind-10-button">-10s</button>
+              <button type="button" id="rewind30Btn" data-testid="live-viewer-rewind-30-button">-30s</button>
+              <button type="button" id="liveBtn" data-testid="live-viewer-live-button">Back to live</button>
+            </div>
+            <div class="status-list">
+              <div class="status-item">
+                <span class="status-label">Mode</span>
+                <span id="rewind-status" class="status-value" data-testid="live-viewer-rewind-status">Live</span>
+              </div>
+              <div class="status-item">
+                <span class="status-label">Buffered</span>
+                <span id="rewind-buffer" class="status-value" data-testid="live-viewer-rewind-buffer">0.0s</span>
+              </div>
+            </div>
+          </section>
+
           <section class="card stack full">
             <div class="card-title-row">
               <h2>Playback</h2>
@@ -84,6 +104,7 @@
             <div class="media-grid">
               <div class="playback-panel">
                 <video id="video" playsinline muted autoplay data-testid="live-viewer-video"></video>
+                <canvas id="review" hidden data-testid="live-viewer-review-canvas"></canvas>
                 <audio id="audio" autoplay data-testid="live-viewer-audio"></audio>
               </div>
             </div>

--- a/examples/browser/examples/live-viewer/main.ts
+++ b/examples/browser/examples/live-viewer/main.ts
@@ -8,9 +8,14 @@ import {
   type MediaCatalogTrack
 } from '../media/catalog'
 import { getErrorMessage, initializeMediaExamplePage, parseTrackNamespace, setStatusText } from '../media/common'
+import { GroupTimeline, type ReviewFrame, sortReviewFrames, toReviewFrame } from './rewind'
 
 const AUTH_INFO = 'secret'
 const ANNEX_B_FORMAT = 'annexb'
+const TIMELINE_CAPACITY = 64
+const REWIND_GROUP_COUNT = 4n
+const FETCH_IDLE_MS = 400
+const FETCH_DEADLINE_MS = 8_000
 
 type MediaKind = 'video' | 'audio'
 
@@ -35,6 +40,9 @@ let videoWriter: WritableStreamDefaultWriter<VideoFrame> | undefined
 let audioWriter: WritableStreamDefaultWriter<AudioData> | undefined
 let videoObjectCount = 0
 let receivedKbps = 0
+const timeline = new GroupTimeline(TIMELINE_CAPACITY)
+let reviewing = false
+let reviewGeneration = 0
 
 initializeMediaExamplePage('namespace')
 element<HTMLButtonElement>('watchBtn').addEventListener('click', () => void watchStream())
@@ -42,6 +50,9 @@ element<HTMLButtonElement>('stopBtn').addEventListener('click', () => void stopS
 element<HTMLSelectElement>('video-track').addEventListener('change', () => void resubscribe('video'))
 element<HTMLSelectElement>('audio-track').addEventListener('change', () => void resubscribe('audio'))
 element<HTMLInputElement>('bypass-jitter-buffer').addEventListener('change', applyDecoderConfig)
+element<HTMLButtonElement>('rewind10Btn').addEventListener('click', () => void rewind(10))
+element<HTMLButtonElement>('rewind30Btn').addEventListener('click', () => void rewind(30))
+element<HTMLButtonElement>('liveBtn').addEventListener('click', backToLive)
 startRendering()
 
 async function watchStream(): Promise<void> {
@@ -59,6 +70,7 @@ async function watchStream(): Promise<void> {
 }
 
 async function stopStream(): Promise<void> {
+  backToLive()
   for (const kind of subscriptions.keys()) {
     await unsubscribeTrack(kind)
   }
@@ -149,6 +161,10 @@ async function resubscribe(kind: MediaKind): Promise<void> {
   }
 
   await unsubscribeTrack(kind)
+  if (kind === 'video') {
+    timeline.reset()
+    setStatusText('rewind-buffer', '0.0s')
+  }
   const track = (kind === 'video' ? videoTracks : audioTracks).find((candidate) => candidate.name === trackName)
   if (!track) {
     return
@@ -164,7 +180,14 @@ async function resubscribe(kind: MediaKind): Promise<void> {
     const chunk = parseIngestChunk(new Uint8Array(object.objectPayload), object.locHeader)
     if (kind === 'video') {
       videoObjectCount += 1
-      setStatusText('playback-status', `Playing ${trackName}`)
+      timeline.record(groupId, chunk.locHeader)
+      setStatusText('rewind-buffer', `${timeline.span.toFixed(1)}s`)
+      if (!reviewing) {
+        setStatusText('playback-status', `Playing ${trackName}`)
+      }
+    }
+    if (reviewing && kind === 'video') {
+      return
     }
     worker.postMessage(
       {
@@ -307,4 +330,139 @@ function element<T extends HTMLElement>(id: string): T {
     throw new Error(`missing element: ${id}`)
   }
   return found as T
+}
+
+async function rewind(seconds: number): Promise<void> {
+  const subscription = subscriptions.get('video')
+  const target = timeline.resolveRewindTarget(seconds)
+  const newestClosed = timeline.newestClosed
+  if (!subscription || !target || !newestClosed) {
+    setStatusText('rewind-status', 'Rewind unavailable: nothing buffered yet')
+    return
+  }
+
+  const endGroup =
+    target.groupId + REWIND_GROUP_COUNT < newestClosed.groupId
+      ? target.groupId + REWIND_GROUP_COUNT
+      : newestClosed.groupId
+
+  const generation = ++reviewGeneration
+  reviewing = true
+  const behind = timeline.secondsBehindLive(target.groupId)
+  setStatusText('rewind-status', `Rewound ${behind.toFixed(1)}s`)
+  setStatusText('playback-status', 'Reviewing')
+  const frames: ReviewFrame[] = []
+  let lastArrival = performance.now()
+  try {
+    await moqtClient.fetch(trackNamespace(), subscription.name, target.groupId, 0n, endGroup, 0n, {
+      onObject: (message) => {
+        if (generation !== reviewGeneration) {
+          return
+        }
+        lastArrival = performance.now()
+        const frame = toReviewFrame(message)
+        if (frame) {
+          frames.push(frame)
+        }
+      }
+    })
+  } catch (error) {
+    backToLive()
+    setStatusText('rewind-status', `Rewind failed: ${getErrorMessage(error)}`)
+    appendLog('error', `fetch: ${getErrorMessage(error)}`)
+    return
+  }
+
+  await waitForFetchIdle(() => lastArrival, generation)
+
+  appendLog('info', `fetched ${frames.length} objects from group ${target.groupId}`)
+  await playReview(sortReviewFrames(frames), generation)
+}
+
+/// FETCH_OK only acknowledges the request. The objects follow on their own
+/// stream and no completion event is surfaced, so wait for the arrivals to go
+/// quiet before replaying them.
+async function waitForFetchIdle(lastArrival: () => number, generation: number): Promise<void> {
+  const deadline = performance.now() + FETCH_DEADLINE_MS
+  while (generation === reviewGeneration && performance.now() < deadline) {
+    if (performance.now() - lastArrival() > FETCH_IDLE_MS) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+}
+
+async function playReview(frames: ReviewFrame[], generation: number): Promise<void> {
+  const canvas = element<HTMLCanvasElement>('review')
+  const context = canvas.getContext('2d')
+  const config = pendingReviewConfig()
+  if (frames.length === 0 || !context || !config) {
+    backToLive()
+    setStatusText('rewind-status', 'Rewind unavailable: no cached objects')
+    return
+  }
+
+  element<HTMLVideoElement>('video').hidden = true
+  canvas.hidden = false
+  const decoder = new VideoDecoder({
+    output: (frame) => {
+      if (generation !== reviewGeneration) {
+        frame.close()
+        return
+      }
+      canvas.width = frame.displayWidth
+      canvas.height = frame.displayHeight
+      context.drawImage(frame, 0, 0)
+      frame.close()
+    },
+    error: (error) => appendLog('error', `review decoder: ${error.message}`)
+  })
+  decoder.configure(config)
+
+  const origin = frames[0].captureMicros ?? 0
+  for (const frame of frames) {
+    if (generation !== reviewGeneration) {
+      break
+    }
+    decoder.decode(
+      new EncodedVideoChunk({
+        type: frame.objectId === 0n ? 'key' : 'delta',
+        timestamp: (frame.captureMicros ?? origin) - origin,
+        data: frame.data
+      })
+    )
+    await pace(frame, frames)
+  }
+  await decoder.flush().catch(() => undefined)
+  decoder.close()
+  if (generation === reviewGeneration) {
+    setStatusText('rewind-status', 'Rewind finished')
+  }
+}
+
+function pendingReviewConfig(): VideoDecoderConfig | undefined {
+  const track = videoTracks.find((candidate) => candidate.name === subscriptions.get('video')?.name)
+  if (!track?.codec) {
+    return undefined
+  }
+  return { codec: track.codec, optimizeForLatency: true }
+}
+
+async function pace(frame: ReviewFrame, frames: ReviewFrame[]): Promise<void> {
+  const next = frames[frames.indexOf(frame) + 1]
+  const delayMs =
+    next?.captureMicros !== undefined && frame.captureMicros !== undefined
+      ? (next.captureMicros - frame.captureMicros) / 1_000
+      : 0
+  if (delayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, Math.min(delayMs, 1_000)))
+  }
+}
+
+function backToLive(): void {
+  reviewGeneration += 1
+  reviewing = false
+  element<HTMLCanvasElement>('review').hidden = true
+  element<HTMLVideoElement>('video').hidden = false
+  setStatusText('rewind-status', 'Live')
 }

--- a/examples/browser/examples/live-viewer/rewind.ts
+++ b/examples/browser/examples/live-viewer/rewind.ts
@@ -1,0 +1,114 @@
+import { type LocHeader, readLocHeader } from '../../utils/media/loc'
+import { parseIngestChunk } from '../../utils/media/ingestChunk'
+
+const MICROS_PER_SECOND = 1_000_000
+
+export type GroupMark = {
+  groupId: bigint
+  captureMicros: number
+}
+
+/// Group ids are seeded from a wall clock by the live-ingest bridge and groups
+/// last as long as the encoder's GOP, so seconds are resolved from the capture
+/// timestamps observed while playing live instead of from group arithmetic.
+export class GroupTimeline {
+  private readonly marks: GroupMark[] = []
+
+  constructor(private readonly capacity: number) {}
+
+  record(groupId: bigint, locHeader?: LocHeader): void {
+    if (this.marks.some((mark) => mark.groupId === groupId)) {
+      return
+    }
+
+    const captureMicros = readLocHeader(locHeader).captureTimestampMicros
+    if (typeof captureMicros !== 'number' || !Number.isFinite(captureMicros)) {
+      return
+    }
+
+    this.marks.push({ groupId, captureMicros })
+    this.marks.sort((left, right) => left.captureMicros - right.captureMicros)
+    while (this.marks.length > this.capacity) {
+      this.marks.shift()
+    }
+  }
+
+  reset(): void {
+    this.marks.length = 0
+  }
+
+  get latest(): GroupMark | undefined {
+    return this.marks[this.marks.length - 1]
+  }
+
+  /// The newest group the publisher has finished writing. The live edge group
+  /// is still open, and a FETCH that reaches into it leaves the relay cache and
+  /// is forwarded to a publisher that does not serve FETCH.
+  get newestClosed(): GroupMark | undefined {
+    return this.marks[this.marks.length - 2]
+  }
+
+  get span(): number {
+    const oldest = this.marks[0]
+    const latest = this.latest
+    if (!oldest || !latest) {
+      return 0
+    }
+    return (latest.captureMicros - oldest.captureMicros) / MICROS_PER_SECOND
+  }
+
+  /// Resolves the newest group that starts at least `seconds` before the live
+  /// edge. The live edge group itself is excluded because the publisher is
+  /// still writing to it and a FETCH for an open group escapes the relay cache.
+  resolveRewindTarget(seconds: number): GroupMark | undefined {
+    const latest = this.latest
+    if (!latest) {
+      return undefined
+    }
+
+    const deadline = latest.captureMicros - seconds * MICROS_PER_SECOND
+    const closed = this.marks.filter((mark) => mark.groupId !== latest.groupId)
+    return closed.filter((mark) => mark.captureMicros <= deadline).pop() ?? closed[0]
+  }
+
+  secondsBehindLive(groupId: bigint): number {
+    const latest = this.latest
+    const mark = this.marks.find((candidate) => candidate.groupId === groupId)
+    if (!latest || !mark) {
+      return 0
+    }
+    return (latest.captureMicros - mark.captureMicros) / MICROS_PER_SECOND
+  }
+}
+
+export type ReviewFrame = {
+  groupId: bigint
+  objectId: bigint
+  data: Uint8Array
+  captureMicros?: number
+}
+
+export function toReviewFrame(message: {
+  groupId: bigint
+  objectId: bigint
+  objectPayload: Uint8Array
+  locHeader?: LocHeader
+}): ReviewFrame | undefined {
+  const chunk = parseIngestChunk(new Uint8Array(message.objectPayload), message.locHeader)
+  if (chunk.data.byteLength === 0) {
+    return undefined
+  }
+
+  return {
+    groupId: message.groupId,
+    objectId: message.objectId,
+    data: chunk.data,
+    captureMicros: readLocHeader(chunk.locHeader).captureTimestampMicros
+  }
+}
+
+export function sortReviewFrames(frames: ReviewFrame[]): ReviewFrame[] {
+  return [...frames].sort((left, right) =>
+    left.groupId === right.groupId ? Number(left.objectId - right.objectId) : Number(left.groupId - right.groupId)
+  )
+}

--- a/examples/browser/playwright.helpers.ts
+++ b/examples/browser/playwright.helpers.ts
@@ -7,6 +7,7 @@ export const MEDIA_PUBLISHER_PATH = '/moq-wasm/examples/media/publisher/index.ht
 export const MEDIA_SUBSCRIBER_PATH = '/moq-wasm/examples/media/subscriber/index.html'
 export const CALL_INDEX_PATH = '/moq-wasm/examples/call/index.html'
 export const MESSAGE_INDEX_PATH = '/moq-wasm/examples/message/index.html'
+export const LIVE_VIEWER_PATH = '/moq-wasm/examples/live-viewer/index.html'
 
 export function ensureLinuxEnvironment(): void {
   if (process.platform !== 'linux' && process.platform !== 'darwin') {

--- a/examples/browser/tests/live-viewer-e2e-arrange.ts
+++ b/examples/browser/tests/live-viewer-e2e-arrange.ts
@@ -1,0 +1,69 @@
+import type { Browser, BrowserContext, Locator, Page } from '@playwright/test'
+import { LIVE_VIEWER_PATH } from '../playwright.helpers'
+
+const moqtUrl = process.env.MEDIA_E2E_MOQT_URL ?? 'https://127.0.0.1:4433'
+const namespace = process.env.LIVE_VIEWER_E2E_NAMESPACE ?? 'live/e2e'
+
+export const liveViewerE2EConfig = {
+  moqtUrl,
+  namespace
+}
+
+export interface LiveViewerPageModel {
+  page: Page
+  urlInput: Locator
+  namespaceInput: Locator
+  watchButton: Locator
+  stopButton: Locator
+  connectionStatus: Locator
+  catalogStatus: Locator
+  playbackStatus: Locator
+  videoTrackSelect: Locator
+  rewind10Button: Locator
+  rewind30Button: Locator
+  liveButton: Locator
+  rewindStatus: Locator
+  rewindBuffer: Locator
+  video: Locator
+  reviewCanvas: Locator
+  logPanel: Locator
+}
+
+export interface LiveViewerE2ESession {
+  context: BrowserContext
+  viewer: LiveViewerPageModel
+}
+
+function buildPagePath(path: string): string {
+  const params = new URLSearchParams({ moqtUrl, trackNamespace: namespace })
+  return `${path}?${params.toString()}`
+}
+
+function createLiveViewerPageModel(page: Page): LiveViewerPageModel {
+  return {
+    page,
+    urlInput: page.getByTestId('live-viewer-url-input'),
+    namespaceInput: page.getByTestId('live-viewer-namespace-input'),
+    watchButton: page.getByTestId('live-viewer-watch-button'),
+    stopButton: page.getByTestId('live-viewer-stop-button'),
+    connectionStatus: page.getByTestId('live-viewer-connection-status'),
+    catalogStatus: page.getByTestId('live-viewer-catalog-status'),
+    playbackStatus: page.getByTestId('live-viewer-playback-status'),
+    videoTrackSelect: page.getByTestId('live-viewer-video-track-select'),
+    rewind10Button: page.getByTestId('live-viewer-rewind-10-button'),
+    rewind30Button: page.getByTestId('live-viewer-rewind-30-button'),
+    liveButton: page.getByTestId('live-viewer-live-button'),
+    rewindStatus: page.getByTestId('live-viewer-rewind-status'),
+    rewindBuffer: page.getByTestId('live-viewer-rewind-buffer'),
+    video: page.getByTestId('live-viewer-video'),
+    reviewCanvas: page.getByTestId('live-viewer-review-canvas'),
+    logPanel: page.getByTestId('live-viewer-log-panel')
+  }
+}
+
+export async function arrangeLiveViewerE2ESession(browser: Browser): Promise<LiveViewerE2ESession> {
+  const context = await browser.newContext({ ignoreHTTPSErrors: true })
+  const page = await context.newPage()
+  await page.goto(buildPagePath(LIVE_VIEWER_PATH), { waitUntil: 'domcontentloaded' })
+  return { context, viewer: createLiveViewerPageModel(page) }
+}

--- a/examples/browser/tests/live-viewer-e2e.spec.ts
+++ b/examples/browser/tests/live-viewer-e2e.spec.ts
@@ -1,41 +1,67 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Locator } from '@playwright/test'
+import { arrangeLiveViewerE2ESession, type LiveViewerPageModel } from './live-viewer-e2e-arrange'
 
-const PAGE_PATH = '/moq-wasm/examples/live-viewer/index.html'
-const MOQT_URL = process.env.MEDIA_E2E_MOQT_URL ?? 'https://127.0.0.1:4433'
-const NAMESPACE = process.env.LIVE_VIEWER_E2E_NAMESPACE ?? 'live'
-
-test('live viewer plays the ingested stream and switches renditions', async ({ page }) => {
+test('live viewer plays the ingested stream, switches renditions and rewinds', async ({ browser }) => {
   // Arrange
-  await page.goto(`${PAGE_PATH}?moqtUrl=${encodeURIComponent(MOQT_URL)}&trackNamespace=${NAMESPACE}`, {
-    waitUntil: 'domcontentloaded'
-  })
+  const { context, viewer } = await arrangeLiveViewerE2ESession(browser)
 
-  // Act
-  await page.getByTestId('live-viewer-watch-button').click()
+  try {
+    // Act
+    await viewer.watchButton.click()
 
-  // Assert
-  await expect(page.getByTestId('live-viewer-connection-status')).toContainText('Connected:')
-  await expect(page.getByTestId('live-viewer-catalog-status')).toContainText(/Catalog loaded: [1-9]/)
-  await expect(page.getByTestId('live-viewer-playback-status')).toContainText('Playing')
-  await expectVideoPlaying(page)
+    // Assert
+    await expect(viewer.connectionStatus).toContainText('Connected:')
+    await expect(viewer.catalogStatus).toContainText(/Catalog loaded: [1-9]/)
+    await expect(viewer.playbackStatus).toContainText('Playing')
+    await expectVideoDecoded(viewer)
 
-  // Act: 下位画質へ切り替える
-  const select = page.getByTestId('live-viewer-video-track-select')
-  const renditions = await select.locator('option').allInnerTexts()
-  expect(renditions.length).toBeGreaterThan(1)
-  await select.selectOption({ index: 1 })
+    // Act: relay のキャッシュが 10 秒分たまるのを待って巻き戻す
+    await expect.poll(async () => parseSeconds(viewer.rewindBuffer), { timeout: 60_000 }).toBeGreaterThan(10)
+    await viewer.rewind10Button.click()
 
-  // Assert
-  await expect(page.getByTestId('live-viewer-playback-status')).toContainText('video_')
-  await expectVideoPlaying(page)
+    // Assert
+    await expect(viewer.rewindStatus).toContainText(/Rewound \d/)
+    await expect(viewer.playbackStatus).toContainText('Reviewing')
+    await expect(viewer.reviewCanvas).toBeVisible()
+    await expect
+      .poll(async () => viewer.reviewCanvas.evaluate((element) => (element as HTMLCanvasElement).width), {
+        timeout: 30_000
+      })
+      .toBeGreaterThan(0)
+
+    // Act
+    await viewer.liveButton.click()
+
+    // Assert
+    await expect(viewer.rewindStatus).toContainText('Live')
+    await expect(viewer.video).toBeVisible()
+    await expect(viewer.playbackStatus).toContainText('Playing')
+
+    // Act: 下位画質へ切り替える
+    const renditions = await viewer.videoTrackSelect.locator('option').allInnerTexts()
+    expect(renditions.length).toBeGreaterThan(1)
+    await viewer.videoTrackSelect.selectOption({ index: 1 })
+
+    // Assert: 元の track を解除して rendition を購読し直す
+    await expect(viewer.logPanel).toContainText('unsubscribed video')
+    await expect(viewer.logPanel).toContainText(/subscribed \S*\/video_\d+p/)
+    await expect(viewer.rewindBuffer).toHaveText('0.0s')
+  } finally {
+    await context.close()
+  }
 })
 
-async function expectVideoPlaying(page: Page): Promise<void> {
-  const video = page.getByTestId('live-viewer-video')
+async function expectVideoDecoded(viewer: LiveViewerPageModel): Promise<void> {
   await expect
-    .poll(async () => video.evaluate((element) => (element as HTMLVideoElement).readyState), { timeout: 30_000 })
+    .poll(async () => viewer.video.evaluate((element) => (element as HTMLVideoElement).readyState), {
+      timeout: 30_000
+    })
     .toBeGreaterThanOrEqual(2)
   await expect
-    .poll(async () => video.evaluate((element) => (element as HTMLVideoElement).videoWidth))
+    .poll(async () => viewer.video.evaluate((element) => (element as HTMLVideoElement).videoWidth))
     .toBeGreaterThan(0)
+}
+
+async function parseSeconds(locator: Locator): Promise<number> {
+  return Number.parseFloat((await locator.innerText()).replace('s', ''))
 }

--- a/examples/browser/utils/media/ingestChunk.ts
+++ b/examples/browser/utils/media/ingestChunk.ts
@@ -1,4 +1,4 @@
-import { type LocHeader } from './loc'
+import { type LocHeader, readLocHeader } from './loc'
 
 /// The live-ingest bridge prefixes each object with its own metadata:
 /// `[meta_len (u32 BE)][meta JSON][coded data]`. Browser publishers instead send
@@ -35,7 +35,7 @@ export function parseIngestChunk(payload: Uint8Array, locHeader?: LocHeader): In
   const [meta, dataOffset] = metadata
   return {
     data: payload.subarray(dataOffset),
-    locHeader: locHeader ?? buildLocHeaderFromMetadata(meta),
+    locHeader: resolveLocHeader(meta, locHeader),
     codec: meta.codec ?? undefined,
     descriptionBase64: meta.descriptionBase64 ?? undefined,
     sampleRate: meta.sampleRate,
@@ -61,6 +61,15 @@ function readMetadata(payload: Uint8Array): [IngestChunkMetadata, number] | unde
   } catch (_error) {
     return undefined
   }
+}
+
+/// The bridge sends empty extension headers, so the timestamp it packed into
+/// the metadata envelope is the only capture time available.
+function resolveLocHeader(meta: IngestChunkMetadata, locHeader?: LocHeader): LocHeader | undefined {
+  if (readLocHeader(locHeader).captureTimestampMicros !== undefined) {
+    return locHeader
+  }
+  return buildLocHeaderFromMetadata(meta) ?? locHeader
 }
 
 function buildLocHeaderFromMetadata(meta: IngestChunkMetadata): LocHeader | undefined {

--- a/scripts/media-e2e-helpers.mjs
+++ b/scripts/media-e2e-helpers.mjs
@@ -14,6 +14,7 @@ export const mediaSubscriberPath =
   "/moq-wasm/examples/media/subscriber/index.html";
 export const mediaIndexPath = "/moq-wasm/examples/media/index.html";
 export const messageIndexPath = "/moq-wasm/examples/message/index.html";
+export const liveViewerPath = "/moq-wasm/examples/live-viewer/index.html";
 export const serverKeysDir = resolve(repoRoot, "relay", "keys");
 export const certPath = resolve(serverKeysDir, "cert.pem");
 export const keyPath = resolve(serverKeysDir, "key.pem");

--- a/scripts/run-live-viewer-e2e.mjs
+++ b/scripts/run-live-viewer-e2e.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import {
+  registerSignalHandlers,
+  runCommand,
+  spawnProcess,
+  terminateProcess,
+  waitForOutput,
+} from "./browser-e2e-process.mjs";
+import {
+  assertPathExists,
+  certPath,
+  ensureLinuxEnvironment,
+  getDefaultBaseUrl,
+  getDefaultMoqtUrl,
+  getDefaultWebPort,
+  getErrorMessage,
+  jsDir,
+  keyPath,
+  liveViewerPath,
+  repoRoot,
+  resolveCommandName,
+  waitForHttpOk,
+} from "./media-e2e-helpers.mjs";
+
+const rtmpAddress = process.env.LIVE_VIEWER_E2E_RTMP_ADDR ?? "127.0.0.1:1935";
+const srtAddress = process.env.LIVE_VIEWER_E2E_SRT_ADDR ?? "127.0.0.1:9000";
+const childProcesses = [];
+
+async function main() {
+  ensureLinuxEnvironment();
+  assertPathExists(
+    certPath,
+    "TLS certificate",
+    "Run node scripts/setup-media-e2e.mjs first.",
+  );
+  assertPathExists(
+    keyPath,
+    "TLS private key",
+    "Run node scripts/setup-media-e2e.mjs first.",
+  );
+  assertPathExists(
+    `${jsDir}/node_modules`,
+    "examples/browser/node_modules",
+    "Run node scripts/setup-media-e2e.mjs first.",
+  );
+  assertPathExists(
+    `${jsDir}/pkg/moqt_client_wasm.js`,
+    "bindings/wasm build output",
+    "Run node scripts/setup-media-e2e.mjs first.",
+  );
+
+  const webPort = getDefaultWebPort();
+  const baseUrl = getDefaultBaseUrl();
+  const moqtUrl = getDefaultMoqtUrl();
+  const namespace = process.env.LIVE_VIEWER_E2E_NAMESPACE ?? "live/e2e";
+
+  const cleanup = async () => {
+    await Promise.allSettled(
+      [...childProcesses].reverse().map((child) => terminateProcess(child)),
+    );
+  };
+
+  registerSignalHandlers(cleanup);
+
+  try {
+    const server = spawnProcess("server", "cargo", ["run", "-p", "relay"], {
+      cwd: repoRoot,
+    });
+    const vite = spawnProcess(
+      "vite",
+      resolveCommandName("npm"),
+      [
+        "exec",
+        "vite",
+        "--",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(webPort),
+        "--strictPort",
+      ],
+      { cwd: jsDir },
+    );
+
+    childProcesses.push(server, vite);
+
+    await Promise.all([
+      waitForOutput(server, /Relay server started/, "relay", 180_000),
+      waitForHttpOk(`${baseUrl}${liveViewerPath}`, 120_000),
+    ]);
+
+    const bridge = spawnProcess(
+      "live-ingest",
+      "cargo",
+      [
+        "run",
+        "-p",
+        "moqt-bridge-live-ingest",
+        "--",
+        "--rtmp-addr",
+        rtmpAddress,
+        "--srt-addr",
+        srtAddress,
+        "--moqt-url",
+        moqtUrl,
+        "--transcode",
+      ],
+      { cwd: repoRoot },
+    );
+    childProcesses.push(bridge);
+    await waitForOutput(
+      bridge,
+      /RTMP listener started/,
+      "live-ingest",
+      180_000,
+    );
+
+    const ffmpeg = spawnProcess(
+      "ffmpeg",
+      "ffmpeg",
+      buildFfmpegArgs(namespace),
+      {
+        cwd: repoRoot,
+      },
+    );
+    childProcesses.push(ffmpeg);
+    await waitForOutput(
+      bridge,
+      /transcoding renditions started/,
+      "live-ingest renditions",
+      120_000,
+    );
+
+    await runCommand(resolveCommandName("npm"), ["run", "e2e:live-viewer"], {
+      cwd: jsDir,
+      env: {
+        ...process.env,
+        MEDIA_E2E_BASE_URL: baseUrl,
+        MEDIA_E2E_MOQT_URL: moqtUrl,
+        LIVE_VIEWER_E2E_NAMESPACE: namespace,
+      },
+    });
+  } finally {
+    await cleanup();
+  }
+}
+
+function buildFfmpegArgs(namespace) {
+  return [
+    "-hide_banner",
+    "-loglevel",
+    "warning",
+    "-re",
+    "-f",
+    "lavfi",
+    "-i",
+    "testsrc=size=1280x720:rate=30",
+    "-f",
+    "lavfi",
+    "-i",
+    "sine=frequency=1000:sample_rate=48000",
+    "-c:v",
+    "libx264",
+    "-preset",
+    "veryfast",
+    "-profile:v",
+    "baseline",
+    "-pix_fmt",
+    "yuv420p",
+    "-g",
+    "60",
+    "-sc_threshold",
+    "0",
+    "-c:a",
+    "aac",
+    "-ar",
+    "48000",
+    "-ac",
+    "2",
+    "-t",
+    "300",
+    "-f",
+    "flv",
+    `rtmp://${rtmpAddress}/${namespace}/stream`,
+  ];
+}
+
+main().catch((error) => {
+  console.error(getErrorMessage(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 概要
Live Viewer に FETCH を使った巻き戻しを追加し、E2E テストを他の example と同じ形（arrange + runner script + make ターゲット）で用意します。
stacked PR（base: #360）です。

## やったこと
- `-10s` / `-30s` で relay のキャッシュに残る group を FETCH し、review canvas に capture timestamp どおりのペースで再生。`Back to live` でライブへ復帰
- 何秒戻るかはライブ再生中に観測した capture timestamp から算出（bridge は group id を壁時計で採番し、group 長は encoder の GOP 次第なので group id の差は秒数にならない）。rendition 切り替え時はタイムラインを破棄
- 取得範囲は publisher が閉じた group までに制限。FETCH_OK は受理応答でしかなく完了通知がないため、object の到着が途切れるまで待ってから再生する
- `tests/live-viewer-e2e-arrange.ts` と `scripts/run-live-viewer-e2e.mjs`（relay・live-ingest `--transcode`・ffmpeg・vite を起動）、`npm run e2e:live-viewer`、`make browser-e2e-live-viewer`、CI の `live_viewer_e2e` ジョブ

```mermaid
sequenceDiagram
    participant V as Live Viewer
    participant R as Relay
    V->>R: SUBSCRIBE video / audio / catalog
    R-->>V: 実況再生（capture timestamp を記録）
    V->>R: FETCH video [target .. 閉じた group]
    R-->>V: FETCH_OK
    R-->>V: 過去の object 群
    V->>V: review canvas で再生 → Back to live
```

## やらないこと
- シークバーでの任意位置指定、コマ送り（現状は固定の -10s / -30s）
- FETCH_CANCEL の送信（relay 側が未実装のため、UI 側は generation で結果を破棄する）

## 影響範囲
`examples/browser`、`scripts`、`Makefile`。既存 example の挙動は変わらない。

## テスト
- `npm --prefix examples/browser run lint`（tsc）、`npx prettier --check`
- `node scripts/run-live-viewer-e2e.mjs`: 再生・rendition 切り替え・10 秒巻き戻し（review canvas に描画）・ライブ復帰まで通過

## 備考
巻き戻せる範囲は relay のキャッシュ保持（既定 30 秒、`RELAY_CACHE_TTL_SECS`）までです。
CI の `live_viewer_e2e` は #361 が master に入るまで失敗します。rendition 切り替えで元 track を UNSUBSCRIBE した後、元 track への送信失敗で rendition への供給が止まるためです（#361 で修正）。
