### PR TITLE
feat(moqt): CLIENT_SETUP に認証トークンを載せ、SETUP を accept/reject 可能にする

### DIFF
--- a/architecture_decision_record/moqt/architecture.md
+++ b/architecture_decision_record/moqt/architecture.md
@@ -82,7 +82,10 @@ Server flow: `Endpoint` → `Accepting` (a boxed `Future`) → `Handshake` → `
 - `connect(url)` returns `Connecting<T>`, whose future performs the transport
   handshake, opens the bidirectional control stream, and runs the whole SETUP
   exchange in `SessionContextFactory` (sends CLIENT_SETUP, awaits SERVER_SETUP,
-  version `0xff00000e` = draft-14). On success a `Session<T>` is created.
+  version `0xff00000e` = draft-14). `ClientConfig.authorization_token`, when
+  set, is sent as a CLIENT_SETUP AUTHORIZATION TOKEN parameter (Alias Type
+  `USE_VALUE`, Token Type `0`, UTF-8 value). On success a `Session<T>` is
+  created.
 - `accept()` returns `Accepting<T>`, whose future performs the transport
   handshake, accepts the control stream, and stops after CLIENT_SETUP is
   received (`SessionContextFactory::receive_client_setup`). It resolves to a

--- a/architecture_decision_record/moqt/architecture.md
+++ b/architecture_decision_record/moqt/architecture.md
@@ -74,15 +74,24 @@ Client-side helpers shared by the three creators:
 
 ## Session establishment (`modules/moqt/domains`)
 
-Flow: `Endpoint` → `Connecting` (a boxed `Future`) → `Session`.
+Client flow: `Endpoint` → `Connecting` (a boxed `Future`) → `Session`.
+Server flow: `Endpoint` → `Accepting` (a boxed `Future`) → `Handshake` → `Session`.
 
 - `Endpoint::create_client(&ClientConfig)` / `create_server(&ServerConfig)`
   build a `SessionCreator` around the transport's `ConnectionCreator`.
-- `connect(url)` / `accept()` return `Connecting<T>`, whose future performs the
-  transport handshake, opens/accepts the bidirectional control stream, and runs
-  the SETUP exchange in `SessionContextFactory` (CLIENT_SETUP/SERVER_SETUP,
-  version `0xff00000e` = draft-14).
-- On success a `Session<T>` is created.
+- `connect(url)` returns `Connecting<T>`, whose future performs the transport
+  handshake, opens the bidirectional control stream, and runs the whole SETUP
+  exchange in `SessionContextFactory` (sends CLIENT_SETUP, awaits SERVER_SETUP,
+  version `0xff00000e` = draft-14). On success a `Session<T>` is created.
+- `accept()` returns `Accepting<T>`, whose future performs the transport
+  handshake, accepts the control stream, and stops after CLIENT_SETUP is
+  received (`SessionContextFactory::receive_client_setup`). It resolves to a
+  `Handshake<T>` that exposes the received `ClientSetup` so the application can
+  decide before SERVER_SETUP is sent:
+  - `Handshake::accept()` sends SERVER_SETUP
+    (`SessionContextFactory::send_server_setup`) and creates the `Session<T>`.
+  - `Handshake::reject(code, reason)` closes the transport with the given
+    termination code without sending SERVER_SETUP.
 
 ### `Session` and its background tasks
 

--- a/architecture_decision_record/moqt/architecture.md
+++ b/architecture_decision_record/moqt/architecture.md
@@ -163,6 +163,10 @@ One struct owns all cross-task state:
 - `handler/*` — received-message facades handed to the application inside
   `SessionEvent` (e.g. `SubscribeHandler::ok(...)`, `::error(...)`). They keep
   an `Arc<SessionContext>` so responding does not require the `Session`.
+  Namespace-carrying handlers expose the track namespace both as the wire
+  tuple (`track_namespace_tuple`) and as the `/`-joined string
+  (`track_namespace`); the tuple is authoritative because a tuple element may
+  itself contain `/`.
 - `enums.rs` — `SessionEvent<T>` (inbound requests + `Disconnected` /
   `ProtocolViolation`) and the crate-private `ResponseMessage`.
 - `constants.rs` — protocol version and `TerminationErrorCode` (draft-14

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -431,10 +431,14 @@ impl MOQTClient {
         &self,
         versions: Vec<u64>,
         max_request_id: u64,
+        auth_token: Option<String>,
     ) -> Result<(), JsValue> {
         let supported_versions = versions.into_iter().map(|version| version as u32).collect();
-        let payload =
-            ClientSetup::new(supported_versions, default_setup_parameters(max_request_id)).encode();
+        let payload = ClientSetup::new(
+            supported_versions,
+            setup_parameters(max_request_id, auth_token.as_deref()),
+        )
+        .encode();
         self.state.borrow_mut().configure(max_request_id);
         self.send_control_message(ControlMessageType::ClientSetup, payload)
             .await
@@ -1867,11 +1871,11 @@ fn emit_subgroup_object(
 }
 
 #[cfg(web_sys_unstable_apis)]
-fn default_setup_parameters(max_request_id: u64) -> SetupParameter {
+fn setup_parameters(max_request_id: u64, auth_token: Option<&str>) -> SetupParameter {
     SetupParameter {
         path: None,
         max_request_id,
-        authorization_token: vec![],
+        authorization_token: auth_token.map(authorization_tokens).unwrap_or_default(),
         max_auth_token_cache_size: None,
         authority: None,
         moq_implementation: Some("moqt-client-wasm".to_string()),
@@ -1884,10 +1888,7 @@ fn authorization_tokens(auth_info: &str) -> Vec<AuthorizationToken> {
         return vec![];
     }
 
-    vec![AuthorizationToken::UseValue {
-        token_type: 0,
-        token_value: Bytes::copy_from_slice(auth_info.as_bytes()),
-    }]
+    vec![AuthorizationToken::use_value_utf8(auth_info)]
 }
 
 #[cfg(web_sys_unstable_apis)]

--- a/bridges/live-ingest/src/moqt.rs
+++ b/bridges/live-ingest/src/moqt.rs
@@ -270,6 +270,7 @@ impl<T: TransportProtocol> ConnectedPublisher<T> {
         let endpoint = Endpoint::<T>::create_client(&ClientConfig {
             port: 0,
             verify_certificate: false,
+            authorization_token: None,
         })?;
         let connecting = endpoint
             .connect(url.as_str())

--- a/bridges/onvif/src/bin/moqt-onvif-client.rs
+++ b/bridges/onvif/src/bin/moqt-onvif-client.rs
@@ -1649,6 +1649,7 @@ async fn connect_session(
     let endpoint = Endpoint::<WEBTRANSPORT>::create_client(&ClientConfig {
         port: 0,
         verify_certificate: !insecure_skip_tls_verify,
+        authorization_token: None,
     })?;
     let connecting = endpoint
         .connect(url)

--- a/examples/cross-protocol-test/publisher/src/moqt_sender.rs
+++ b/examples/cross-protocol-test/publisher/src/moqt_sender.rs
@@ -11,6 +11,7 @@ pub async fn connect_and_wait_for_subscriber(
     let config = ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     };
     let endpoint = Endpoint::<QUIC>::create_client(&config)?;
     info!("connecting to relay");

--- a/examples/cross-protocol-test/quic-subscriber/src/moqt_receiver.rs
+++ b/examples/cross-protocol-test/quic-subscriber/src/moqt_receiver.rs
@@ -10,6 +10,7 @@ pub async fn subscribe_and_receive(namespace: &str, track_name: &str) -> Result<
     let config = ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     };
     let endpoint = Endpoint::<QUIC>::create_client(&config)?;
     info!("connecting to relay via QUIC");

--- a/examples/rust/manual-client/src/client.rs
+++ b/examples/rust/manual-client/src/client.rs
@@ -37,6 +37,7 @@ impl<T: TransportProtocol> Client<T> {
             Endpoint::<T>::create_client(&ClientConfig {
                 port: 0,
                 verify_certificate: false,
+                authorization_token: None,
             })?
         };
         tracing::info!(moqt_url, "connecting");

--- a/examples/rust/moq-cli/src/transport/session.rs
+++ b/examples/rust/moq-cli/src/transport/session.rs
@@ -13,6 +13,7 @@ pub async fn connect_session(relay: &Url, insecure: bool) -> Result<Session<QUIC
     let config = ClientConfig {
         port: 0,
         verify_certificate: !insecure,
+        authorization_token: None,
     };
     let endpoint = Endpoint::<QUIC>::create_client(&config)?;
     info!(%relay, "connecting to relay");

--- a/moqt/src/lib.rs
+++ b/moqt/src/lib.rs
@@ -95,6 +95,8 @@ pub use modules::moqt::data_plane::stream::stream_data_sender_factory::StreamDat
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::data_plane::stream::stream_receiver::StreamReceiveError;
 #[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::domains::accepting::Accepting;
+#[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::connecting::Connecting;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::endpoint::ClientConfig;
@@ -104,6 +106,8 @@ pub use modules::moqt::domains::endpoint::Endpoint;
 pub use modules::moqt::domains::endpoint::ServerConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::fetch_handle::FetchHandle;
+#[cfg(not(target_arch = "wasm32"))]
+pub use modules::moqt::domains::handshake::Handshake;
 #[cfg(not(target_arch = "wasm32"))]
 pub use modules::moqt::domains::publisher::Publisher;
 #[cfg(not(target_arch = "wasm32"))]

--- a/moqt/src/modules/moqt/control_plane/control_messages/messages/parameters/authorization_token.rs
+++ b/moqt/src/modules/moqt/control_plane/control_messages/messages/parameters/authorization_token.rs
@@ -32,6 +32,13 @@ pub enum AuthorizationToken {
 }
 
 impl AuthorizationToken {
+    pub fn use_value_utf8(value: &str) -> Self {
+        Self::UseValue {
+            token_type: 0,
+            token_value: Bytes::copy_from_slice(value.as_bytes()),
+        }
+    }
+
     pub fn decode(buf: &mut std::io::Cursor<&[u8]>) -> Option<Self> {
         let token_alias = buf.try_get_varint().log_context("alias type").ok()?;
         if let Ok(token_alias) = AliasType::try_from(token_alias) {

--- a/moqt/src/modules/moqt/control_plane/handler/publish_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/publish_handler.rs
@@ -23,6 +23,7 @@ pub struct PublishHandler<T: TransportProtocol> {
     session_context: Arc<SessionContext<T>>,
     pub request_id: u64,
     pub track_namespace: String,
+    pub track_namespace_tuple: Vec<String>,
     pub track_name: String,
     pub track_alias: u64,
     pub group_order: GroupOrder,
@@ -46,6 +47,7 @@ impl<T: TransportProtocol> PublishHandler<T> {
             guard,
             request_id: publish_message.request_id,
             track_namespace: publish_message.track_namespace_tuple.join("/"),
+            track_namespace_tuple: publish_message.track_namespace_tuple,
             track_name: publish_message.track_name,
             track_alias: publish_message.track_alias,
             group_order: publish_message.group_order,
@@ -133,5 +135,43 @@ impl<T: TransportProtocol> PublishHandler<T> {
             .send(ControlMessageType::PublishError, err.encode())
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::PublishOption;
+    use crate::{
+        SessionEvent,
+        modules::test_support::{connect_sessions, spawn_dual_server},
+    };
+
+    #[tokio::test]
+    async fn exposes_track_namespace_as_tuple_and_joined_string() {
+        // Arrange
+        let (port, accept) = spawn_dual_server("publish-handler-namespace");
+        let (client, server) = connect_sessions(&format!("moqt://127.0.0.1:{port}"), accept)
+            .await
+            .unwrap();
+        let request = tokio::spawn(async move {
+            client
+                .publisher()
+                .publish(
+                    "a/b/c".to_string(),
+                    "track".to_string(),
+                    PublishOption::default(),
+                )
+                .await
+        });
+
+        // Act
+        let SessionEvent::Publish(handler) = server.receive_event().await.unwrap() else {
+            panic!("expected PUBLISH from the client");
+        };
+
+        // Assert
+        assert_eq!(handler.track_namespace_tuple, vec!["a", "b", "c"]);
+        assert_eq!(handler.track_namespace, "a/b/c");
+        request.abort();
     }
 }

--- a/moqt/src/modules/moqt/control_plane/handler/publish_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/publish_handler.rs
@@ -29,7 +29,6 @@ pub struct PublishHandler<T: TransportProtocol> {
     pub group_order: GroupOrder,
     pub content_exists: ContentExists,
     pub forward: bool,
-    pub authorization_token: Option<String>,
     pub max_cache_duration: Option<u64>,
     pub delivery_timeout: Option<u64>,
     guard: ResponseGuard<T>,
@@ -53,7 +52,6 @@ impl<T: TransportProtocol> PublishHandler<T> {
             group_order: publish_message.group_order,
             content_exists: publish_message.content_exists,
             forward: publish_message.forward,
-            authorization_token: None,
             max_cache_duration: None,
             delivery_timeout: None,
         }

--- a/moqt/src/modules/moqt/control_plane/handler/publish_namespace_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/publish_namespace_handler.rs
@@ -24,7 +24,6 @@ pub struct PublishNamespaceHandler<T: TransportProtocol> {
     request_id: u64,
     pub track_namespace: String,
     pub track_namespace_tuple: Vec<String>,
-    pub authorization_token: Option<String>,
     guard: ResponseGuard<T>,
 }
 
@@ -44,7 +43,6 @@ impl<T: TransportProtocol> PublishNamespaceHandler<T> {
             request_id: publish_namespace.request_id,
             track_namespace: publish_namespace.track_namespace.join("/"),
             track_namespace_tuple: publish_namespace.track_namespace,
-            authorization_token: None,
         }
     }
 

--- a/moqt/src/modules/moqt/control_plane/handler/publish_namespace_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/publish_namespace_handler.rs
@@ -23,6 +23,7 @@ pub struct PublishNamespaceHandler<T: TransportProtocol> {
     session_context: Arc<SessionContext<T>>,
     request_id: u64,
     pub track_namespace: String,
+    pub track_namespace_tuple: Vec<String>,
     pub authorization_token: Option<String>,
     guard: ResponseGuard<T>,
 }
@@ -42,6 +43,7 @@ impl<T: TransportProtocol> PublishNamespaceHandler<T> {
             guard,
             request_id: publish_namespace.request_id,
             track_namespace: publish_namespace.track_namespace.join("/"),
+            track_namespace_tuple: publish_namespace.track_namespace,
             authorization_token: None,
         }
     }
@@ -75,5 +77,38 @@ impl<T: TransportProtocol> PublishNamespaceHandler<T> {
             .send_stream
             .send(ControlMessageType::PublishNamespaceError, err.encode())
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        SessionEvent,
+        modules::test_support::{connect_sessions, spawn_dual_server},
+    };
+
+    #[tokio::test]
+    async fn exposes_track_namespace_as_tuple_and_joined_string() {
+        // Arrange
+        let (port, accept) = spawn_dual_server("publish-namespace-handler-namespace");
+        let (client, server) = connect_sessions(&format!("moqt://127.0.0.1:{port}"), accept)
+            .await
+            .unwrap();
+        let request = tokio::spawn(async move {
+            client
+                .publisher()
+                .publish_namespace("a/b/c".to_string())
+                .await
+        });
+
+        // Act
+        let SessionEvent::PublishNamespace(handler) = server.receive_event().await.unwrap() else {
+            panic!("expected PUBLISH_NAMESPACE from the client");
+        };
+
+        // Assert
+        assert_eq!(handler.track_namespace_tuple, vec!["a", "b", "c"]);
+        assert_eq!(handler.track_namespace, "a/b/c");
+        request.abort();
     }
 }

--- a/moqt/src/modules/moqt/control_plane/handler/subscribe_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/subscribe_handler.rs
@@ -23,6 +23,7 @@ pub struct SubscribeHandler<T: TransportProtocol> {
     session_context: Arc<SessionContext<T>>,
     request_id: u64,
     pub track_namespace: String,
+    pub track_namespace_tuple: Vec<String>,
     pub track_name: String,
     pub subscriber_priority: u8,
     pub group_order: GroupOrder,
@@ -49,6 +50,7 @@ impl<T: TransportProtocol> SubscribeHandler<T> {
             guard,
             request_id: subscribe_message.request_id,
             track_namespace: subscribe_message.track_namespace.join("/"),
+            track_namespace_tuple: subscribe_message.track_namespace,
             track_name: subscribe_message.track_name,
             subscriber_priority: subscribe_message.subscriber_priority,
             group_order: subscribe_message.group_order,
@@ -127,5 +129,43 @@ impl<T: TransportProtocol> SubscribeHandler<T> {
             track_alias,
             self,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::SubscribeOption;
+    use crate::{
+        SessionEvent,
+        modules::test_support::{connect_sessions, spawn_dual_server},
+    };
+
+    #[tokio::test]
+    async fn exposes_track_namespace_as_tuple_and_joined_string() {
+        // Arrange
+        let (port, accept) = spawn_dual_server("subscribe-handler-namespace");
+        let (client, server) = connect_sessions(&format!("moqt://127.0.0.1:{port}"), accept)
+            .await
+            .unwrap();
+        let request = tokio::spawn(async move {
+            client
+                .subscriber()
+                .subscribe(
+                    "a/b/c".to_string(),
+                    "track".to_string(),
+                    SubscribeOption::default(),
+                )
+                .await
+        });
+
+        // Act
+        let SessionEvent::Subscribe(handler) = server.receive_event().await.unwrap() else {
+            panic!("expected SUBSCRIBE from the client");
+        };
+
+        // Assert
+        assert_eq!(handler.track_namespace_tuple, vec!["a", "b", "c"]);
+        assert_eq!(handler.track_namespace, "a/b/c");
+        request.abort();
     }
 }

--- a/moqt/src/modules/moqt/control_plane/handler/subscribe_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/subscribe_handler.rs
@@ -29,7 +29,6 @@ pub struct SubscribeHandler<T: TransportProtocol> {
     pub group_order: GroupOrder,
     pub forward: bool,
     pub filter_type: FilterType,
-    pub authorization_token: Option<String>,
     pub max_cache_duration: Option<u64>,
     pub delivery_timeout: Option<u64>,
     guard: ResponseGuard<T>,
@@ -56,7 +55,6 @@ impl<T: TransportProtocol> SubscribeHandler<T> {
             group_order: subscribe_message.group_order,
             forward: subscribe_message.forward,
             filter_type: subscribe_message.filter_type,
-            authorization_token: None,
             max_cache_duration: None,
             delivery_timeout: None,
         }

--- a/moqt/src/modules/moqt/control_plane/handler/subscribe_namespace_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/subscribe_namespace_handler.rs
@@ -24,7 +24,6 @@ pub struct SubscribeNamespaceHandler<T: TransportProtocol> {
     request_id: u64,
     pub track_namespace_prefix: String,
     pub track_namespace_prefix_tuple: Vec<String>,
-    pub authorization_token: Option<String>,
     guard: ResponseGuard<T>,
 }
 
@@ -44,7 +43,6 @@ impl<T: TransportProtocol> SubscribeNamespaceHandler<T> {
             request_id: subscribe_namespace.request_id,
             track_namespace_prefix: subscribe_namespace.track_namespace_prefix.join("/"),
             track_namespace_prefix_tuple: subscribe_namespace.track_namespace_prefix,
-            authorization_token: None,
         }
     }
 

--- a/moqt/src/modules/moqt/control_plane/handler/subscribe_namespace_handler.rs
+++ b/moqt/src/modules/moqt/control_plane/handler/subscribe_namespace_handler.rs
@@ -23,6 +23,7 @@ pub struct SubscribeNamespaceHandler<T: TransportProtocol> {
     session_context: Arc<SessionContext<T>>,
     request_id: u64,
     pub track_namespace_prefix: String,
+    pub track_namespace_prefix_tuple: Vec<String>,
     pub authorization_token: Option<String>,
     guard: ResponseGuard<T>,
 }
@@ -42,6 +43,7 @@ impl<T: TransportProtocol> SubscribeNamespaceHandler<T> {
             guard,
             request_id: subscribe_namespace.request_id,
             track_namespace_prefix: subscribe_namespace.track_namespace_prefix.join("/"),
+            track_namespace_prefix_tuple: subscribe_namespace.track_namespace_prefix,
             authorization_token: None,
         }
     }
@@ -77,5 +79,39 @@ impl<T: TransportProtocol> SubscribeNamespaceHandler<T> {
             .send(ControlMessageType::SubscribeNamespaceError, err.encode())
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        SessionEvent,
+        modules::test_support::{connect_sessions, spawn_dual_server},
+    };
+
+    #[tokio::test]
+    async fn exposes_track_namespace_prefix_as_tuple_and_joined_string() {
+        // Arrange
+        let (port, accept) = spawn_dual_server("subscribe-namespace-handler-namespace");
+        let (client, server) = connect_sessions(&format!("moqt://127.0.0.1:{port}"), accept)
+            .await
+            .unwrap();
+        let request = tokio::spawn(async move {
+            client
+                .subscriber()
+                .subscribe_namespace("a/b/c".to_string())
+                .await
+        });
+
+        // Act
+        let SessionEvent::SubscribeNameSpace(handler) = server.receive_event().await.unwrap()
+        else {
+            panic!("expected SUBSCRIBE_NAMESPACE from the client");
+        };
+
+        // Assert
+        assert_eq!(handler.track_namespace_prefix_tuple, vec!["a", "b", "c"]);
+        assert_eq!(handler.track_namespace_prefix, "a/b/c");
+        request.abort();
     }
 }

--- a/moqt/src/modules/moqt/domains.rs
+++ b/moqt/src/modules/moqt/domains.rs
@@ -1,6 +1,8 @@
+pub(crate) mod accepting;
 pub(crate) mod connecting;
 pub(crate) mod endpoint;
 pub(crate) mod fetch_handle;
+pub(crate) mod handshake;
 pub(crate) mod publisher;
 pub(crate) mod session;
 pub(crate) mod session_context;

--- a/moqt/src/modules/moqt/domains/accepting.rs
+++ b/moqt/src/modules/moqt/domains/accepting.rs
@@ -1,0 +1,15 @@
+use std::{pin::Pin, task::Poll};
+
+use crate::{Handshake, TransportProtocol};
+
+pub struct Accepting<T: TransportProtocol> {
+    pub(crate) inner: Pin<Box<dyn Future<Output = anyhow::Result<Handshake<T>>> + Send>>,
+}
+
+impl<T: TransportProtocol> Future for Accepting<T> {
+    type Output = anyhow::Result<Handshake<T>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
+}

--- a/moqt/src/modules/moqt/domains/endpoint.rs
+++ b/moqt/src/modules/moqt/domains/endpoint.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Connecting, TransportProtocol,
+    Accepting, Connecting, TransportProtocol,
     modules::{
         moqt::domains::session_creator::SessionCreator,
         transport::transport_connection_creator::TransportConnectionCreator,
@@ -73,7 +73,7 @@ impl<T: TransportProtocol> Endpoint<T> {
         self.session_creator.create_new_connection(url).await
     }
 
-    pub async fn accept(&mut self) -> anyhow::Result<Connecting<T>> {
+    pub async fn accept(&mut self) -> anyhow::Result<Accepting<T>> {
         self.session_creator.accept_new_connection().await
     }
 }

--- a/moqt/src/modules/moqt/domains/endpoint.rs
+++ b/moqt/src/modules/moqt/domains/endpoint.rs
@@ -9,6 +9,7 @@ use crate::{
 pub struct ClientConfig {
     pub port: u16,
     pub verify_certificate: bool,
+    pub authorization_token: Option<String>,
 }
 
 impl Default for ClientConfig {
@@ -16,6 +17,7 @@ impl Default for ClientConfig {
         Self {
             port: 0,
             verify_certificate: true,
+            authorization_token: None,
         }
     }
 }
@@ -37,6 +39,7 @@ impl<T: TransportProtocol> Endpoint<T> {
         let client = T::ConnectionCreator::client(config.port, config.verify_certificate)?;
         let session_creator = SessionCreator {
             transport_creator: client,
+            authorization_token: config.authorization_token.clone(),
         };
         Ok(Self { session_creator })
     }
@@ -48,6 +51,7 @@ impl<T: TransportProtocol> Endpoint<T> {
         let client = T::ConnectionCreator::client_with_custom_cert(port_num, custom_cert_path)?;
         let session_creator = SessionCreator {
             transport_creator: client,
+            authorization_token: None,
         };
         Ok(Self { session_creator })
     }
@@ -61,6 +65,7 @@ impl<T: TransportProtocol> Endpoint<T> {
         )?;
         let session_creator = SessionCreator {
             transport_creator: server,
+            authorization_token: None,
         };
         Ok(Self { session_creator })
     }

--- a/moqt/src/modules/moqt/domains/handshake.rs
+++ b/moqt/src/modules/moqt/domains/handshake.rs
@@ -1,0 +1,126 @@
+use std::sync::atomic::AtomicU64;
+
+use crate::{
+    Session, TerminationErrorCode, TransportProtocol,
+    modules::{
+        moqt::{
+            control_plane::control_messages::messages::client_setup::ClientSetup,
+            data_plane::stream::{
+                bi_stream_sender::BiStreamSender, stream_receiver::BiStreamReceiver,
+            },
+            domains::{
+                session_context::SessionContext, session_context_factory::SessionContextFactory,
+            },
+        },
+        transport::transport_connection::TransportConnection,
+    },
+};
+
+pub struct Handshake<T: TransportProtocol> {
+    pub(crate) client_setup: ClientSetup,
+    pub(crate) transport_connection: T::Connection,
+    pub(crate) send_stream: BiStreamSender<T>,
+    pub(crate) receive_stream: BiStreamReceiver<T>,
+}
+
+impl<T: TransportProtocol> Handshake<T> {
+    pub fn client_setup(&self) -> &ClientSetup {
+        &self.client_setup
+    }
+
+    pub async fn accept(mut self) -> anyhow::Result<Session<T>> {
+        SessionContextFactory::send_server_setup(&mut self.send_stream).await?;
+        let (event_sender, event_receiver) = tokio::sync::mpsc::unbounded_channel();
+        let context = SessionContext::new(
+            self.transport_connection,
+            self.send_stream,
+            AtomicU64::new(1),
+            event_sender,
+        );
+        tracing::info!("Session is established.");
+        Ok(Session::new(self.receive_stream, context, event_receiver))
+    }
+
+    pub fn reject(self, code: TerminationErrorCode, reason: &str) {
+        self.transport_connection.close(code as u32, reason);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        TerminationErrorCode,
+        modules::{
+            moqt::control_plane::constants::MOQ_TRANSPORT_VERSION,
+            test_support::{HANDSHAKE_TIMEOUT, dual_client, spawn_dual_server_handshake},
+        },
+    };
+
+    #[tokio::test]
+    async fn client_setup_is_exposed_before_server_setup() {
+        // Arrange
+        let (port, accept) = spawn_dual_server_handshake("handshake-client-setup");
+        let url = format!("moqt://127.0.0.1:{port}");
+        let client = tokio::spawn(async move { dual_client().connect(&url).await?.await });
+
+        // Act
+        let handshake = tokio::time::timeout(HANDSHAKE_TIMEOUT, accept)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Assert
+        assert!(
+            handshake
+                .client_setup()
+                .supported_versions
+                .contains(&MOQ_TRANSPORT_VERSION)
+        );
+        client.abort();
+    }
+
+    #[tokio::test]
+    async fn accept_establishes_session() {
+        // Arrange
+        let (port, accept) = spawn_dual_server_handshake("handshake-accept");
+        let url = format!("moqt://127.0.0.1:{port}");
+        let client = tokio::spawn(async move { dual_client().connect(&url).await?.await });
+        let handshake = tokio::time::timeout(HANDSHAKE_TIMEOUT, accept)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Act
+        let server = handshake.accept().await;
+        let client = tokio::time::timeout(HANDSHAKE_TIMEOUT, client)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Assert
+        assert!(server.is_ok());
+        assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reject_closes_connection_before_server_setup() {
+        // Arrange
+        let (port, accept) = spawn_dual_server_handshake("handshake-reject");
+        let url = format!("moqt://127.0.0.1:{port}");
+        let client = tokio::spawn(async move { dual_client().connect(&url).await?.await });
+        let handshake = tokio::time::timeout(HANDSHAKE_TIMEOUT, accept)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Act
+        handshake.reject(TerminationErrorCode::Unauthorized, "test");
+        let client = tokio::time::timeout(HANDSHAKE_TIMEOUT, client)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Assert
+        assert!(client.is_err());
+    }
+}

--- a/moqt/src/modules/moqt/domains/handshake.rs
+++ b/moqt/src/modules/moqt/domains/handshake.rs
@@ -41,8 +41,14 @@ impl<T: TransportProtocol> Handshake<T> {
         Ok(Session::new(self.receive_stream, context, event_receiver))
     }
 
-    pub fn reject(self, code: TerminationErrorCode, reason: &str) {
+    pub async fn reject(self, code: TerminationErrorCode, reason: &str) {
         self.transport_connection.close(code as u32, reason);
+        // Wait for the WebTransport CLOSE_SESSION capsule (carrying the code and
+        // reason) to be delivered before this connection is dropped; otherwise
+        // the QUIC connection is torn down first and the browser only sees a
+        // generic "Connection lost." (web-transport-quinn's close() flushes the
+        // capsule in a background task).
+        self.transport_connection.closed().await;
     }
 }
 
@@ -114,7 +120,9 @@ mod tests {
             .unwrap();
 
         // Act
-        handshake.reject(TerminationErrorCode::Unauthorized, "test");
+        handshake
+            .reject(TerminationErrorCode::Unauthorized, "test")
+            .await;
         let client = tokio::time::timeout(HANDSHAKE_TIMEOUT, client)
             .await
             .unwrap()

--- a/moqt/src/modules/moqt/domains/session_context_factory.rs
+++ b/moqt/src/modules/moqt/domains/session_context_factory.rs
@@ -1,14 +1,15 @@
-use std::sync::atomic::AtomicU64;
-
 use crate::{
-    SessionEvent, TransportProtocol,
+    TransportProtocol,
     modules::moqt::{
         control_plane::{
             constants::{self, MOQ_TRANSPORT_VERSION},
             control_messages::{
                 control_message_type::ControlMessageType,
                 messages::{
-                    client_setup::ClientSetup, parameters::setup_parameters::SetupParameter,
+                    client_setup::ClientSetup,
+                    parameters::{
+                        authorization_token::AuthorizationToken, setup_parameters::SetupParameter,
+                    },
                     server_setup::ServerSetup,
                 },
             },
@@ -17,38 +18,23 @@ use crate::{
             bi_stream_sender::BiStreamSender, received_message::ReceivedMessage,
             stream_receiver::BiStreamReceiver,
         },
-        domains::session_context::SessionContext,
     },
 };
 
 pub(crate) struct SessionContextFactory;
 
 impl SessionContextFactory {
-    pub(crate) async fn client<T: TransportProtocol>(
-        transport_connection: T::Connection,
-        send_stream: T::SendStream,
-        receive_stream: &mut BiStreamReceiver<T>,
-        event_sender: tokio::sync::mpsc::UnboundedSender<SessionEvent<T>>,
-    ) -> anyhow::Result<SessionContext<T>> {
-        let mut send_stream = BiStreamSender::new(send_stream);
-        Self::setup_client(&mut send_stream, receive_stream).await?;
-
-        Ok(SessionContext::new(
-            transport_connection,
-            send_stream,
-            AtomicU64::new(1),
-            event_sender,
-        ))
-    }
-
-    async fn setup_client<T: TransportProtocol>(
+    pub(crate) async fn send_client_setup<T: TransportProtocol>(
         send_stream: &mut BiStreamSender<T>,
-        receive_stream: &mut BiStreamReceiver<T>,
+        authorization_token: Option<&str>,
     ) -> anyhow::Result<()> {
         let setup_param = SetupParameter {
             path: None,
             max_request_id: 1000,
-            authorization_token: vec![],
+            authorization_token: authorization_token
+                .map(AuthorizationToken::use_value_utf8)
+                .into_iter()
+                .collect(),
             max_auth_token_cache_size: None,
             authority: None,
             moq_implementation: Some("MOQ-WASM".to_string()),
@@ -60,7 +46,12 @@ impl SessionContextFactory {
             .await
             .inspect_err(|e| tracing::error!("failed to send. :{}", e.to_string()))?;
         tracing::info!("Sent client setup.");
+        Ok(())
+    }
 
+    pub(crate) async fn receive_server_setup<T: TransportProtocol>(
+        receive_stream: &mut BiStreamReceiver<T>,
+    ) -> anyhow::Result<()> {
         let received_message = match receive_stream.receive().await {
             Ok(Some(b)) => b,
             Ok(None) => {

--- a/moqt/src/modules/moqt/domains/session_context_factory.rs
+++ b/moqt/src/modules/moqt/domains/session_context_factory.rs
@@ -41,23 +41,6 @@ impl SessionContextFactory {
         ))
     }
 
-    pub(crate) async fn server<T: TransportProtocol>(
-        transport_connection: T::Connection,
-        send_stream: T::SendStream,
-        receive_stream: &mut BiStreamReceiver<T>,
-        event_sender: tokio::sync::mpsc::UnboundedSender<SessionEvent<T>>,
-    ) -> anyhow::Result<SessionContext<T>> {
-        let mut send_stream = BiStreamSender::new(send_stream);
-        Self::setup_server(&mut send_stream, receive_stream).await?;
-
-        Ok(SessionContext::new(
-            transport_connection,
-            send_stream,
-            AtomicU64::new(1),
-            event_sender,
-        ))
-    }
-
     async fn setup_client<T: TransportProtocol>(
         send_stream: &mut BiStreamSender<T>,
         receive_stream: &mut BiStreamReceiver<T>,
@@ -104,10 +87,9 @@ impl SessionContextFactory {
         }
     }
 
-    async fn setup_server<T: TransportProtocol>(
-        send_stream: &mut BiStreamSender<T>,
+    pub(crate) async fn receive_client_setup<T: TransportProtocol>(
         receive_stream: &mut BiStreamReceiver<T>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<ClientSetup> {
         let received_message = match receive_stream.receive().await {
             Ok(Some(b)) => b,
             Ok(None) => {
@@ -125,12 +107,18 @@ impl SessionContextFactory {
                     "Received client setup. supported_versions: {:?}",
                     client_setup.supported_versions
                 );
+                Ok(client_setup)
             }
             _ => {
                 tracing::error!("Protocol violation.");
                 anyhow::bail!("Protocol violation.")
             }
-        };
+        }
+    }
+
+    pub(crate) async fn send_server_setup<T: TransportProtocol>(
+        send_stream: &mut BiStreamSender<T>,
+    ) -> anyhow::Result<()> {
         let setup_param = SetupParameter {
             path: None,
             max_request_id: 1000,

--- a/moqt/src/modules/moqt/domains/session_creator.rs
+++ b/moqt/src/modules/moqt/domains/session_creator.rs
@@ -1,5 +1,5 @@
-use crate::Connecting;
 use crate::modules::moqt::data_plane::codec::control_message_decoder::ControlMessageDecoder;
+use crate::modules::moqt::data_plane::stream::bi_stream_sender::BiStreamSender;
 use crate::modules::moqt::data_plane::stream::stream_receiver::BiStreamReceiver;
 use crate::modules::moqt::domains::session::Session;
 use crate::modules::moqt::domains::session_context_factory::SessionContextFactory;
@@ -7,6 +7,7 @@ use crate::modules::moqt::protocol::TransportProtocol;
 use crate::modules::transport::connect_target::ConnectTarget;
 use crate::modules::transport::transport_connection::TransportConnection;
 use crate::modules::transport::transport_connection_creator::TransportConnectionCreator;
+use crate::{Accepting, Connecting, Handshake};
 
 pub(crate) struct SessionCreator<T: TransportProtocol> {
     pub(crate) transport_creator: T::ConnectionCreator,
@@ -35,23 +36,21 @@ impl<T: TransportProtocol> SessionCreator<T> {
         })
     }
 
-    pub(crate) async fn accept_new_connection(&mut self) -> anyhow::Result<Connecting<T>> {
+    pub(crate) async fn accept_new_connection(&mut self) -> anyhow::Result<Accepting<T>> {
         let transport_conn = self.transport_creator.accept_new_transport().await?;
         let handshake = async move {
             let (send_stream, receive_stream) = transport_conn.accept_bi().await?;
-            let mut moqt_receiver = BiStreamReceiver::new(receive_stream, ControlMessageDecoder);
-            let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
-            let inner = SessionContextFactory::server(
-                transport_conn,
-                send_stream,
-                &mut moqt_receiver,
-                sender,
-            )
-            .await
-            .inspect(|_| tracing::info!("Session is established."))?;
-            Ok(Session::<T>::new(moqt_receiver, inner, receiver))
+            let mut receive_stream = BiStreamReceiver::new(receive_stream, ControlMessageDecoder);
+            let client_setup =
+                SessionContextFactory::receive_client_setup(&mut receive_stream).await?;
+            Ok(Handshake {
+                client_setup,
+                transport_connection: transport_conn,
+                send_stream: BiStreamSender::new(send_stream),
+                receive_stream,
+            })
         };
-        Ok(Connecting {
+        Ok(Accepting {
             inner: Box::pin(handshake),
         })
     }

--- a/moqt/src/modules/moqt/domains/session_creator.rs
+++ b/moqt/src/modules/moqt/domains/session_creator.rs
@@ -2,34 +2,41 @@ use crate::modules::moqt::data_plane::codec::control_message_decoder::ControlMes
 use crate::modules::moqt::data_plane::stream::bi_stream_sender::BiStreamSender;
 use crate::modules::moqt::data_plane::stream::stream_receiver::BiStreamReceiver;
 use crate::modules::moqt::domains::session::Session;
+use crate::modules::moqt::domains::session_context::SessionContext;
 use crate::modules::moqt::domains::session_context_factory::SessionContextFactory;
 use crate::modules::moqt::protocol::TransportProtocol;
 use crate::modules::transport::connect_target::ConnectTarget;
 use crate::modules::transport::transport_connection::TransportConnection;
 use crate::modules::transport::transport_connection_creator::TransportConnectionCreator;
+use std::sync::atomic::AtomicU64;
+
 use crate::{Accepting, Connecting, Handshake};
 
 pub(crate) struct SessionCreator<T: TransportProtocol> {
     pub(crate) transport_creator: T::ConnectionCreator,
+    pub(crate) authorization_token: Option<String>,
 }
 
 impl<T: TransportProtocol> SessionCreator<T> {
     pub(crate) async fn create_new_connection(&self, url: &str) -> anyhow::Result<Connecting<T>> {
         let target = ConnectTarget::parse(url)?;
         let transport_conn = self.transport_creator.create_new_transport(&target).await?;
+        let authorization_token = self.authorization_token.clone();
         let handshake = async move {
             let (send_stream, receive_stream) = transport_conn.open_bi().await?;
-            let mut moqt_receiver = BiStreamReceiver::new(receive_stream, ControlMessageDecoder);
-            let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
-            let inner = SessionContextFactory::client(
-                transport_conn,
-                send_stream,
-                &mut moqt_receiver,
-                sender,
+            let mut send_stream = BiStreamSender::new(send_stream);
+            let mut receive_stream = BiStreamReceiver::new(receive_stream, ControlMessageDecoder);
+            SessionContextFactory::send_client_setup(
+                &mut send_stream,
+                authorization_token.as_deref(),
             )
-            .await
-            .inspect(|_| tracing::info!("Session is created."))?;
-            Ok(Session::<T>::new(moqt_receiver, inner, receiver))
+            .await?;
+            SessionContextFactory::receive_server_setup(&mut receive_stream).await?;
+            let (event_sender, event_receiver) = tokio::sync::mpsc::unbounded_channel();
+            let context =
+                SessionContext::new(transport_conn, send_stream, AtomicU64::new(1), event_sender);
+            tracing::info!("Session is created.");
+            Ok(Session::<T>::new(receive_stream, context, event_receiver))
         };
         Ok(Connecting {
             inner: Box::pin(handshake),
@@ -53,5 +60,76 @@ impl<T: TransportProtocol> SessionCreator<T> {
         Ok(Accepting {
             inner: Box::pin(handshake),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ClientConfig,
+        modules::{
+            moqt::control_plane::control_messages::messages::parameters::authorization_token::AuthorizationToken,
+            test_support::{
+                HANDSHAKE_TIMEOUT, dual_client, dual_client_with_config,
+                spawn_dual_server_handshake,
+            },
+        },
+    };
+
+    #[tokio::test]
+    async fn connect_sends_authorization_token_in_client_setup() {
+        // Arrange
+        let (port, accept) = spawn_dual_server_handshake("client-setup-with-token");
+        let url = format!("moqt://127.0.0.1:{port}");
+        let client = tokio::spawn(async move {
+            dual_client_with_config(ClientConfig {
+                port: 0,
+                verify_certificate: false,
+                authorization_token: Some("jwt".to_string()),
+            })
+            .connect(&url)
+            .await?
+            .await
+        });
+
+        // Act
+        let handshake = tokio::time::timeout(HANDSHAKE_TIMEOUT, accept)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Assert
+        assert_eq!(
+            handshake
+                .client_setup()
+                .setup_parameters
+                .authorization_token,
+            vec![AuthorizationToken::use_value_utf8("jwt")]
+        );
+        client.abort();
+    }
+
+    #[tokio::test]
+    async fn connect_without_token_sends_no_authorization_token() {
+        // Arrange
+        let (port, accept) = spawn_dual_server_handshake("client-setup-without-token");
+        let url = format!("moqt://127.0.0.1:{port}");
+        let client = tokio::spawn(async move { dual_client().connect(&url).await?.await });
+
+        // Act
+        let handshake = tokio::time::timeout(HANDSHAKE_TIMEOUT, accept)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Assert
+        assert!(
+            handshake
+                .client_setup()
+                .setup_parameters
+                .authorization_token
+                .is_empty()
+        );
+        client.abort();
     }
 }

--- a/moqt/src/modules/test_support.rs
+++ b/moqt/src/modules/test_support.rs
@@ -54,12 +54,16 @@ pub(crate) fn spawn_dual_server(name: &str) -> (u16, tokio::task::JoinHandle<Ses
     (port, accept)
 }
 
+pub(crate) fn dual_client_with_config(config: ClientConfig) -> Endpoint<DUAL> {
+    Endpoint::<DUAL>::create_client(&config).unwrap()
+}
+
 pub(crate) fn dual_client() -> Endpoint<DUAL> {
-    Endpoint::<DUAL>::create_client(&ClientConfig {
+    dual_client_with_config(ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     })
-    .unwrap()
 }
 
 /// Connects a DUAL client to the server started by `spawn_dual_server` and

--- a/moqt/src/modules/test_support.rs
+++ b/moqt/src/modules/test_support.rs
@@ -3,8 +3,8 @@ use std::{net::UdpSocket, path::Path, time::Duration};
 use rcgen::{CertifiedKey, generate_simple_self_signed};
 
 use crate::{
-    ClientConfig, DUAL, DataReceiver, Endpoint, FilterType, ServerConfig, Session, SessionEvent,
-    Subscription, TrackReader,
+    ClientConfig, DUAL, DataReceiver, Endpoint, FilterType, Handshake, ServerConfig, Session,
+    SessionEvent, Subscription, TrackReader,
 };
 
 pub(crate) const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -32,14 +32,25 @@ fn write_self_signed_cert(dir: &Path) -> ServerConfig {
 }
 
 /// Starts a DUAL server on a free port whose accept loop resolves the first
-/// incoming session; returns the port and the accept task.
-pub(crate) fn spawn_dual_server(name: &str) -> (u16, tokio::task::JoinHandle<Session<DUAL>>) {
+/// incoming handshake (CLIENT_SETUP received, SERVER_SETUP not yet sent);
+/// returns the port and the accept task.
+pub(crate) fn spawn_dual_server_handshake(
+    name: &str,
+) -> (u16, tokio::task::JoinHandle<Handshake<DUAL>>) {
     let port = free_udp_port();
     let cert_dir = std::env::temp_dir().join(format!("moqt-test-{name}-{port}"));
     let mut server_config = write_self_signed_cert(&cert_dir);
     server_config.port = port;
     let mut server = Endpoint::<DUAL>::create_server(&server_config).unwrap();
     let accept = tokio::spawn(async move { server.accept().await.unwrap().await.unwrap() });
+    (port, accept)
+}
+
+/// Starts a DUAL server on a free port whose accept loop resolves the first
+/// incoming session; returns the port and the accept task.
+pub(crate) fn spawn_dual_server(name: &str) -> (u16, tokio::task::JoinHandle<Session<DUAL>>) {
+    let (port, handshake) = spawn_dual_server_handshake(name);
+    let accept = tokio::spawn(async move { handshake.await.unwrap().accept().await.unwrap() });
     (port, accept)
 }
 

--- a/relay/src/modules/core/handler/publish.rs
+++ b/relay/src/modules/core/handler/publish.rs
@@ -22,7 +22,6 @@ pub(crate) trait PublishHandler: 'static + Send + Sync + Debug {
     fn _group_order(&self) -> GroupOrder;
     fn _content_exists(&self) -> ContentExists;
     fn _forward(&self) -> bool;
-    fn _authorization_token(&self) -> Option<String>;
     fn _delivery_timeout(&self) -> Option<u64>;
     fn _max_cache_duration(&self) -> Option<u64>;
     fn subscription(
@@ -56,9 +55,6 @@ impl<T: moqt::TransportProtocol> PublishHandler for moqt::PublishHandler<T> {
     }
     fn _forward(&self) -> bool {
         self.forward
-    }
-    fn _authorization_token(&self) -> Option<String> {
-        self.authorization_token.clone()
     }
     fn _delivery_timeout(&self) -> Option<u64> {
         self.delivery_timeout

--- a/relay/src/modules/core/handler/subscribe.rs
+++ b/relay/src/modules/core/handler/subscribe.rs
@@ -14,7 +14,6 @@ pub(crate) trait SubscribeHandler: 'static + Send + Sync {
     fn _group_order(&self) -> GroupOrder;
     fn _forward(&self) -> bool;
     fn _filter_type(&self) -> FilterType;
-    fn _authorization_token(&self) -> Option<String>;
     fn _max_cache_duration(&self) -> Option<u64>;
     fn _delivery_timeout(&self) -> Option<u64>;
     fn allocate_track_alias(&self) -> u64;
@@ -51,9 +50,6 @@ impl<T: moqt::TransportProtocol> SubscribeHandler for moqt::SubscribeHandler<T> 
     }
     fn _filter_type(&self) -> FilterType {
         FilterType::from(self.filter_type)
-    }
-    fn _authorization_token(&self) -> Option<String> {
-        self.authorization_token.clone()
     }
     fn _max_cache_duration(&self) -> Option<u64> {
         self.max_cache_duration

--- a/relay/src/modules/inter_relay.rs
+++ b/relay/src/modules/inter_relay.rs
@@ -44,6 +44,7 @@ impl InterRelayConnectionManager {
         let endpoint = moqt::Endpoint::<moqt::QUIC>::create_client(&moqt::ClientConfig {
             port: 0,
             verify_certificate: false,
+            authorization_token: None,
         })?;
         let connecting = endpoint
             .connect(&format!("moqt://{}:{}", relay.host, relay.port))

--- a/relay/src/modules/sequences/tables/hashmap_table.rs
+++ b/relay/src/modules/sequences/tables/hashmap_table.rs
@@ -643,10 +643,6 @@ mod tests {
             true
         }
 
-        fn _authorization_token(&self) -> Option<String> {
-            None
-        }
-
         fn _delivery_timeout(&self) -> Option<u64> {
             None
         }

--- a/relay/src/modules/session_handler.rs
+++ b/relay/src/modules/session_handler.rs
@@ -82,12 +82,14 @@ impl SessionHandler {
                     let accepted_peer = accepted_peer.clone();
                     tokio::spawn(async move {
                         let session = async {
-                            connecting.await.inspect_err(|error| {
-                                tracing::warn!(%error, "failed to establish session");
-                            })
+                            let handshake = connecting.await?;
+                            handshake.accept().await
                         }
                         .instrument(session_span.clone())
-                        .await;
+                        .await
+                        .inspect_err(|error| {
+                            tracing::warn!(%error, "failed to establish session");
+                        });
                         let session = match session {
                             Ok(session) => session,
                             Err(_) => return,

--- a/relay/src/modules/session_repository.rs
+++ b/relay/src/modules/session_repository.rs
@@ -99,7 +99,6 @@ fn log_session_event(event: &MoqtSessionEvent) {
                 group_order = ?handler._group_order(),
                 content_exists = ?handler._content_exists(),
                 forward = handler._forward(),
-                has_authorization_token = handler._authorization_token().is_some(),
                 delivery_timeout = ?handler._delivery_timeout(),
                 max_cache_duration = ?handler._max_cache_duration(),
                 "Received session event"
@@ -116,7 +115,6 @@ fn log_session_event(event: &MoqtSessionEvent) {
                 group_order = ?handler._group_order(),
                 forward = handler._forward(),
                 filter_type = %filter_type_label(&filter_type),
-                has_authorization_token = handler._authorization_token().is_some(),
                 max_cache_duration = ?handler._max_cache_duration(),
                 delivery_timeout = ?handler._delivery_timeout(),
                 "Received session event"

--- a/relay/tests/concurrent_accept.rs
+++ b/relay/tests/concurrent_accept.rs
@@ -39,6 +39,7 @@ fn client_endpoint() -> Endpoint<QUIC> {
     Endpoint::<QUIC>::create_client(&ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     })
     .unwrap()
 }

--- a/tests/cache-eviction-e2e/src/main.rs
+++ b/tests/cache-eviction-e2e/src/main.rs
@@ -53,6 +53,7 @@ async fn new_session() -> anyhow::Result<Session<QUIC>> {
     let endpoint = Endpoint::<QUIC>::create_client(&ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     })?;
     let connecting = endpoint.connect(&relay_url).await?;
     connecting.await

--- a/tests/cascading-relay-e2e/src/main.rs
+++ b/tests/cascading-relay-e2e/src/main.rs
@@ -706,6 +706,7 @@ async fn connect(url: &str) -> anyhow::Result<Session<QUIC>> {
     let endpoint = Endpoint::<QUIC>::create_client(&ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     })?;
     tracing::info!(url, "connecting to relay");
     let connecting = endpoint.connect(url).await?;

--- a/tests/fetch-e2e/src/main.rs
+++ b/tests/fetch-e2e/src/main.rs
@@ -65,6 +65,7 @@ async fn connect_to_relay(relay_url: &str) -> anyhow::Result<Session<QUIC>> {
     let endpoint = Endpoint::<QUIC>::create_client(&ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     })?;
     let connecting = endpoint.connect(relay_url).await?;
     connecting.await

--- a/tests/multiple-publishers-e2e/src/main.rs
+++ b/tests/multiple-publishers-e2e/src/main.rs
@@ -40,6 +40,7 @@ async fn new_session() -> anyhow::Result<Session<QUIC>> {
     let endpoint = Endpoint::<QUIC>::create_client(&ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     })?;
     let connecting = endpoint.connect(&relay_url).await?;
     connecting.await

--- a/tests/object-dedup-e2e/src/main.rs
+++ b/tests/object-dedup-e2e/src/main.rs
@@ -29,6 +29,7 @@ async fn new_session() -> anyhow::Result<Session<QUIC>> {
     let endpoint = Endpoint::<QUIC>::create_client(&ClientConfig {
         port: 0,
         verify_certificate: false,
+        authorization_token: None,
     })?;
     let connecting = endpoint.connect(&relay_url).await?;
     connecting.await


### PR DESCRIPTION
## 概要
relay が認証・認可を行うための moqt 側の土台。CLIENT_SETUP で認証トークンを送れるようにし、サーバ側は SERVER_SETUP を返す前にセッションを受理/拒否できる `Handshake` を導入する。

## やったこと
- サーバの SETUP 交換を `Connecting` → `Handshake` に分割し、`client_setup()` 参照後に `accept()` / `reject()` を選べるようにした
- `ClientConfig.authorization_token` を CLIENT_SETUP の AUTHORIZATION TOKEN(USE_VALUE, type 0) として送出(wasm `sendClientSetup` に引数追加)。リクエスト handler に wire の namespace タプルを公開
- `Handshake::reject` を async 化し、close 後に `closed()` を await して WebTransport の CLOSE_SESSION capsule 送達を待つ

## やらないこと
認証・認可のロジック本体（VTS 連携、namespace 認可）は relay 側の後続 PR。

## 影響範囲
`moqt`、`bindings/wasm`。全クライアントの `ClientConfig` に `authorization_token` フィールドが増える。

## テスト
`cargo test`(moqt)、`cargo clippy`/`cargo fmt --check`、`wasm-pack build`。
